### PR TITLE
feat: github.com/flanksource/sandbox-runtime with --sandbox flag

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,7 +3,6 @@ version: "3"
 vars:
   BINARY: captain
   BIN_DIR: .bin
-  INSTALL_DIR: /usr/local/bin
 
 tasks:
   default:
@@ -88,10 +87,25 @@ tasks:
       - PATH="$PWD/.bin:$PATH" gavel fixtures pkg/cli/testdata/history_test.md
 
   install:
-    desc: Build and install captain to /usr/local/bin
-    deps: [build]
+    desc: Build and install captain to the default Go bin
+    vars:
+      VERSION:
+        sh: git describe --tags --always
+      COMMIT:
+        sh: git rev-parse --short HEAD
+      DATE:
+        sh: date -u '+%Y-%m-%dT%H:%M:%SZ'
+      DIRTY:
+        sh: |
+          if test -n "$(git status --porcelain)"
+          then
+            echo true
+          else
+            echo false
+          fi
+      LDFLAGS: -s -w -X main.version={{.VERSION}} -X main.commit={{.COMMIT}} -X main.date={{.DATE}} -X main.dirty={{.DIRTY}}
     cmds:
-      - cp {{.BIN_DIR}}/{{.BINARY}} {{.INSTALL_DIR}}/{{.BINARY}}
+      - go install -ldflags "{{.LDFLAGS}}" ./cmd/captain
 
   fmt:
     desc: Format Go code

