### PR TITLE
fix(security): resolve open CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/pkg/api/model.go
+++ b/pkg/api/model.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"strings"
+
+	"github.com/flanksource/captain/pkg/collections"
 )
 
 // Model identifies which LLM serves a request plus the per-request inference
@@ -120,7 +122,7 @@ func (m Model) Candidates() []Model {
 	m = m.ExpandCSV()
 	primary := m
 	primary.Fallbacks = nil
-	out := make([]Model, 0, 1+len(m.Fallbacks))
+	out := make([]Model, 0, collections.SafeAdd(1, len(m.Fallbacks)))
 	out = append(out, primary)
 	for _, fb := range m.Fallbacks {
 		fb.Fallbacks = nil

--- a/pkg/cli/permission_catalog.go
+++ b/pkg/cli/permission_catalog.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,17 +18,44 @@ func handlePermissionCatalog(baseCwd string) http.HandlerFunc {
 		if dir == "" {
 			dir = strings.TrimSpace(r.URL.Query().Get("cwd"))
 		}
-		if dir == "" {
-			dir = baseCwd
-		}
-		if !filepath.IsAbs(dir) {
-			dir = filepath.Join(baseCwd, dir)
+		resolved, err := resolveCatalogDir(baseCwd, dir)
+		if err != nil {
+			http.Error(w, "invalid dir", http.StatusBadRequest)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(buildPermissionCatalog(dir)); err != nil {
+		if err := json.NewEncoder(w).Encode(buildPermissionCatalog(resolved)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
+}
+
+// resolveCatalogDir resolves the caller-supplied directory against baseCwd and
+// guarantees the result stays within baseCwd. The dir value comes straight from
+// an untrusted query parameter, so it must be confined to the workspace root to
+// prevent path traversal (e.g. "../../etc") into arbitrary parts of the
+// filesystem.
+func resolveCatalogDir(baseCwd, dir string) (string, error) {
+	base, err := filepath.Abs(baseCwd)
+	if err != nil {
+		return "", err
+	}
+	base = filepath.Clean(base)
+
+	if dir == "" {
+		return base, nil
+	}
+
+	target := dir
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(base, target)
+	}
+	target = filepath.Clean(target)
+
+	if target != base && !strings.HasPrefix(target, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("dir %q escapes workspace root", dir)
+	}
+	return target, nil
 }
 
 func buildPermissionCatalog(dir string) api.PermissionCatalog {

--- a/pkg/cli/permission_catalog_test.go
+++ b/pkg/cli/permission_catalog_test.go
@@ -46,6 +46,35 @@ func TestBuildPermissionCatalog(t *testing.T) {
 	}
 }
 
+func TestResolveCatalogDir(t *testing.T) {
+	base := t.TempDir()
+	nested := filepath.Join(base, "sub", "child")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	// Empty dir resolves to the workspace root.
+	if got, err := resolveCatalogDir(base, ""); err != nil || got != filepath.Clean(base) {
+		t.Fatalf("empty dir: got %q err %v, want %q", got, err, filepath.Clean(base))
+	}
+
+	// Relative paths that stay inside the workspace are allowed.
+	if got, err := resolveCatalogDir(base, filepath.Join("sub", "child")); err != nil || got != nested {
+		t.Fatalf("relative dir: got %q err %v, want %q", got, err, nested)
+	}
+
+	// Traversal attempts must be rejected.
+	for _, dir := range []string{
+		"../../etc",
+		filepath.Join("sub", "..", "..", "etc"),
+		"/etc",
+	} {
+		if got, err := resolveCatalogDir(base, dir); err == nil {
+			t.Fatalf("expected %q to be rejected, got %q", dir, got)
+		}
+	}
+}
+
 func mustWrite(t *testing.T, path, data string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/pkg/cli/prompt_entity.go
+++ b/pkg/cli/prompt_entity.go
@@ -23,6 +23,7 @@ import (
 	promptlib "github.com/flanksource/captain/pkg/ai/prompt"
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/captainconfig"
+	"github.com/flanksource/captain/pkg/collections"
 	"github.com/flanksource/clicky"
 	clickyapi "github.com/flanksource/clicky/api"
 	clickyrpc "github.com/flanksource/clicky/rpc"
@@ -606,7 +607,7 @@ func mergeStringMaps(base, overlay map[string]string) map[string]string {
 	if len(overlay) == 0 {
 		return base
 	}
-	out := make(map[string]string, len(base)+len(overlay))
+	out := make(map[string]string, collections.SafeAdd(len(base), len(overlay)))
 	for k, v := range base {
 		out[k] = v
 	}
@@ -620,7 +621,7 @@ func mergeToolModes(base, overlay map[string]api.ToolMode) map[string]api.ToolMo
 	if len(overlay) == 0 {
 		return base
 	}
-	out := make(map[string]api.ToolMode, len(base)+len(overlay))
+	out := make(map[string]api.ToolMode, collections.SafeAdd(len(base), len(overlay)))
 	for k, v := range base {
 		out[k] = v
 	}
@@ -634,8 +635,8 @@ func mergePresets(base, overlay []api.Preset) []api.Preset {
 	if len(overlay) == 0 {
 		return base
 	}
-	seen := make(map[api.Preset]bool, len(base)+len(overlay))
-	out := make([]api.Preset, 0, len(base)+len(overlay))
+	seen := make(map[api.Preset]bool, collections.SafeAdd(len(base), len(overlay)))
+	out := make([]api.Preset, 0, collections.SafeAdd(len(base), len(overlay)))
 	for _, preset := range base {
 		if seen[preset] {
 			continue

--- a/pkg/cli/webapp/vite.config.ts
+++ b/pkg/cli/webapp/vite.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -103,10 +103,10 @@ function clickySourceAliases(enabled: boolean) {
 function clickyVersionDefines() {
   const version = readClickyPackageVersion();
   return {
-    __CLICKY_COMMIT__: JSON.stringify(git("rev-parse --short HEAD", "")),
+    __CLICKY_COMMIT__: JSON.stringify(git(["rev-parse", "--short", "HEAD"], "")),
     __CLICKY_TAG__: JSON.stringify(`clicky-ui@${version}`),
     __CLICKY_DATE__: JSON.stringify(new Date().toISOString()),
-    __CLICKY_DIRTY__: JSON.stringify(git("status --porcelain", "").length > 0),
+    __CLICKY_DIRTY__: JSON.stringify(git(["status", "--porcelain"], "").length > 0),
   };
 }
 
@@ -120,9 +120,11 @@ function readClickyPackageVersion() {
   }
 }
 
-function git(args: string, fallback: string) {
+function git(args: string[], fallback: string) {
   try {
-    return execSync(`git -C ${JSON.stringify(clickyPackageRoot)} ${args}`, {
+    // Pass arguments as an argv array via execFileSync so no shell is spawned,
+    // avoiding shell interpretation of the (filesystem-derived) repo path.
+    return execFileSync("git", ["-C", clickyPackageRoot, ...args], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();

--- a/pkg/collections/alloc.go
+++ b/pkg/collections/alloc.go
@@ -1,0 +1,16 @@
+package collections
+
+import "math"
+
+// SafeAdd returns a + b, saturating at math.MaxInt if the sum would overflow.
+//
+// It is intended for computing make() size or capacity hints from independent
+// lengths (e.g. len(a)+len(b)) without risking an integer-overflow wraparound,
+// which could otherwise yield a tiny allocation followed by out-of-bounds
+// writes. Negative operands are treated as an overflow guard as well.
+func SafeAdd(a, b int) int {
+	if a < 0 || b < 0 || a > math.MaxInt-b {
+		return math.MaxInt
+	}
+	return a + b
+}

--- a/pkg/collections/fuzzy.go
+++ b/pkg/collections/fuzzy.go
@@ -39,9 +39,9 @@ func Levenshtein(s1, s2 string) int {
 		return len(s1)
 	}
 
-	matrix := make([][]int, len(s1)+1)
+	matrix := make([][]int, SafeAdd(len(s1), 1))
 	for i := range matrix {
-		matrix[i] = make([]int, len(s2)+1)
+		matrix[i] = make([]int, SafeAdd(len(s2), 1))
 		matrix[i][0] = i
 	}
 	for j := range len(s2) + 1 {


### PR DESCRIPTION
## Summary

Resolves the open CodeQL code-scanning alerts on `main` across four categories.

### Path traversal — "Uncontrolled data used in path expression" (High) — `pkg/cli/permission_catalog.go`
The `dir`/`cwd` query parameter of the permission-catalog HTTP handler flowed straight into `os.ReadFile`/`os.Stat`/`os.ReadDir`. An attacker could pass `dir=../../etc` (or an absolute path) to enumerate arbitrary directories. Added `resolveCatalogDir`, which resolves the value against the workspace root and rejects anything that escapes it (using a cleaned-path prefix containment check) before any filesystem access. The handler now returns `400` for invalid input.

### Integer overflow — "Size computation for allocation may overflow" (High)
`make()` size/capacity hints computed by adding two lengths (`len(a)+len(b)`, `len(x)+1`) were flagged as potentially overflowing. Added a small `collections.SafeAdd` helper that saturates at `math.MaxInt` under a proper overflow guard, and routed all flagged sites through it — preserving the original capacity hints:
- `pkg/collections/fuzzy.go` (Levenshtein matrix)
- `pkg/api/model.go` (`Candidates`)
- `pkg/cli/prompt_entity.go` (`mergeStringMaps`, `mergeToolModes`, `mergePresets`)

### Shell injection — "Shell command built from environment values" (Medium) — `pkg/cli/webapp/vite.config.ts`
The build-time `git()` helper interpolated a filesystem-derived path into a shell command string via `execSync`. Switched to `execFileSync` with an argv array so no shell is spawned.

### Workflow hardening — "Workflow does not contain permissions" (Medium) — `.github/workflows/test.yml`
Added a least-privilege top-level `permissions: contents: read` block.

## Testing
- `go build` / `go test` pass for the affected packages (`collections`, `api`, `cli`).
- Added `TestResolveCatalogDir` covering the allowed and rejected (traversal / absolute) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186pQzdDXNY1jsbozM7Ed3B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission catalog directory handling by blocking path traversal outside the workspace.
  * Invalid catalog paths now return a clear error instead of being processed.
  * Improved protection against integer overflow during internal capacity and allocation calculations.
  * Hardened build-time Git metadata retrieval.

* **Security**
  * Restricted GitHub Actions token permissions to read-only repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->