--- a/pkg/ai/provider/claude_cli.go
+++ b/pkg/ai/provider/claude_cli.go
@@ -15,7 +15,8 @@ import (
 var claudeCLICommand = "claude"
 
 type ClaudeCLI struct {
-	model string
+	model   string
+	sandbox bool
 }
 
 func NewClaudeCLI(model string) *ClaudeCLI {
@@ -62,7 +63,7 @@ func (c *ClaudeCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan a
 	if req.Setup != nil {
 		env = commandEnv(req.Setup.Env)
 	}
-	cmd, stdout, stderrBuf, err := startCLIStream(ctx, claudeCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env)
+	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, claudeCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env, c.sandbox)
 	if err != nil {
 		cleanup()
 		return nil, err
@@ -71,6 +72,7 @@ func (c *ClaudeCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan a
 	go func() {
 		defer close(out)
 		defer cleanup()
+		defer closeSandbox()
 		defer func() { _ = stdout.Close() }()
 		iterator := claude.NewStreamJSONIterator(stdout)
 		for iterator.Next() {

--- a/pkg/ai/provider/cli.go
+++ b/pkg/ai/provider/cli.go
@@ -175,9 +175,7 @@ func cliSandboxConfig(command, cwd string) (sandboxruntime.Config, error) {
 		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox home directory: %w", err)
 	}
 
-	domains := []string{}
-	passthroughEnv := []string{}
-	statePaths := []string{}
+	var domains, passthroughEnv, statePaths []string
 	switch filepath.Base(command) {
 	case "claude":
 		domains = []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}

--- a/pkg/ai/provider/cli.go
+++ b/pkg/ai/provider/cli.go
@@ -9,9 +9,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/flanksource/captain/pkg/ai"
+	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
 )
 
 func IsCommandNotFound(err error) bool {
@@ -75,8 +78,26 @@ func HandleExitError(exitCode int, stderr string) error {
 	}
 }
 
-func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, cwd string, env []string) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, error) {
-	cmd := exec.CommandContext(ctx, command, args...)
+type commandSandbox interface {
+	Command(context.Context, string, ...string) (*exec.Cmd, error)
+	Close(context.Context) error
+}
+
+var newCommandSandbox = func(ctx context.Context, cfg sandboxruntime.Config) (commandSandbox, error) {
+	return sandboxruntime.New(ctx, cfg)
+}
+
+func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, cwd string, env []string, sandboxed bool) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, func(), error) {
+	cmd, closeSandbox, err := newCLICommand(ctx, command, args, cwd, sandboxed)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			closeSandbox()
+		}
+	}()
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
@@ -85,19 +106,19 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create stdin pipe: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 	stderrBuf := &bytes.Buffer{}
 	cmd.Stderr = stderrBuf
 	if err := cmd.Start(); err != nil {
 		if IsCommandNotFound(err) {
-			return nil, nil, nil, fmt.Errorf("%w: %v", ai.ErrCLINotFound, err)
+			return nil, nil, nil, nil, fmt.Errorf("%w: %v", ai.ErrCLINotFound, err)
 		}
-		return nil, nil, nil, fmt.Errorf("failed to start %s: %w", command, err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to start %s: %w", command, err)
 	}
 	go func() {
 		if len(stdinData) > 0 {
@@ -108,7 +129,95 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 		}
 		_ = stdin.Close()
 	}()
-	return cmd, stdout, stderrBuf, nil
+	closeOnError = false
+	return cmd, stdout, stderrBuf, closeSandbox, nil
+}
+
+func newCLICommand(ctx context.Context, command string, args []string, cwd string, sandboxed bool) (*exec.Cmd, func(), error) {
+	if !sandboxed {
+		return exec.CommandContext(ctx, command, args...), func() {}, nil
+	}
+	cfg, err := cliSandboxConfig(command, cwd)
+	if err != nil {
+		return nil, nil, err
+	}
+	sb, err := newCommandSandbox(ctx, cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("initialize sandbox-runtime: %w", err)
+	}
+	closeSandbox := func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = sb.Close(closeCtx)
+	}
+	cmd, err := sb.Command(ctx, command, args...)
+	if err != nil {
+		closeSandbox()
+		return nil, nil, fmt.Errorf("wrap %s with sandbox-runtime: %w", command, err)
+	}
+	return cmd, closeSandbox, nil
+}
+
+func cliSandboxConfig(command, cwd string) (sandboxruntime.Config, error) {
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox working directory: %w", err)
+		}
+	}
+	absoluteCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox working directory %q: %w", cwd, err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox home directory: %w", err)
+	}
+
+	domains := []string{}
+	passthroughEnv := []string{}
+	statePaths := []string{}
+	switch filepath.Base(command) {
+	case "claude":
+		domains = []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}
+		passthroughEnv = []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}
+		statePaths = []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}
+	case "codex":
+		domains = []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}
+		passthroughEnv = []string{"OPENAI_API_KEY"}
+		statePaths = []string{filepath.Join(home, ".codex")}
+	case "gemini":
+		domains = []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}
+		passthroughEnv = []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
+		statePaths = []string{filepath.Join(home, ".gemini")}
+	default:
+		return sandboxruntime.Config{}, fmt.Errorf("sandbox-runtime does not support CLI command %q", command)
+	}
+
+	return sandboxruntime.Config{
+		Network: sandboxruntime.NetworkConfig{
+			AllowedDomains: domains,
+			DeniedDomains:  []string{},
+		},
+		Filesystem: sandboxruntime.FilesystemConfig{
+			AllowWrite: append([]string{absoluteCwd, "/tmp"}, statePaths...),
+			DenyRead: []string{
+				filepath.Join(home, ".ssh"),
+				filepath.Join(home, ".aws"),
+				filepath.Join(home, ".azure"),
+				filepath.Join(home, ".config", "gcloud"),
+				filepath.Join(home, ".kube"),
+				filepath.Join(home, ".docker", "run", "docker.sock"),
+				"/var/run/docker.sock",
+				"/run/docker.sock",
+				"/run/containerd/containerd.sock",
+				"/run/podman/podman.sock",
+			},
+			DenyWrite: []string{},
+		},
+		PassthroughEnv: passthroughEnv,
+	}, nil
 }
 
 func finishCLIStream(ctx context.Context, cmd *exec.Cmd, stderrBuf *bytes.Buffer) error {

--- a/pkg/ai/provider/cli_test.go
+++ b/pkg/ai/provider/cli_test.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,15 +17,19 @@ import (
 )
 
 type fakeCommandSandbox struct {
-	command string
-	args    []string
-	closed  bool
+	commandErr error
+	executable string
+	closed     bool
 }
 
 func (f *fakeCommandSandbox) Command(ctx context.Context, command string, args ...string) (*exec.Cmd, error) {
-	f.command = command
-	f.args = append([]string{}, args...)
-	return exec.CommandContext(ctx, "true"), nil
+	if f.commandErr != nil {
+		return nil, f.commandErr
+	}
+	if f.executable != "" {
+		command = f.executable
+	}
+	return exec.CommandContext(ctx, command, args...), nil
 }
 
 func (f *fakeCommandSandbox) Close(context.Context) error {
@@ -53,6 +59,13 @@ func TestParseStderr(t *testing.T) {
 }
 
 func TestGeminiCLIUsesContextDir(t *testing.T) {
+	original := newCommandSandbox
+	fake := &fakeCommandSandbox{}
+	newCommandSandbox = func(context.Context, sandboxruntime.Config) (commandSandbox, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newCommandSandbox = original })
+
 	cwd := filepath.Join(t.TempDir(), "workspace")
 	if err := os.MkdirAll(cwd, 0o755); err != nil {
 		t.Fatalf("mkdir workspace: %v", err)
@@ -70,7 +83,9 @@ func TestGeminiCLIUsesContextDir(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	resp, err := NewGeminiCLI("gemini-cli-pro").Execute(context.Background(), ai.Request{
+	provider := NewGeminiCLI("gemini-cli-pro")
+	provider.sandbox = true
+	resp, err := provider.Execute(context.Background(), ai.Request{
 		Prompt: api.Prompt{User: "hello"},
 		Setup:  &shell.Setup{Cwd: cwd},
 	})
@@ -91,51 +106,97 @@ func TestGeminiCLIUsesContextDir(t *testing.T) {
 	if resp.Usage.InputTokens != 1 || resp.Usage.CacheReadTokens != 2 || resp.Usage.OutputTokens != 2 {
 		t.Errorf("usage = %+v, want input=1 cacheRead=2 output=2", resp.Usage)
 	}
+	if !fake.closed {
+		t.Fatal("sandbox was not closed after the CLI stream completed")
+	}
 }
 
-func TestNewCLICommandUsesSandboxRuntime(t *testing.T) {
+func TestCLISandboxConfig(t *testing.T) {
+	cwd := t.TempDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	denyRead := []string{
+		filepath.Join(home, ".ssh"), filepath.Join(home, ".aws"), filepath.Join(home, ".azure"),
+		filepath.Join(home, ".config", "gcloud"), filepath.Join(home, ".kube"),
+		filepath.Join(home, ".docker", "run", "docker.sock"), "/var/run/docker.sock",
+		"/run/docker.sock", "/run/containerd/containerd.sock", "/run/podman/podman.sock",
+	}
+	tests := []struct {
+		command string
+		domains []string
+		env     []string
+		state   []string
+	}{
+		{"claude", []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}, []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}, []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}},
+		{"codex", []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}, []string{"OPENAI_API_KEY"}, []string{filepath.Join(home, ".codex")}},
+		{"gemini", []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}, []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, []string{filepath.Join(home, ".gemini")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			got, err := cliSandboxConfig(tt.command, cwd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := sandboxruntime.Config{
+				Network: sandboxruntime.NetworkConfig{AllowedDomains: tt.domains, DeniedDomains: []string{}},
+				Filesystem: sandboxruntime.FilesystemConfig{
+					AllowWrite: append([]string{cwd, "/tmp"}, tt.state...),
+					DenyRead:   denyRead,
+					DenyWrite:  []string{},
+				},
+				PassthroughEnv: tt.env,
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("cliSandboxConfig() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestCLIProviderFactoriesCarrySandbox(t *testing.T) {
+	tests := []struct {
+		backend api.Backend
+		model   string
+		enabled func(api.Provider) bool
+	}{
+		{api.BackendClaudeCLI, "claude-sonnet-5", func(p api.Provider) bool { return p.(*ClaudeCLI).sandbox }},
+		{api.BackendCodexCLI, "gpt-5.5", func(p api.Provider) bool { return p.(*CodexCLI).sandbox }},
+		{api.BackendGeminiCLI, "gemini-3.5-flash", func(p api.Provider) bool { return p.(*GeminiCLI).sandbox }},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.backend), func(t *testing.T) {
+			provider, err := api.NewProvider(api.Config{Model: api.Model{Name: tt.model, Backend: tt.backend}, Sandbox: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !tt.enabled(provider) {
+				t.Fatal("provider did not retain the sandbox setting")
+			}
+		})
+	}
+}
+
+func TestSandboxCommandFailuresClose(t *testing.T) {
 	original := newCommandSandbox
 	t.Cleanup(func() { newCommandSandbox = original })
 
-	cwd := t.TempDir()
-	fake := &fakeCommandSandbox{}
-	var cfg sandboxruntime.Config
-	newCommandSandbox = func(_ context.Context, got sandboxruntime.Config) (commandSandbox, error) {
-		cfg = got
-		return fake, nil
+	fake := &fakeCommandSandbox{commandErr: errors.New("wrap failed")}
+	newCommandSandbox = func(context.Context, sandboxruntime.Config) (commandSandbox, error) { return fake, nil }
+	if _, _, err := newCLICommand(context.Background(), "codex", nil, t.TempDir(), true); err == nil || !strings.Contains(err.Error(), "wrap codex") {
+		t.Fatalf("err = %v, want sandbox wrapping failure", err)
 	}
-
-	_, closeSandbox, err := newCLICommand(context.Background(), "codex", []string{"exec", "--json"}, cwd, true)
-	if err != nil {
-		t.Fatalf("newCLICommand: %v", err)
-	}
-	if fake.command != "codex" || strings.Join(fake.args, " ") != "exec --json" {
-		t.Fatalf("sandbox command = %q %v", fake.command, fake.args)
-	}
-	if cfg.Filesystem.AllowWrite[0] != cwd {
-		t.Fatalf("first writable path = %q, want workspace %q", cfg.Filesystem.AllowWrite[0], cwd)
-	}
-	if !containsString(cfg.Network.AllowedDomains, "*.openai.com") {
-		t.Fatalf("allowed domains = %v, want OpenAI endpoints", cfg.Network.AllowedDomains)
-	}
-	if !containsString(cfg.Filesystem.DenyRead, filepath.Join(os.Getenv("HOME"), ".ssh")) {
-		t.Fatalf("deny-read policy = %v, want .ssh protected", cfg.Filesystem.DenyRead)
-	}
-	if !containsString(cfg.Filesystem.DenyRead, "/var/run/docker.sock") {
-		t.Fatalf("deny-read policy = %v, want Docker socket protected", cfg.Filesystem.DenyRead)
-	}
-
-	closeSandbox()
 	if !fake.closed {
-		t.Fatal("sandbox was not closed")
+		t.Fatal("sandbox was not closed after wrapping failed")
 	}
-}
 
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
+	fake = &fakeCommandSandbox{executable: "captain-command-that-does-not-exist"}
+	newCommandSandbox = func(context.Context, sandboxruntime.Config) (commandSandbox, error) { return fake, nil }
+	if _, _, _, _, err := startCLIStream(context.Background(), "codex", nil, nil, t.TempDir(), nil, true); err == nil {
+		t.Fatal("expected process start failure")
 	}
-	return false
+	if !fake.closed {
+		t.Fatal("sandbox was not closed after process start failed")
+	}
 }

--- a/pkg/ai/provider/cli_test.go
+++ b/pkg/ai/provider/cli_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,7 +11,25 @@ import (
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/commons-db/shell"
+	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
 )
+
+type fakeCommandSandbox struct {
+	command string
+	args    []string
+	closed  bool
+}
+
+func (f *fakeCommandSandbox) Command(ctx context.Context, command string, args ...string) (*exec.Cmd, error) {
+	f.command = command
+	f.args = append([]string{}, args...)
+	return exec.CommandContext(ctx, "true"), nil
+}
+
+func (f *fakeCommandSandbox) Close(context.Context) error {
+	f.closed = true
+	return nil
+}
 
 func TestParseStderr(t *testing.T) {
 	tests := []struct {
@@ -72,4 +91,51 @@ func TestGeminiCLIUsesContextDir(t *testing.T) {
 	if resp.Usage.InputTokens != 1 || resp.Usage.CacheReadTokens != 2 || resp.Usage.OutputTokens != 2 {
 		t.Errorf("usage = %+v, want input=1 cacheRead=2 output=2", resp.Usage)
 	}
+}
+
+func TestNewCLICommandUsesSandboxRuntime(t *testing.T) {
+	original := newCommandSandbox
+	t.Cleanup(func() { newCommandSandbox = original })
+
+	cwd := t.TempDir()
+	fake := &fakeCommandSandbox{}
+	var cfg sandboxruntime.Config
+	newCommandSandbox = func(_ context.Context, got sandboxruntime.Config) (commandSandbox, error) {
+		cfg = got
+		return fake, nil
+	}
+
+	_, closeSandbox, err := newCLICommand(context.Background(), "codex", []string{"exec", "--json"}, cwd, true)
+	if err != nil {
+		t.Fatalf("newCLICommand: %v", err)
+	}
+	if fake.command != "codex" || strings.Join(fake.args, " ") != "exec --json" {
+		t.Fatalf("sandbox command = %q %v", fake.command, fake.args)
+	}
+	if cfg.Filesystem.AllowWrite[0] != cwd {
+		t.Fatalf("first writable path = %q, want workspace %q", cfg.Filesystem.AllowWrite[0], cwd)
+	}
+	if !containsString(cfg.Network.AllowedDomains, "*.openai.com") {
+		t.Fatalf("allowed domains = %v, want OpenAI endpoints", cfg.Network.AllowedDomains)
+	}
+	if !containsString(cfg.Filesystem.DenyRead, filepath.Join(os.Getenv("HOME"), ".ssh")) {
+		t.Fatalf("deny-read policy = %v, want .ssh protected", cfg.Filesystem.DenyRead)
+	}
+	if !containsString(cfg.Filesystem.DenyRead, "/var/run/docker.sock") {
+		t.Fatalf("deny-read policy = %v, want Docker socket protected", cfg.Filesystem.DenyRead)
+	}
+
+	closeSandbox()
+	if !fake.closed {
+		t.Fatal("sandbox was not closed")
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ai/provider/codex_cli.go
+++ b/pkg/ai/provider/codex_cli.go
@@ -19,8 +19,9 @@ import (
 var codexCLICommand = "codex"
 
 type CodexCLI struct {
-	model  string
-	apiURL string
+	model   string
+	apiURL  string
+	sandbox bool
 }
 
 func NewCodexCLI(cfg ai.Config) *CodexCLI {
@@ -29,8 +30,9 @@ func NewCodexCLI(cfg ai.Config) *CodexCLI {
 		model = CodexCLIDefaultModel
 	}
 	return &CodexCLI{
-		model:  ai.NormalizeModelForBackend(ai.BackendCodexCLI, model),
-		apiURL: strings.TrimSpace(cfg.APIURL),
+		model:   ai.NormalizeModelForBackend(ai.BackendCodexCLI, model),
+		apiURL:  strings.TrimSpace(cfg.APIURL),
+		sandbox: cfg.Sandbox,
 	}
 }
 
@@ -70,7 +72,7 @@ func (c *CodexCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan ai
 	if req.Setup != nil {
 		env = commandEnv(req.Setup.Env)
 	}
-	cmd, stdout, stderrBuf, err := startCLIStream(ctx, codexCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env)
+	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, codexCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env, c.sandbox)
 	if err != nil {
 		cleanup()
 		return nil, err
@@ -79,6 +81,7 @@ func (c *CodexCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan ai
 	go func() {
 		defer close(out)
 		defer cleanup()
+		defer closeSandbox()
 		defer func() { _ = stdout.Close() }()
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)

--- a/pkg/ai/provider/gemini_cli.go
+++ b/pkg/ai/provider/gemini_cli.go
@@ -18,7 +18,8 @@ var geminiCLICommand = "gemini"
 const geminiCLIDefaultModel = "gemini-3.5-flash"
 
 type GeminiCLI struct {
-	model string
+	model   string
+	sandbox bool
 }
 
 // registry.Google declares Streaming for ModeCLI, and the logging/validating
@@ -74,13 +75,14 @@ func (g *GeminiCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan a
 	}
 	// gemini reads the prompt from stdin and goes headless whenever stdin or
 	// stdout is not a TTY, which piping both guarantees.
-	cmd, stdout, stderrBuf, err := startCLIStream(ctx, geminiCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env)
+	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, geminiCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env, g.sandbox)
 	if err != nil {
 		return nil, err
 	}
 	out := make(chan ai.Event, 16)
 	go func() {
 		defer close(out)
+		defer closeSandbox()
 		defer func() { _ = stdout.Close() }()
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)

--- a/pkg/ai/provider/init.go
+++ b/pkg/ai/provider/init.go
@@ -17,7 +17,11 @@ func init() {
 	ai.RegisterProvider(ai.BackendDeepSeek, func(cfg ai.Config) (ai.Provider, error) { return genkit.New(cfg) })
 
 	ai.RegisterProvider(ai.BackendClaudeAgent, func(cfg ai.Config) (ai.Provider, error) { return claudeagent.New(cfg) })
-	ai.RegisterProvider(ai.BackendClaudeCLI, func(cfg ai.Config) (ai.Provider, error) { return NewClaudeCLI(cfg.Model.Name), nil })
+	ai.RegisterProvider(ai.BackendClaudeCLI, func(cfg ai.Config) (ai.Provider, error) {
+		provider := NewClaudeCLI(cfg.Model.Name)
+		provider.sandbox = cfg.Sandbox
+		return provider, nil
+	})
 
 	ai.RegisterProvider(ai.BackendCodexCLI, func(cfg ai.Config) (ai.Provider, error) { return NewCodexCLI(cfg), nil })
 	ai.RegisterProvider(ai.BackendCodexAgent, func(cfg ai.Config) (ai.Provider, error) { return NewCodexAppServer(cfg.Model.Name) })
@@ -28,5 +32,9 @@ func init() {
 	ai.RegisterProvider(ai.BackendClaudeCmux, func(cfg ai.Config) (ai.Provider, error) { return cmux.New(cfg) })
 	ai.RegisterProvider(ai.BackendCodexCmux, func(cfg ai.Config) (ai.Provider, error) { return cmux.New(cfg) })
 
-	ai.RegisterProvider(ai.BackendGeminiCLI, func(cfg ai.Config) (ai.Provider, error) { return NewGeminiCLI(cfg.Model.Name), nil })
+	ai.RegisterProvider(ai.BackendGeminiCLI, func(cfg ai.Config) (ai.Provider, error) {
+		provider := NewGeminiCLI(cfg.Model.Name)
+		provider.sandbox = cfg.Sandbox
+		return provider, nil
+	})
 }

--- a/pkg/aiflags/flags.go
+++ b/pkg/aiflags/flags.go
@@ -108,6 +108,9 @@ func (f ModelFlags) ToModel() (registry.Model, error) {
 			return registry.Model{}, err
 		}
 	}
+	if strings.TrimSpace(f.Mode) != "" {
+		return m.WithMode(m.Mode)
+	}
 	return m, nil
 }
 
@@ -125,26 +128,8 @@ func (f ModelFlags) Resolve() (registry.Model, error) {
 // ResolveWith is the pure core: no ambient I/O, no globals. Saved defaults arrive
 // as a parameter so tests and spec-overlaying callers can drive it directly.
 func (f ModelFlags) ResolveWith(saved captainconfig.AIDefaults) (registry.Model, error) {
-	return f.ResolveWithMode(saved, "")
-}
-
-// ResolveWithMode resolves flags and saved defaults while requesting one
-// runtime mechanism for the primary model and all fallbacks.
-func (f ModelFlags) ResolveWithMode(saved captainconfig.AIDefaults, mode registry.RuntimeMode) (registry.Model, error) {
-	if mode != "" && strings.TrimSpace(f.Mode) != "" {
-		explicit, ok := registry.ParseRuntimeMode(f.Mode)
-		if !ok {
-			return registry.Model{}, fmt.Errorf("invalid --mode %q (valid: %s)", f.Mode, registry.RuntimeModeList())
-		}
-		if explicit != mode {
-			return registry.Model{}, fmt.Errorf("mode %q contradicts requested mode %q", explicit, mode)
-		}
-	}
 	m, err := f.ToModel()
 	if err != nil {
-		return registry.Model{}, err
-	}
-	if m, err = m.WithMode(mode); err != nil {
 		return registry.Model{}, err
 	}
 	if !f.NoCache && saved.NoCache {

--- a/pkg/aiflags/flags.go
+++ b/pkg/aiflags/flags.go
@@ -125,8 +125,26 @@ func (f ModelFlags) Resolve() (registry.Model, error) {
 // ResolveWith is the pure core: no ambient I/O, no globals. Saved defaults arrive
 // as a parameter so tests and spec-overlaying callers can drive it directly.
 func (f ModelFlags) ResolveWith(saved captainconfig.AIDefaults) (registry.Model, error) {
+	return f.ResolveWithMode(saved, "")
+}
+
+// ResolveWithMode resolves flags and saved defaults while requesting one
+// runtime mechanism for the primary model and all fallbacks.
+func (f ModelFlags) ResolveWithMode(saved captainconfig.AIDefaults, mode registry.RuntimeMode) (registry.Model, error) {
+	if mode != "" && strings.TrimSpace(f.Mode) != "" {
+		explicit, ok := registry.ParseRuntimeMode(f.Mode)
+		if !ok {
+			return registry.Model{}, fmt.Errorf("invalid --mode %q (valid: %s)", f.Mode, registry.RuntimeModeList())
+		}
+		if explicit != mode {
+			return registry.Model{}, fmt.Errorf("mode %q contradicts requested mode %q", explicit, mode)
+		}
+	}
 	m, err := f.ToModel()
 	if err != nil {
+		return registry.Model{}, err
+	}
+	if m, err = m.WithMode(mode); err != nil {
 		return registry.Model{}, err
 	}
 	if !f.NoCache && saved.NoCache {

--- a/pkg/api/registry/model.go
+++ b/pkg/api/registry/model.go
@@ -97,6 +97,48 @@ func (m Model) Capabilities() Model {
 	return m
 }
 
+// WithMode applies one runtime mechanism to the primary model and every
+// fallback before backend resolution. Explicit backends that name a different
+// mechanism remain contradictions rather than being silently rewritten.
+func (m Model) WithMode(mode RuntimeMode) (Model, error) {
+	if mode == "" {
+		return m, nil
+	}
+	if _, ok := ParseRuntimeMode(string(mode)); !ok {
+		return Model{}, fmt.Errorf("invalid mode %q (valid: %s)", mode, RuntimeModeList())
+	}
+
+	var err error
+	if m, err = m.Expand(); err != nil {
+		return Model{}, err
+	}
+	apply := func(candidate Model) (Model, error) {
+		expanded, expandErr := candidate.Expand()
+		if expandErr != nil {
+			return Model{}, expandErr
+		}
+		candidate = expanded
+		if candidate.Mode != "" && candidate.Mode != mode {
+			return Model{}, fmt.Errorf("mode %q contradicts requested mode %q", candidate.Mode, mode)
+		}
+		candidate.Mode = mode
+		if err := candidate.validateMode(); err != nil {
+			return Model{}, err
+		}
+		return candidate, nil
+	}
+
+	if m, err = apply(m); err != nil {
+		return Model{}, err
+	}
+	for i := range m.Fallbacks {
+		if m.Fallbacks[i], err = apply(m.Fallbacks[i]); err != nil {
+			return Model{}, fmt.Errorf("fallback[%d]: %w", i, err)
+		}
+	}
+	return m, nil
+}
+
 // ResolveBackend returns Backend when set, otherwise infers it from Name.
 func (m Model) ResolveBackend() (Backend, error) {
 	if m.Backend != "" {

--- a/pkg/api/registry/model_compact.go
+++ b/pkg/api/registry/model_compact.go
@@ -114,6 +114,9 @@ func (m Model) Expand() (Model, error) {
 	if parsed.Backend == "" {
 		parsed.Backend = m.Backend
 	}
+	if parsed.Mode == "" {
+		parsed.Mode = m.Mode
+	}
 	parsed.ID = m.ID
 	parsed.Temperature = m.Temperature
 	if !parsed.NoCache {

--- a/pkg/api/registry/parse.go
+++ b/pkg/api/registry/parse.go
@@ -298,7 +298,7 @@ func ResolveModel(m Model) (Model, error) {
 			out.Fallbacks = append(out.Fallbacks, fb)
 			continue
 		}
-		rfb, err := ParseModelElement(fb.Name, ParseOptions{Backend: fb.Backend})
+		rfb, err := ParseModelElement(fb.Name, ParseOptions{Backend: fb.Backend, Mode: fb.Mode})
 		if err != nil {
 			return Model{}, err
 		}

--- a/pkg/api/runtime_config.go
+++ b/pkg/api/runtime_config.go
@@ -50,7 +50,10 @@ type Config struct {
 	// googlegenai plugin exposes no override and silently calling the real API
 	// would be worse. codex-cli honours it by declaring a model_providers entry,
 	// since it ignores OPENAI_BASE_URL once account auth is stored.
-	APIURL        string
+	APIURL string
+	// Sandbox runs local agent CLI processes through sandbox-runtime. Provider
+	// selection must resolve to CLI mode so the flag cannot be silently ignored.
+	Sandbox       bool
 	CacheDBPath   string
 	CacheTTL      time.Duration
 	NoCache       bool

--- a/pkg/api/runtime_provider_ginkgo_test.go
+++ b/pkg/api/runtime_provider_ginkgo_test.go
@@ -76,3 +76,13 @@ var _ = Describe("API key resolution", func() {
 		Expect(resolved.Detail).To(Equal("OPENAI_API_KEY"))
 	})
 })
+
+var _ = Describe("Sandbox provider selection", func() {
+	It("rejects non-CLI backends", func() {
+		_, err := api.NewProvider(api.Config{
+			Model:   api.Model{Name: "claude-sonnet-5", Backend: api.BackendAnthropic},
+			Sandbox: true,
+		})
+		Expect(err).To(MatchError(ContainSubstring("requires a CLI backend")))
+	})
+})

--- a/pkg/api/runtime_registry.go
+++ b/pkg/api/runtime_registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/flanksource/captain/pkg/api/registry"
 	"github.com/flanksource/captain/pkg/credentials"
 )
 
@@ -45,6 +46,9 @@ func NewProvider(cfg Config) (Provider, error) {
 		}
 	}
 	cfg.Model.Backend = backend
+	if cfg.Sandbox && backend.Mode() != registry.ModeCLI {
+		return nil, fmt.Errorf("sandbox-runtime requires a CLI backend, got %s", backend)
+	}
 
 	factory, ok := factories[backend]
 	if !ok {

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -86,11 +86,20 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 	// One resolve: flags → Model → saved per-provider defaults → catalog. The
 	// warn-and-continue policy for a broken config stays here (loadSavedConfig), so
 	// aiflags can hand the error back instead of swallowing it.
-	mode := registry.RuntimeMode("")
+	flags := o.ModelFlags
 	if o.Sandbox {
-		mode = registry.ModeCLI
+		if value := strings.TrimSpace(flags.Mode); value != "" {
+			mode, ok := registry.ParseRuntimeMode(value)
+			if !ok {
+				return ai.Config{}, fmt.Errorf("invalid --mode %q (valid: %s)", value, registry.RuntimeModeList())
+			}
+			if mode != registry.ModeCLI {
+				return ai.Config{}, fmt.Errorf("--sandbox requires CLI mode, but --mode is %q", mode)
+			}
+		}
+		flags.Mode = string(registry.ModeCLI)
 	}
-	m, err := o.ResolveWithMode(saved, mode)
+	m, err := flags.ResolveWith(saved)
 	if err != nil {
 		return ai.Config{}, err
 	}

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -86,15 +86,13 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 	// One resolve: flags → Model → saved per-provider defaults → catalog. The
 	// warn-and-continue policy for a broken config stays here (loadSavedConfig), so
 	// aiflags can hand the error back instead of swallowing it.
-	m, err := o.ResolveWith(saved)
+	mode := registry.RuntimeMode("")
+	if o.Sandbox {
+		mode = registry.ModeCLI
+	}
+	m, err := o.ResolveWithMode(saved, mode)
 	if err != nil {
 		return ai.Config{}, err
-	}
-	if o.Sandbox {
-		m, err = sandboxCLIModel(m)
-		if err != nil {
-			return ai.Config{}, err
-		}
 	}
 	return ai.Config{
 		Model:        m,
@@ -105,38 +103,6 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 		NoCache:      o.NoCache || saved.NoCache,
 		SchemaRepair: schemaRepairConfig(savedCfg.Prompts.SchemaRepair),
 	}, nil
-}
-
-func sandboxCLIModel(model api.Model) (api.Model, error) {
-	forceCLI := func(candidate api.Model) (api.Model, error) {
-		provider := candidate.Backend.ModelProvider()
-		if provider == nil {
-			return api.Model{}, fmt.Errorf("cannot sandbox model %q: no model provider found", candidate.Name)
-		}
-		backend, err := provider.BackendFor(registry.ModeCLI)
-		if err != nil {
-			return api.Model{}, fmt.Errorf("cannot sandbox model %q: %w", candidate.Name, err)
-		}
-		candidate.Backend = backend
-		candidate.Mode = registry.ModeCLI
-		return candidate.Capabilities(), nil
-	}
-
-	fallbacks := model.Fallbacks
-	model.Fallbacks = nil
-	resolved, err := forceCLI(model)
-	if err != nil {
-		return api.Model{}, err
-	}
-	for _, fallback := range fallbacks {
-		fallback.Fallbacks = nil
-		fallback, err = forceCLI(fallback)
-		if err != nil {
-			return api.Model{}, err
-		}
-		resolved.Fallbacks = append(resolved.Fallbacks, fallback)
-	}
-	return resolved, nil
 }
 
 func schemaRepairConfig(saved captainconfig.SchemaRepairDefaults) api.SchemaRepairConfig {

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flanksource/captain/pkg/ai/pricing"
 	"github.com/flanksource/captain/pkg/aiflags"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/api/registry"
 	"github.com/flanksource/captain/pkg/captainconfig"
 	"github.com/flanksource/captain/pkg/claude"
 	"github.com/flanksource/captain/pkg/claude/tools"
@@ -47,9 +48,10 @@ func loadSavedConfig() captainconfig.Config {
 type AIProviderOptions struct {
 	aiflags.ModelFlags
 
-	APIKey string `flag:"api-key" help:"API key (env: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, DEEPSEEK_API_KEY)"`
-	APIURL string `flag:"api-url" help:"Override the backend endpoint, e.g. a 'captain ai mock' URL. Required for codex-cli, which ignores OPENAI_BASE_URL when a ChatGPT credential is stored"`
-	Budget string `flag:"budget" help:"Max spend in USD, 0=unlimited" default:"0"`
+	APIKey  string `flag:"api-key" help:"API key (env: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, DEEPSEEK_API_KEY)"`
+	APIURL  string `flag:"api-url" help:"Override the backend endpoint, e.g. a 'captain ai mock' URL. Required for codex-cli, which ignores OPENAI_BASE_URL when a ChatGPT credential is stored"`
+	Budget  string `flag:"budget" help:"Max spend in USD, 0=unlimited" default:"0"`
+	Sandbox bool   `flag:"sandbox" help:"Run the local agent CLI in an OS-level sandbox"`
 }
 
 // BudgetUSD parses --budget, failing loud on malformed input.
@@ -88,14 +90,53 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 	if err != nil {
 		return ai.Config{}, err
 	}
+	if o.Sandbox {
+		m, err = sandboxCLIModel(m)
+		if err != nil {
+			return ai.Config{}, err
+		}
+	}
 	return ai.Config{
 		Model:        m,
 		Budget:       api.Budget{Cost: budget},
 		APIKey:       o.APIKey,
 		APIURL:       strings.TrimSpace(o.APIURL),
+		Sandbox:      o.Sandbox,
 		NoCache:      o.NoCache || saved.NoCache,
 		SchemaRepair: schemaRepairConfig(savedCfg.Prompts.SchemaRepair),
 	}, nil
+}
+
+func sandboxCLIModel(model api.Model) (api.Model, error) {
+	forceCLI := func(candidate api.Model) (api.Model, error) {
+		provider := candidate.Backend.ModelProvider()
+		if provider == nil {
+			return api.Model{}, fmt.Errorf("cannot sandbox model %q: no model provider found", candidate.Name)
+		}
+		backend, err := provider.BackendFor(registry.ModeCLI)
+		if err != nil {
+			return api.Model{}, fmt.Errorf("cannot sandbox model %q: %w", candidate.Name, err)
+		}
+		candidate.Backend = backend
+		candidate.Mode = registry.ModeCLI
+		return candidate.Capabilities(), nil
+	}
+
+	fallbacks := model.Fallbacks
+	model.Fallbacks = nil
+	resolved, err := forceCLI(model)
+	if err != nil {
+		return api.Model{}, err
+	}
+	for _, fallback := range fallbacks {
+		fallback.Fallbacks = nil
+		fallback, err = forceCLI(fallback)
+		if err != nil {
+			return api.Model{}, err
+		}
+		resolved.Fallbacks = append(resolved.Fallbacks, fallback)
+	}
+	return resolved, nil
 }
 
 func schemaRepairConfig(saved captainconfig.SchemaRepairDefaults) api.SchemaRepairConfig {

--- a/pkg/cli/ai_prompt_file.go
+++ b/pkg/cli/ai_prompt_file.go
@@ -101,6 +101,12 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	if err != nil {
 		return base, baseCfg, err
 	}
+	if o.Sandbox {
+		req.Model, err = sandboxCLIModel(req.Model)
+		if err != nil {
+			return base, baseCfg, err
+		}
+	}
 
 	req.Budget.MaxTokens = firstPositive(o.MaxTokens, base.Budget.MaxTokens, baseCfg.Budget.MaxTokens, saved.MaxTokens, 4096)
 	req.Budget.Cost = firstPositiveFloat(budget, base.Budget.Cost, baseCfg.Budget.Cost, saved.BudgetUSD)
@@ -155,6 +161,7 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	cfg.Budget = req.Budget
 	cfg.APIKey = o.APIKey
 	cfg.APIURL = firstNonEmpty(strings.TrimSpace(o.APIURL), baseCfg.APIURL)
+	cfg.Sandbox = o.Sandbox || baseCfg.Sandbox
 	cfg.NoCache = req.NoCache
 	return req, cfg, nil
 }

--- a/pkg/cli/ai_prompt_file.go
+++ b/pkg/cli/ai_prompt_file.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/ai/prompt"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/api/registry"
 )
 
 // resolvePromptTemplate picks the prompt source for `captain ai prompt` and loads
@@ -93,6 +94,37 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	m.Effort = api.Effort(firstNonEmpty(o.Effort, string(bm.Effort)))
 	m.NoCache = o.NoCache || bm.NoCache || saved.NoCache
 	m.Fallbacks = firstFallbacks(o.Fallback, bm.Fallbacks)
+
+	requestedMode := registry.RuntimeMode("")
+	if value := strings.TrimSpace(o.Mode); value != "" {
+		var ok bool
+		requestedMode, ok = registry.ParseRuntimeMode(value)
+		if !ok {
+			return base, baseCfg, fmt.Errorf("invalid --mode %q (valid: %s)", o.Mode, registry.RuntimeModeList())
+		}
+	}
+	if o.Sandbox {
+		if requestedMode != "" && requestedMode != registry.ModeCLI {
+			return base, baseCfg, fmt.Errorf("--sandbox requires CLI mode, but --mode is %q", requestedMode)
+		}
+		requestedMode = registry.ModeCLI
+	}
+	if requestedMode != "" {
+		m.Mode = ""
+		if strings.TrimSpace(o.Backend) == "" && !ai.ContainsRuntimeSelector(o.Model) {
+			m.Backend = ""
+		}
+		if len(o.Fallback) == 0 {
+			for i := range m.Fallbacks {
+				m.Fallbacks[i].Backend = ""
+				m.Fallbacks[i].Mode = ""
+			}
+		}
+		m, err = m.WithMode(requestedMode)
+		if err != nil {
+			return base, baseCfg, err
+		}
+	}
 	m, err = applyProviderDefaults(m, saved)
 	if err != nil {
 		return base, baseCfg, err
@@ -100,12 +132,6 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	req.Model, err = ai.ResolveModelSelectors(m)
 	if err != nil {
 		return base, baseCfg, err
-	}
-	if o.Sandbox {
-		req.Model, err = sandboxCLIModel(req.Model)
-		if err != nil {
-			return base, baseCfg, err
-		}
 	}
 
 	req.Budget.MaxTokens = firstPositive(o.MaxTokens, base.Budget.MaxTokens, baseCfg.Budget.MaxTokens, saved.MaxTokens, 4096)

--- a/pkg/cli/ai_prompt_file_test.go
+++ b/pkg/cli/ai_prompt_file_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/flanksource/captain/pkg/ai"
-	"github.com/flanksource/captain/pkg/aiflags"
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/commons-db/shell"
 )
@@ -148,42 +147,31 @@ func TestOverlayCLI_CLIOverridesFrontmatter(t *testing.T) {
 	}
 }
 
-func TestOverlayCLI_SandboxForcesFrontmatterModelToCLI(t *testing.T) {
-	isolateSavedAI(t)
-	base := baseFileReq()
-	base.Model.Backend = api.BackendAnthropic
-	req, cfg, err := overlayCLI(base, ai.Config{}, AIPromptOptions{
-		AIRuntimeOptions: AIRuntimeOptions{
-			AIProviderOptions: AIProviderOptions{Sandbox: true},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Model.Backend != api.BackendClaudeCLI {
-		t.Fatalf("req backend = %q, want %q", req.Model.Backend, api.BackendClaudeCLI)
-	}
-	if req.Model.Name != base.Model.Name {
-		t.Fatalf("req model = %q, want unchanged %q", req.Model.Name, base.Model.Name)
-	}
-	if !cfg.Sandbox {
-		t.Fatal("cfg.Sandbox = false, want true")
-	}
-}
-
-func TestOverlayCLI_SandboxRejectsExplicitAPIMode(t *testing.T) {
-	isolateSavedAI(t)
-	opts := AIPromptOptions{
-		AIRuntimeOptions: AIRuntimeOptions{
-			AIProviderOptions: AIProviderOptions{
-				ModelFlags: aiflags.ModelFlags{Mode: "api"},
-				Sandbox:    true,
-			},
-		},
-	}
-	_, _, err := overlayCLI(baseFileReq(), ai.Config{}, opts)
-	if err == nil || !strings.Contains(err.Error(), "--sandbox requires CLI mode") {
-		t.Fatalf("err = %v, want sandbox/mode contradiction", err)
+func TestOverlayCLI_Sandbox(t *testing.T) {
+	for _, tt := range []struct{ name, mode, wantErr string }{
+		{name: "selects CLI for frontmatter model"},
+		{name: "rejects explicit API mode", mode: "api", wantErr: "--sandbox requires CLI mode"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateSavedAI(t)
+			base := baseFileReq()
+			base.Model.Backend = api.BackendAnthropic
+			opts := AIPromptOptions{AIRuntimeOptions: AIRuntimeOptions{AIProviderOptions: AIProviderOptions{Sandbox: true}}}
+			opts.Mode = tt.mode
+			req, cfg, err := overlayCLI(base, ai.Config{}, opts)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if req.Model.Backend != api.BackendClaudeCLI || req.Model.Name != base.Model.Name || !cfg.Sandbox {
+				t.Fatalf("sandbox model = %#v, sandbox=%v", req.Model, cfg.Sandbox)
+			}
+		})
 	}
 }
 

--- a/pkg/cli/ai_prompt_file_test.go
+++ b/pkg/cli/ai_prompt_file_test.go
@@ -146,6 +146,24 @@ func TestOverlayCLI_CLIOverridesFrontmatter(t *testing.T) {
 	}
 }
 
+func TestOverlayCLI_SandboxForcesFrontmatterModelToCLI(t *testing.T) {
+	isolateSavedAI(t)
+	req, cfg, err := overlayCLI(baseFileReq(), ai.Config{}, AIPromptOptions{
+		AIRuntimeOptions: AIRuntimeOptions{
+			AIProviderOptions: AIProviderOptions{Sandbox: true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Model.Backend != api.BackendClaudeCLI {
+		t.Fatalf("req backend = %q, want %q", req.Model.Backend, api.BackendClaudeCLI)
+	}
+	if !cfg.Sandbox {
+		t.Fatal("cfg.Sandbox = false, want true")
+	}
+}
+
 // --api-url is what points a run at a `captain ai mock` endpoint, so it has to
 // survive the overlay; a prompt file may pin its own endpoint, and the flag wins.
 func TestOverlayCLI_APIURLFlagBeatsFrontmatter(t *testing.T) {

--- a/pkg/cli/ai_prompt_file_test.go
+++ b/pkg/cli/ai_prompt_file_test.go
@@ -4,9 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/aiflags"
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/commons-db/shell"
 )
@@ -148,7 +150,9 @@ func TestOverlayCLI_CLIOverridesFrontmatter(t *testing.T) {
 
 func TestOverlayCLI_SandboxForcesFrontmatterModelToCLI(t *testing.T) {
 	isolateSavedAI(t)
-	req, cfg, err := overlayCLI(baseFileReq(), ai.Config{}, AIPromptOptions{
+	base := baseFileReq()
+	base.Model.Backend = api.BackendAnthropic
+	req, cfg, err := overlayCLI(base, ai.Config{}, AIPromptOptions{
 		AIRuntimeOptions: AIRuntimeOptions{
 			AIProviderOptions: AIProviderOptions{Sandbox: true},
 		},
@@ -159,8 +163,27 @@ func TestOverlayCLI_SandboxForcesFrontmatterModelToCLI(t *testing.T) {
 	if req.Model.Backend != api.BackendClaudeCLI {
 		t.Fatalf("req backend = %q, want %q", req.Model.Backend, api.BackendClaudeCLI)
 	}
+	if req.Model.Name != base.Model.Name {
+		t.Fatalf("req model = %q, want unchanged %q", req.Model.Name, base.Model.Name)
+	}
 	if !cfg.Sandbox {
 		t.Fatal("cfg.Sandbox = false, want true")
+	}
+}
+
+func TestOverlayCLI_SandboxRejectsExplicitAPIMode(t *testing.T) {
+	isolateSavedAI(t)
+	opts := AIPromptOptions{
+		AIRuntimeOptions: AIRuntimeOptions{
+			AIProviderOptions: AIProviderOptions{
+				ModelFlags: aiflags.ModelFlags{Mode: "api"},
+				Sandbox:    true,
+			},
+		},
+	}
+	_, _, err := overlayCLI(baseFileReq(), ai.Config{}, opts)
+	if err == nil || !strings.Contains(err.Error(), "--sandbox requires CLI mode") {
+		t.Fatalf("err = %v, want sandbox/mode contradiction", err)
 	}
 }
 

--- a/pkg/cli/ai_test.go
+++ b/pkg/cli/ai_test.go
@@ -266,7 +266,7 @@ func TestAIProviderOptions_ToConfig_ValidationErrors(t *testing.T) {
 func TestAIProviderOptions_ToConfig_SandboxForcesCLI(t *testing.T) {
 	isolateSavedAI(t)
 	cfg, err := (AIProviderOptions{
-		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"},
+		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5"},
 		Sandbox:    true,
 	}).ToConfig()
 	if err != nil {
@@ -277,6 +277,65 @@ func TestAIProviderOptions_ToConfig_SandboxForcesCLI(t *testing.T) {
 	}
 	if cfg.Model.Backend != api.BackendClaudeCLI || cfg.Model.Mode != registry.ModeCLI {
 		t.Fatalf("model runtime = %s/%s, want %s/%s", cfg.Model.Backend, cfg.Model.Mode, api.BackendClaudeCLI, registry.ModeCLI)
+	}
+	if cfg.Model.Name != "claude-sonnet-5" {
+		t.Fatalf("model name = %q, want unchanged", cfg.Model.Name)
+	}
+}
+
+func TestAIProviderOptions_ToConfig_SandboxRejectsExplicitAPIBackend(t *testing.T) {
+	isolateSavedAI(t)
+	_, err := (AIProviderOptions{
+		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"},
+		Sandbox:    true,
+	}).ToConfig()
+	if err == nil || !strings.Contains(err.Error(), "contradicts backend") {
+		t.Fatalf("err = %v, want CLI/API contradiction", err)
+	}
+}
+
+func TestAIProviderOptions_ToConfig_SandboxRejectsExplicitAPIMode(t *testing.T) {
+	isolateSavedAI(t)
+	_, err := (AIProviderOptions{
+		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"},
+		Sandbox:    true,
+	}).ToConfig()
+	if err == nil || !strings.Contains(err.Error(), "contradicts requested mode") {
+		t.Fatalf("err = %v, want CLI/API mode contradiction", err)
+	}
+}
+
+func TestAIProviderOptions_ToConfig_SandboxOverridesSavedRuntime(t *testing.T) {
+	seedSavedAI(t, "ai:\n  model: opus\n  backend: claude-agent\n")
+	cfg, err := (AIProviderOptions{Sandbox: true}).ToConfig()
+	if err != nil {
+		t.Fatalf("ToConfig: %v", err)
+	}
+	if cfg.Model.Backend != api.BackendClaudeCLI {
+		t.Fatalf("backend = %q, want %q", cfg.Model.Backend, api.BackendClaudeCLI)
+	}
+}
+
+func TestAIProviderOptions_ToConfig_SandboxResolvesFallbacksInCLIMode(t *testing.T) {
+	isolateSavedAI(t)
+	cfg, err := (AIProviderOptions{
+		ModelFlags: aiflags.ModelFlags{
+			Model:    "claude-sonnet-5",
+			Fallback: []string{"gpt-5.5", "gemini-3.5-flash"},
+		},
+		Sandbox: true,
+	}).ToConfig()
+	if err != nil {
+		t.Fatalf("ToConfig: %v", err)
+	}
+	want := []api.Backend{api.BackendCodexCLI, api.BackendGeminiCLI}
+	if len(cfg.Model.Fallbacks) != len(want) {
+		t.Fatalf("fallbacks = %v, want %d", cfg.Model.Fallbacks, len(want))
+	}
+	for i, backend := range want {
+		if cfg.Model.Fallbacks[i].Backend != backend {
+			t.Fatalf("fallback[%d] backend = %q, want %q", i, cfg.Model.Fallbacks[i].Backend, backend)
+		}
 	}
 }
 

--- a/pkg/cli/ai_test.go
+++ b/pkg/cli/ai_test.go
@@ -263,79 +263,48 @@ func TestAIProviderOptions_ToConfig_ValidationErrors(t *testing.T) {
 	}
 }
 
-func TestAIProviderOptions_ToConfig_SandboxForcesCLI(t *testing.T) {
-	isolateSavedAI(t)
-	cfg, err := (AIProviderOptions{
-		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5"},
-		Sandbox:    true,
-	}).ToConfig()
-	if err != nil {
-		t.Fatalf("ToConfig: %v", err)
+func TestAIProviderOptions_ToConfig_Sandbox(t *testing.T) {
+	tests := []struct {
+		name, saved, wantName, wantErr string
+		flags                          aiflags.ModelFlags
+		backends                       []api.Backend
+	}{
+		{name: "selects CLI without changing model", flags: aiflags.ModelFlags{Model: "claude-sonnet-5"}, wantName: "claude-sonnet-5", backends: []api.Backend{api.BackendClaudeCLI}},
+		{name: "rejects explicit API backend", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"}, wantErr: "contradicts backend"},
+		{name: "rejects explicit API mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"}, wantErr: "--sandbox requires CLI mode"},
+		{name: "overrides saved runtime", saved: "ai:\n  model: opus\n  backend: claude-agent\n", backends: []api.Backend{api.BackendClaudeCLI}},
+		{name: "resolves fallbacks in CLI mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5,gpt-5.5", Fallback: []string{"gemini-3.5-flash"}}, backends: []api.Backend{api.BackendClaudeCLI, api.BackendCodexCLI, api.BackendGeminiCLI}},
 	}
-	if !cfg.Sandbox {
-		t.Fatal("Sandbox = false, want true")
-	}
-	if cfg.Model.Backend != api.BackendClaudeCLI || cfg.Model.Mode != registry.ModeCLI {
-		t.Fatalf("model runtime = %s/%s, want %s/%s", cfg.Model.Backend, cfg.Model.Mode, api.BackendClaudeCLI, registry.ModeCLI)
-	}
-	if cfg.Model.Name != "claude-sonnet-5" {
-		t.Fatalf("model name = %q, want unchanged", cfg.Model.Name)
-	}
-}
-
-func TestAIProviderOptions_ToConfig_SandboxRejectsExplicitAPIBackend(t *testing.T) {
-	isolateSavedAI(t)
-	_, err := (AIProviderOptions{
-		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"},
-		Sandbox:    true,
-	}).ToConfig()
-	if err == nil || !strings.Contains(err.Error(), "contradicts backend") {
-		t.Fatalf("err = %v, want CLI/API contradiction", err)
-	}
-}
-
-func TestAIProviderOptions_ToConfig_SandboxRejectsExplicitAPIMode(t *testing.T) {
-	isolateSavedAI(t)
-	_, err := (AIProviderOptions{
-		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"},
-		Sandbox:    true,
-	}).ToConfig()
-	if err == nil || !strings.Contains(err.Error(), "contradicts requested mode") {
-		t.Fatalf("err = %v, want CLI/API mode contradiction", err)
-	}
-}
-
-func TestAIProviderOptions_ToConfig_SandboxOverridesSavedRuntime(t *testing.T) {
-	seedSavedAI(t, "ai:\n  model: opus\n  backend: claude-agent\n")
-	cfg, err := (AIProviderOptions{Sandbox: true}).ToConfig()
-	if err != nil {
-		t.Fatalf("ToConfig: %v", err)
-	}
-	if cfg.Model.Backend != api.BackendClaudeCLI {
-		t.Fatalf("backend = %q, want %q", cfg.Model.Backend, api.BackendClaudeCLI)
-	}
-}
-
-func TestAIProviderOptions_ToConfig_SandboxResolvesFallbacksInCLIMode(t *testing.T) {
-	isolateSavedAI(t)
-	cfg, err := (AIProviderOptions{
-		ModelFlags: aiflags.ModelFlags{
-			Model:    "claude-sonnet-5",
-			Fallback: []string{"gpt-5.5", "gemini-3.5-flash"},
-		},
-		Sandbox: true,
-	}).ToConfig()
-	if err != nil {
-		t.Fatalf("ToConfig: %v", err)
-	}
-	want := []api.Backend{api.BackendCodexCLI, api.BackendGeminiCLI}
-	if len(cfg.Model.Fallbacks) != len(want) {
-		t.Fatalf("fallbacks = %v, want %d", cfg.Model.Fallbacks, len(want))
-	}
-	for i, backend := range want {
-		if cfg.Model.Fallbacks[i].Backend != backend {
-			t.Fatalf("fallback[%d] backend = %q, want %q", i, cfg.Model.Fallbacks[i].Backend, backend)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.saved == "" {
+				isolateSavedAI(t)
+			} else {
+				seedSavedAI(t, tt.saved)
+			}
+			cfg, err := (AIProviderOptions{ModelFlags: tt.flags, Sandbox: true}).ToConfig()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidates := cfg.Model.Candidates()
+			if !cfg.Sandbox || len(candidates) != len(tt.backends) {
+				t.Fatalf("sandbox/candidates = %v/%v, want true/%v", cfg.Sandbox, candidates, tt.backends)
+			}
+			for i, backend := range tt.backends {
+				if candidates[i].Backend != backend || candidates[i].Mode != registry.ModeCLI {
+					t.Fatalf("candidate[%d] runtime = %s/%s, want %s/%s", i, candidates[i].Backend, candidates[i].Mode, backend, registry.ModeCLI)
+				}
+			}
+			if tt.wantName != "" && cfg.Model.Name != tt.wantName {
+				t.Fatalf("model name = %q, want %q", cfg.Model.Name, tt.wantName)
+			}
+		})
 	}
 }
 

--- a/pkg/cli/ai_test.go
+++ b/pkg/cli/ai_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"github.com/flanksource/captain/pkg/aiflags"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/aiflags"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/api/registry"
 	"github.com/flanksource/captain/pkg/captainconfig"
 	"github.com/flanksource/commons-db/shell"
 )
@@ -259,6 +260,23 @@ func TestAIProviderOptions_ToConfig_ValidationErrors(t *testing.T) {
 	}
 	if _, err := (AIProviderOptions{ModelFlags: aiflags.ModelFlags{Model: "claude-x"}, Budget: "free"}).ToConfig(); err == nil || !strings.Contains(err.Error(), "budget") {
 		t.Fatalf("expected invalid budget error, got %v", err)
+	}
+}
+
+func TestAIProviderOptions_ToConfig_SandboxForcesCLI(t *testing.T) {
+	isolateSavedAI(t)
+	cfg, err := (AIProviderOptions{
+		ModelFlags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"},
+		Sandbox:    true,
+	}).ToConfig()
+	if err != nil {
+		t.Fatalf("ToConfig: %v", err)
+	}
+	if !cfg.Sandbox {
+		t.Fatal("Sandbox = false, want true")
+	}
+	if cfg.Model.Backend != api.BackendClaudeCLI || cfg.Model.Mode != registry.ModeCLI {
+		t.Fatalf("model runtime = %s/%s, want %s/%s", cfg.Model.Backend, cfg.Model.Mode, api.BackendClaudeCLI, registry.ModeCLI)
 	}
 }
 

--- a/pkg/cli/prompt_source.go
+++ b/pkg/cli/prompt_source.go
@@ -122,6 +122,7 @@ func actionFlagsToOptions(f map[string]string) (AIPromptOptions, error) {
 	o.APIURL = f["api-url"]
 	o.NoCache = flagBool(f["no-cache"])
 	o.Budget = f["budget"]
+	o.Sandbox = flagBool(f["sandbox"])
 	mt, err := flagInt("max-tokens", f["max-tokens"])
 	if err != nil {
 		return o, err

--- a/pkg/cli/prompt_source_test.go
+++ b/pkg/cli/prompt_source_test.go
@@ -20,12 +20,13 @@ func TestActionFlagsToOptions_DecodesSlicesBoolsInts(t *testing.T) {
 		"multi-models":    "cli:sonnet-5,cmux:opus",
 		"prompt":          "hi",
 		"permission-mode": "plan",
+		"sandbox":         "true",
 	}
 	o, err := actionFlagsToOptions(f)
 	if err != nil {
 		t.Fatalf("actionFlagsToOptions: %v", err)
 	}
-	if o.Model != "gpt-4o" || o.Backend != "openai" || o.Prompt != "hi" || o.PermissionMode != "plan" {
+	if o.Model != "gpt-4o" || o.Backend != "openai" || o.Prompt != "hi" || o.PermissionMode != "plan" || !o.Sandbox {
 		t.Fatalf("scalars = %+v", o)
 	}
 	if !o.NoStream || !o.Edit {

--- a/pkg/cli/provider_defaults.go
+++ b/pkg/cli/provider_defaults.go
@@ -97,7 +97,7 @@ func applyCandidateDefaults(model api.Model, saved captainconfig.AIDefaults, all
 	if err != nil {
 		return api.Model{}, err
 	}
-	if model.Backend == "" {
+	if model.Backend == "" && model.Mode == "" {
 		model.Backend = api.Backend(defaults.Agent)
 	}
 	if strings.TrimSpace(model.Name) == "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional sandboxing for local Claude, Codex, and Gemini CLI processes, with restricted network, filesystem, environment, and state access.
  - Added the `--sandbox` option and automatic CLI-mode enforcement.
  - Added runtime mode selection and validation across primary and fallback models.

- **Bug Fixes**
  - Preserved explicitly selected runtime modes during model expansion and fallback resolution.
  - Improved validation and error reporting for incompatible modes and backends.

- **Chores**
  - Updated installation to use Go’s standard install workflow with embedded version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->