### PR TITLE
Add sandbox adapter framework for CLI confinement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,12 @@ jobs:
           key: embedded-postgres-${{ runner.os }}-${{ runner.arch }}
       # dbtest shares one embedded PostgreSQL server while isolating each test
       # with a leased ephemeral database.
+      # pkg/cli/webapp is ignored: its vitest suite needs a sibling clicky-ui
+      # checkout (a link: dependency), which does not exist on CI runners.
       - name: Test with Gavel
         uses: flanksource/gavel@25b5e48fb166ba33a47544606aaa3e16644fa4bb # v0.0.53
         with:
-          args: test --ignore tests/e2e
+          args: test --ignore tests/e2e --ignore pkg/cli/webapp
           version: v0.0.53
           artifact-name: gavel-test-results
           comment-header: captain-gavel-test

--- a/pkg/ai/agent/commit/commit.go
+++ b/pkg/ai/agent/commit/commit.go
@@ -152,7 +152,7 @@ func (h *Hook) commit(hc *agent.HookContext, phase agent.Phase) error {
 	if err != nil || len(paths) == 0 {
 		return err
 	}
-	if err := checkGates(dir, h.EffectiveGates(), h.MaxFileSize, paths); err != nil {
+	if err := CheckGates(dir, h.EffectiveGates(), h.MaxFileSize, paths); err != nil {
 		return err
 	}
 

--- a/pkg/ai/agent/commit/gates.go
+++ b/pkg/ai/agent/commit/gates.go
@@ -31,10 +31,10 @@ var secretBaseNames = map[string]bool{
 // secretSuffixes are extensions whose contents are keys by definition.
 var secretSuffixes = []string{".pem", ".key", ".p12", ".pfx", ".keystore"}
 
-// checkGates applies the policy's pre-commit checks to the paths about to be
+// CheckGates applies the policy's pre-commit checks to the paths about to be
 // staged. It rejects rather than filters: dropping a file would produce a commit
 // that silently disagrees with the run's diff.
-func checkGates(dir string, level api.CommitGates, maxSize int64, paths []string) error {
+func CheckGates(dir string, level api.CommitGates, maxSize int64, paths []string) error {
 	if level != api.CommitGatesCheap {
 		return nil
 	}
@@ -43,7 +43,7 @@ func checkGates(dir string, level api.CommitGates, maxSize int64, paths []string
 	}
 	var secrets, oversized []string
 	for _, p := range paths {
-		if looksSecret(p) {
+		if LooksSecret(p) {
 			secrets = append(secrets, p)
 			continue
 		}
@@ -65,9 +65,9 @@ func checkGates(dir string, level api.CommitGates, maxSize int64, paths []string
 	return nil
 }
 
-// looksSecret reports whether a repo-relative path names a credential file, by
+// LooksSecret reports whether a repo-relative path names a credential file, by
 // base name (including the .env.production family) or by extension.
-func looksSecret(path string) bool {
+func LooksSecret(path string) bool {
 	base := strings.ToLower(filepath.Base(path))
 	if secretBaseNames[base] {
 		return true

--- a/pkg/ai/agent/runner.go
+++ b/pkg/ai/agent/runner.go
@@ -408,6 +408,12 @@ func (r *Runner[T]) runLoop(ctx context.Context, hc *HookContext, result *Result
 // trivially true when no Verify hooks ran at all. Runner.Run uses it to set
 // HookContext.Verified for Post hooks; mirrors pkg/cli's own verifyPassed,
 // which summarizes the same Result.Verdicts for CLI output.
+//
+// Reading only the last verdict is sound because verify() stops a round at
+// its first failure: within any round a failure is that round's final
+// verdict, so the last entry of the accumulated list is always the final
+// round's outcome. Earlier invalid entries are the history of rounds whose
+// feedback drove a retry, not the run's result.
 func verifyPassed(verdicts []VerifyResult) bool {
 	if len(verdicts) == 0 {
 		return true
@@ -415,10 +421,13 @@ func verifyPassed(verdicts []VerifyResult) bool {
 	return verdicts[len(verdicts)-1].Valid
 }
 
-// verify runs every Verify hook; allValid is true only if all passed. retry is
-// the first failing hook's proposed next request.
+// verify runs the Verify hooks in declaration order and stops at the first
+// failure (issue #40 R5.1). Stopping is not just economy — a cheap failing
+// gate short-circuits the expensive judges behind it — it is what keeps
+// verifyPassed's last-verdict read correct: continuing past a failure lets a
+// later passing hook become the round's final verdict and mask the failure.
+// retry is the failing hook's proposed next request.
 func (r *Runner[T]) verify(hc *HookContext) (verdicts []VerifyResult, retry *ai.Request, allValid bool, err error) {
-	allValid = true
 	for _, h := range r.Hooks {
 		v, ok := h.(Verify)
 		if !ok {
@@ -430,13 +439,10 @@ func (r *Runner[T]) verify(hc *HookContext) (verdicts []VerifyResult, retry *ai.
 		}
 		verdicts = append(verdicts, res)
 		if !res.Valid {
-			allValid = false
-			if retry == nil && res.Retry != nil {
-				retry = res.Retry
-			}
+			return verdicts, res.Retry, false, nil
 		}
 	}
-	return verdicts, retry, allValid, nil
+	return verdicts, nil, true, nil
 }
 
 // updateResponse folds one completed iteration into the accumulating response:

--- a/pkg/ai/agent/verify/cmd_hardening_test.go
+++ b/pkg/ai/agent/verify/cmd_hardening_test.go
@@ -1,0 +1,63 @@
+package verify
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdVerifier_TimeoutKillsProcessGroup(t *testing.T) {
+	// `sleep 30 & wait` puts a child in the group holding our output pipe. If
+	// only the shell's pid were signalled, the orphaned sleep would keep the
+	// pipe open and this test would stall on WaitDelay; the group kill brings
+	// the verdict back immediately.
+	v := &CmdVerifier{Cmd: "sh", Args: []string{"-c", "sleep 30 & wait"}, Timeout: 200 * time.Millisecond}
+
+	start := time.Now()
+	verdict, err := v.Verify(context.Background(), t.TempDir(), nil)
+
+	require.NoError(t, err)
+	assert.False(t, verdict.OK)
+	assert.Contains(t, verdict.Reason, "timed out after")
+	assert.Less(t, time.Since(start), 3*time.Second, "group kill must not wait for the orphaned child")
+}
+
+func TestCmdVerifier_ParentCancellationIsAnErrorNotAVerdict(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	v := &CmdVerifier{Cmd: "sleep", Args: []string{"5"}}
+	_, err := v.Verify(ctx, t.TempDir(), nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCmdVerifier_OutputIsTailBoundedWithMarker(t *testing.T) {
+	v := &CmdVerifier{
+		Cmd:          "sh",
+		Args:         []string{"-c", "i=0; while [ $i -lt 2000 ]; do echo line-$i; i=$((i+1)); done; exit 1"},
+		FeedbackTail: 512,
+	}
+
+	verdict, err := v.Verify(context.Background(), t.TempDir(), nil)
+
+	require.NoError(t, err)
+	assert.False(t, verdict.OK)
+	assert.LessOrEqual(t, len(verdict.Feedback), 512+len("[output truncated]\n"))
+	assert.True(t, strings.HasPrefix(verdict.Feedback, "[output truncated]"), "truncation must be marked")
+	assert.Contains(t, verdict.Feedback, "line-1999", "the tail, not the head, must be kept")
+}
+
+func TestCmdVerifier_StartFailureFeedsBackTheError(t *testing.T) {
+	v := &CmdVerifier{Cmd: "captain-no-such-binary"}
+
+	verdict, err := v.Verify(context.Background(), t.TempDir(), nil)
+
+	require.NoError(t, err)
+	assert.False(t, verdict.OK)
+	assert.Contains(t, verdict.Feedback, "captain-no-such-binary")
+}

--- a/pkg/ai/agent/verify/cmd_hardening_test.go
+++ b/pkg/ai/agent/verify/cmd_hardening_test.go
@@ -61,3 +61,16 @@ func TestCmdVerifier_StartFailureFeedsBackTheError(t *testing.T) {
 	assert.False(t, verdict.OK)
 	assert.Contains(t, verdict.Feedback, "captain-no-such-binary")
 }
+
+// A parent deadline shorter than the verifier's own Timeout is the RUN's
+// cancellation, not the command's: it must come back as an error, never as a
+// verdict blaming the command for "timing out after <Timeout>".
+func TestCmdVerifier_ParentDeadlineIsNotTheCommandsTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	v := &CmdVerifier{Cmd: "sleep", Args: []string{"30"}, Timeout: time.Hour}
+	_, err := v.Verify(ctx, t.TempDir(), nil)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/pkg/ai/agent/verify/prompt_hooks_test.go
+++ b/pkg/ai/agent/verify/prompt_hooks_test.go
@@ -1,0 +1,100 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/api"
+)
+
+// judgeStubProvider records the request it judged; no live model call.
+type judgeStubProvider struct{ requests []ai.Request }
+
+func (p *judgeStubProvider) Execute(_ context.Context, req ai.Request) (*ai.Response, error) {
+	p.requests = append(p.requests, req)
+	return &ai.Response{Text: `{"ok":false,"reason":"stub","feedback":"try again"}`}, nil
+}
+func (p *judgeStubProvider) GetModel() string        { return "stub" }
+func (p *judgeStubProvider) GetBackend() api.Backend { return api.BackendAnthropic }
+
+func writeJudgePrompt(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "review-diff.prompt")
+	body := "{{role \"user\"}}\nJudge the work in {{cwd}}."
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestPromptHooksForWorkflow(t *testing.T) {
+	provider := &judgeStubProvider{}
+
+	t.Run("nothing declared yields no hooks", func(t *testing.T) {
+		if hooks, err := PromptHooksForWorkflow(nil, provider); err != nil || hooks != nil {
+			t.Fatalf("hooks = %v, err = %v", hooks, err)
+		}
+		if hooks, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{}}, provider); err != nil || hooks != nil {
+			t.Fatalf("hooks = %v, err = %v", hooks, err)
+		}
+	})
+
+	t.Run("builds a named LLM judge per prompt", func(t *testing.T) {
+		path := writeJudgePrompt(t)
+		wf := &api.Workflow{Verify: &api.Verify{Prompts: []string{path, "  "}}}
+
+		hooks, err := PromptHooksForWorkflow(wf, provider)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(hooks) != 1 {
+			t.Fatalf("want 1 hook (blank skipped), got %d", len(hooks))
+		}
+		plugin, ok := hooks[0].(*Plugin)
+		if !ok || plugin.Name() != "judge:"+path {
+			t.Fatalf("unexpected hook %#v", hooks[0])
+		}
+		if _, ok := plugin.v.(*LLMJudgeVerifier); !ok {
+			t.Fatalf("verifier = %T, want *LLMJudgeVerifier", plugin.v)
+		}
+	})
+
+	t.Run("the judge consults the provider, not a live model", func(t *testing.T) {
+		path := writeJudgePrompt(t)
+		hooks, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}, provider)
+		if err != nil {
+			t.Fatal(err)
+		}
+		judge := hooks[0].(*Plugin).v
+
+		before := len(provider.requests)
+		if _, err := judge.Verify(context.Background(), "/work", nil); err != nil {
+			t.Fatal(err)
+		}
+		if len(provider.requests) != before+1 {
+			t.Fatalf("provider judged %d times, want 1", len(provider.requests)-before)
+		}
+		if user := provider.requests[len(provider.requests)-1].Prompt.User; !strings.Contains(user, "/work") {
+			t.Fatalf("judge prompt %q must render the run's cwd", user)
+		}
+	})
+
+	t.Run("a missing prompt file is an error, not a skipped check", func(t *testing.T) {
+		_, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{"/does/not/exist.prompt"}}}, provider)
+		if err == nil || !strings.Contains(err.Error(), "/does/not/exist.prompt") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("declared prompts with no provider fail loud", func(t *testing.T) {
+		path := writeJudgePrompt(t)
+		_, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}, nil)
+		if err == nil || !strings.Contains(err.Error(), "no provider") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}

--- a/pkg/ai/agent/verify/prompt_hooks_test.go
+++ b/pkg/ai/agent/verify/prompt_hooks_test.go
@@ -90,6 +90,42 @@ func TestPromptHooksForWorkflow(t *testing.T) {
 		}
 	})
 
+	t.Run("a judge declaring a sandbox is rejected, not silently ignored", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "judge.prompt")
+		body := "---\nsandbox: git-agent\n---\n{{role \"user\"}}\nJudge {{cwd}}."
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}, provider)
+		if err == nil || !strings.Contains(err.Error(), "declares a sandbox") {
+			t.Fatalf("err = %v, want sandbox declaration rejected (R5.4)", err)
+		}
+	})
+
+	t.Run("a judge declaring a different model is rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "judge.prompt")
+		body := "---\nmodel: gpt-5.5\n---\n{{role \"user\"}}\nJudge {{cwd}}."
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}, provider)
+		if err == nil || !strings.Contains(err.Error(), `declares model "gpt-5.5"`) {
+			t.Fatalf("err = %v, want model mismatch rejected", err)
+		}
+	})
+
+	t.Run("a judge matching the provider's model is accepted", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "judge.prompt")
+		body := "---\nmodel: stub\n---\n{{role \"user\"}}\nJudge {{cwd}}."
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		hooks, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}, provider)
+		if err != nil || len(hooks) != 1 {
+			t.Fatalf("hooks = %v, err = %v", hooks, err)
+		}
+	})
+
 	t.Run("declared prompts with no provider fail loud", func(t *testing.T) {
 		path := writeJudgePrompt(t)
 		_, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}, nil)

--- a/pkg/ai/agent/verify/prompt_hooks_test.go
+++ b/pkg/ai/agent/verify/prompt_hooks_test.go
@@ -43,16 +43,24 @@ func TestPromptHooksForWorkflow(t *testing.T) {
 		}
 	})
 
+	t.Run("a blank prompt entry fails instead of dropping the check", func(t *testing.T) {
+		path := writeJudgePrompt(t)
+		_, err := PromptHooksForWorkflow(&api.Workflow{Verify: &api.Verify{Prompts: []string{path, "  "}}}, provider)
+		if err == nil || !strings.Contains(err.Error(), "prompts[1] is empty") {
+			t.Fatalf("err = %v, want blank entry rejected", err)
+		}
+	})
+
 	t.Run("builds a named LLM judge per prompt", func(t *testing.T) {
 		path := writeJudgePrompt(t)
-		wf := &api.Workflow{Verify: &api.Verify{Prompts: []string{path, "  "}}}
+		wf := &api.Workflow{Verify: &api.Verify{Prompts: []string{path}}}
 
 		hooks, err := PromptHooksForWorkflow(wf, provider)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if len(hooks) != 1 {
-			t.Fatalf("want 1 hook (blank skipped), got %d", len(hooks))
+			t.Fatalf("want 1 hook, got %d", len(hooks))
 		}
 		plugin, ok := hooks[0].(*Plugin)
 		if !ok || plugin.Name() != "judge:"+path {

--- a/pkg/ai/agent/verify/verify.go
+++ b/pkg/ai/agent/verify/verify.go
@@ -108,7 +108,10 @@ func (c *CmdVerifier) Verify(ctx context.Context, cwd string, changed []string) 
 	if timeout <= 0 {
 		timeout = DefaultCmdTimeout
 	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	// The verifier's own timeout lives on a derived context; the parent is
+	// consulted separately below, so a parent deadline shorter than Timeout is
+	// reported as the run's cancellation, not misattributed to the command.
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	tail := c.FeedbackTail
@@ -117,7 +120,7 @@ func (c *CmdVerifier) Verify(ctx context.Context, cwd string, changed []string) 
 	}
 	output := &tailBuffer{max: tail}
 
-	cmd := exec.CommandContext(ctx, c.Cmd, args...)
+	cmd := exec.CommandContext(runCtx, c.Cmd, args...)
 	cmd.Dir = cwd
 	cmd.Stdout, cmd.Stderr = output, output
 	// Own process group, and cancellation kills the group: signalling only the
@@ -132,15 +135,16 @@ func (c *CmdVerifier) Verify(ctx context.Context, cwd string, changed []string) 
 	switch {
 	case err == nil:
 		return Verdict{OK: true}, nil
-	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+	case ctx.Err() != nil:
+		// The parent context ended (cancellation or its own, earlier deadline):
+		// the run is being torn down, which is not a verdict on the work.
+		return Verdict{}, ctx.Err()
+	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
 		return Verdict{
 			OK:       false,
 			Reason:   fmt.Sprintf("%s timed out after %s", c.Cmd, timeout),
 			Feedback: output.String(),
 		}, nil
-	case ctx.Err() != nil:
-		// The run itself is being torn down; that is not a verdict on the work.
-		return Verdict{}, ctx.Err()
 	}
 	feedback := output.String()
 	if feedback == "" {

--- a/pkg/ai/agent/verify/verify.go
+++ b/pkg/ai/agent/verify/verify.go
@@ -6,11 +6,16 @@ package verify
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os/exec"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/ai/agent"
-	"github.com/flanksource/clicky/exec"
 )
 
 // Verdict is a Verifier's judgement. Feedback is fed back into the next
@@ -73,34 +78,105 @@ func (f FuncVerifier) Verify(ctx context.Context, cwd string, changed []string) 
 	return f(ctx, cwd, changed)
 }
 
+// DefaultCmdTimeout bounds a verify command that declares no timeout of its
+// own. A hook with no bound is a denial-of-service against whatever is waiting
+// on the verdict — locally a stuck loop, remotely a blocked push.
+const DefaultCmdTimeout = 10 * time.Minute
+
 // CmdVerifier runs an external command (lint, test, build, …) in the run's cwd.
 // A zero exit code is a pass; a non-zero exit is a failure whose feedback is the
 // tail of the combined output. When PerFile is set the changed files are
 // appended to the command's arguments.
+//
+// The command is bounded three ways: the caller's context and Timeout cap its
+// wall clock, it runs in its own process group so a kill reaches its children,
+// and its output is tail-bounded as it streams rather than buffered in full.
 type CmdVerifier struct {
 	Cmd          string
 	Args         []string
 	PerFile      bool
-	FeedbackTail int // max bytes of output fed back; 0 ⇒ 4096
+	FeedbackTail int           // max bytes of output fed back; 0 ⇒ 4096
+	Timeout      time.Duration // wall-clock bound; 0 ⇒ DefaultCmdTimeout
 }
 
-func (c *CmdVerifier) Verify(_ context.Context, cwd string, changed []string) (Verdict, error) {
+func (c *CmdVerifier) Verify(ctx context.Context, cwd string, changed []string) (Verdict, error) {
 	args := append([]string(nil), c.Args...)
 	if c.PerFile {
 		args = append(args, changed...)
 	}
-	res := exec.NewExec(c.Cmd, args...).WithCwd(cwd).Run().Result()
-	if res.Error == nil && res.ExitCode == 0 {
-		return Verdict{OK: true}, nil
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = DefaultCmdTimeout
 	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	tail := c.FeedbackTail
 	if tail <= 0 {
 		tail = 4096
 	}
-	out := strings.TrimSpace(res.Stdout + "\n" + res.Stderr)
-	if len(out) > tail {
-		out = out[len(out)-tail:]
+	output := &tailBuffer{max: tail}
+
+	cmd := exec.CommandContext(ctx, c.Cmd, args...)
+	cmd.Dir = cwd
+	cmd.Stdout, cmd.Stderr = output, output
+	// Own process group, and cancellation kills the group: signalling only the
+	// pid leaves a hook's children running after their parent is dead.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
+	// A grandchild that survives the kill holding our output pipe must not hold
+	// Wait open indefinitely.
+	cmd.WaitDelay = 10 * time.Second
+
+	err := cmd.Run()
+	switch {
+	case err == nil:
+		return Verdict{OK: true}, nil
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return Verdict{
+			OK:       false,
+			Reason:   fmt.Sprintf("%s timed out after %s", c.Cmd, timeout),
+			Feedback: output.String(),
+		}, nil
+	case ctx.Err() != nil:
+		// The run itself is being torn down; that is not a verdict on the work.
+		return Verdict{}, ctx.Err()
 	}
-	return Verdict{OK: false, Reason: c.Cmd + " failed", Feedback: out}, nil
+	feedback := output.String()
+	if feedback == "" {
+		feedback = err.Error()
+	}
+	return Verdict{OK: false, Reason: c.Cmd + " failed", Feedback: feedback}, nil
+}
+
+// tailBuffer keeps the last max bytes written through it, so a chatty command
+// is bounded while it streams instead of being buffered whole and truncated
+// afterwards.
+type tailBuffer struct {
+	mu        sync.Mutex
+	max       int
+	buf       []byte
+	truncated bool
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.max {
+		copy(b.buf, b.buf[len(b.buf)-b.max:])
+		b.buf = b.buf[:b.max]
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := strings.TrimSpace(string(b.buf))
+	if b.truncated && out != "" {
+		return "[output truncated]\n" + out
+	}
+	return out
 }

--- a/pkg/ai/agent/verify/workflow.go
+++ b/pkg/ai/agent/verify/workflow.go
@@ -47,10 +47,13 @@ func PromptHooksForWorkflow(wf *api.Workflow, provider ai.Provider) ([]any, erro
 		return nil, fmt.Errorf("verify prompts declared but no provider available to judge them")
 	}
 	var hooks []any
-	for _, path := range wf.Verify.Prompts {
+	for i, path := range wf.Verify.Prompts {
 		path = strings.TrimSpace(path)
 		if path == "" {
-			continue
+			// Same rule as api.Workflow.Validate: a blank entry is a broken
+			// declaration, and skipping it would silently drop a configured check
+			// for callers that never ran Validate.
+			return nil, fmt.Errorf("workflow.verify.prompts[%d] is empty", i)
 		}
 		tmpl, err := prompt.LoadFile(path)
 		if err != nil {

--- a/pkg/ai/agent/verify/workflow.go
+++ b/pkg/ai/agent/verify/workflow.go
@@ -56,9 +56,33 @@ func PromptHooksForWorkflow(wf *api.Workflow, provider ai.Provider) ([]any, erro
 		if err != nil {
 			return nil, fmt.Errorf("verify prompt %q: %w", path, err)
 		}
+		if err := rejectJudgeOverrides(path, tmpl, provider); err != nil {
+			return nil, err
+		}
 		hooks = append(hooks, New("judge:"+path, &LLMJudgeVerifier{Provider: provider, Prompt: tmpl}))
 	}
 	return hooks, nil
+}
+
+// rejectJudgeOverrides refuses judge frontmatter the hook cannot honour. A
+// judge executes on the run's provider, so a declared sandbox — relocating or
+// not — and a model different from the provider's would both be silently
+// ignored, which is exactly the downgrade issue #39 forbids (R5.4: a hook
+// prompt declaring a relocating sandbox is a validation error, never a silent
+// fallback).
+func rejectJudgeOverrides(path string, tmpl *prompt.Template, provider ai.Provider) error {
+	probe, _, err := tmpl.Render(map[string]any{"cwd": "", "changed": []string{}}, nil)
+	if err != nil {
+		return fmt.Errorf("verify prompt %q: %w", path, err)
+	}
+	if probe.Sandbox != nil {
+		return fmt.Errorf("verify prompt %q declares a sandbox; judge hooks run on the run's provider and cannot relocate", path)
+	}
+	if declared := strings.TrimSpace(probe.Model.Name); declared != "" && declared != provider.GetModel() {
+		return fmt.Errorf("verify prompt %q declares model %q but judge hooks run on the run's provider (%s); remove the model or match it",
+			path, declared, provider.GetModel())
+	}
+	return nil
 }
 
 // MaxIterationsForWorkflow is the loop cap: the declared maxIterations, else 1

--- a/pkg/ai/agent/verify/workflow.go
+++ b/pkg/ai/agent/verify/workflow.go
@@ -1,9 +1,12 @@
 package verify
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/ai/agent"
+	"github.com/flanksource/captain/pkg/ai/prompt"
 	"github.com/flanksource/captain/pkg/api"
 )
 
@@ -26,6 +29,36 @@ func HooksForWorkflow(wf *api.Workflow) []any {
 		hooks = append(hooks, New("verify:"+cmd, &CmdVerifier{Cmd: "sh", Args: []string{"-c", cmd}}))
 	}
 	return hooks
+}
+
+// PromptHooksForWorkflow builds the LLM-judge hooks from Verify.Prompts: each
+// entry is a .prompt template whose output schema is {ok, reason, feedback},
+// judged by the given provider. It is separate from HooksForWorkflow because
+// judge hooks need a provider and command hooks do not — keeping the original
+// signature stable for gavel, which shares it.
+//
+// A prompt that fails to load is an error, not a skipped hook: a declared
+// check that silently never runs is a false accept.
+func PromptHooksForWorkflow(wf *api.Workflow, provider ai.Provider) ([]any, error) {
+	if wf == nil || wf.Verify == nil || len(wf.Verify.Prompts) == 0 {
+		return nil, nil
+	}
+	if provider == nil {
+		return nil, fmt.Errorf("verify prompts declared but no provider available to judge them")
+	}
+	var hooks []any
+	for _, path := range wf.Verify.Prompts {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		tmpl, err := prompt.LoadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("verify prompt %q: %w", path, err)
+		}
+		hooks = append(hooks, New("judge:"+path, &LLMJudgeVerifier{Provider: provider, Prompt: tmpl}))
+	}
+	return hooks, nil
 }
 
 // MaxIterationsForWorkflow is the loop cap: the declared maxIterations, else 1

--- a/pkg/ai/agent/verify_order_test.go
+++ b/pkg/ai/agent/verify_order_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/flanksource/captain/pkg/ai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A round must stop at its first failing verifier (issue #40 R5.1). Before
+// this rule, a later passing judge became the round's final verdict and
+// masked the failure — [fail, pass] reported the run as verified.
+func TestVerify_StopsAtFirstFailure(t *testing.T) {
+	judgeCalls := 0
+	r := &Runner[string]{Hooks: []any{
+		verifyHook{name: "cmd", fn: func(*HookContext) (VerifyResult, error) {
+			return VerifyResult{Valid: false, Retry: &ai.Request{}}, nil
+		}},
+		verifyHook{name: "judge", fn: func(*HookContext) (VerifyResult, error) {
+			judgeCalls++
+			return VerifyResult{Valid: true}, nil
+		}},
+	}}
+
+	verdicts, retry, allValid, err := r.verify(&HookContext{})
+
+	require.NoError(t, err)
+	assert.False(t, allValid, "a failing verifier must fail the round regardless of hooks behind it")
+	assert.Equal(t, 0, judgeCalls, "hooks after the failure must not run (R5.1)")
+	require.Len(t, verdicts, 1)
+	assert.False(t, verdicts[len(verdicts)-1].Valid, "the round's last verdict must be the failure")
+	assert.NotNil(t, retry, "the failing hook's retry must be proposed")
+	assert.False(t, verifyPassed(verdicts))
+}
+
+func TestVerify_AllPassingRunsEveryHook(t *testing.T) {
+	calls := 0
+	hook := verifyHook{name: "ok", fn: func(*HookContext) (VerifyResult, error) {
+		calls++
+		return VerifyResult{Valid: true}, nil
+	}}
+	r := &Runner[string]{Hooks: []any{hook, hook, hook}}
+
+	verdicts, retry, allValid, err := r.verify(&HookContext{})
+
+	require.NoError(t, err)
+	assert.True(t, allValid)
+	assert.Nil(t, retry)
+	assert.Equal(t, 3, calls)
+	assert.Len(t, verdicts, 3)
+	assert.True(t, verifyPassed(verdicts))
+}

--- a/pkg/ai/provider/claude_cli.go
+++ b/pkg/ai/provider/claude_cli.go
@@ -59,11 +59,7 @@ func (c *ClaudeCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan a
 	if err != nil {
 		return nil, err
 	}
-	env := []string(nil)
-	if req.Setup != nil {
-		env = commandEnv(req.Setup.Env)
-	}
-	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, claudeCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env, c.sandbox)
+	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, claudeCLICommand, args, []byte(composePrompt(req)), &req, c.sandbox)
 	if err != nil {
 		cleanup()
 		return nil, err

--- a/pkg/ai/provider/claude_cli.go
+++ b/pkg/ai/provider/claude_cli.go
@@ -16,7 +16,7 @@ var claudeCLICommand = "claude"
 
 type ClaudeCLI struct {
 	model   string
-	sandbox bool
+	sandbox *api.SandboxConfig
 }
 
 func NewClaudeCLI(model string) *ClaudeCLI {

--- a/pkg/ai/provider/cli.go
+++ b/pkg/ai/provider/cli.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/api"
 	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
 )
 
@@ -135,7 +136,11 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 
 func newCLICommand(ctx context.Context, command string, args []string, cwd string, sandboxed bool) (*exec.Cmd, func(), error) {
 	if !sandboxed {
-		return exec.CommandContext(ctx, command, args...), func() {}, nil
+		// The legacy boolean still routes srt below; everything else goes through
+		// the adapter registry. Today that resolves the "none" adapter; a kind
+		// whose adapter provides a CommandWrapper gets its argv rewritten here —
+		// the single exec seam shared by claude-cli, codex-cli and gemini-cli.
+		return newSandboxedCommand(ctx, api.SandboxConfig{Kind: api.SandboxNone}, command, args)
 	}
 	cfg, err := cliSandboxConfig(command, cwd)
 	if err != nil {
@@ -156,6 +161,27 @@ func newCLICommand(ctx context.Context, command string, args []string, cwd strin
 		return nil, nil, fmt.Errorf("wrap %s with sandbox-runtime: %w", command, err)
 	}
 	return cmd, closeSandbox, nil
+}
+
+// newSandboxedCommand constructs the selected sandbox adapter and builds the
+// command through its CommandWrapper when it provides one. An adapter without
+// the capability falls through to a bare command, which is exactly what the
+// "none" adapter is.
+func newSandboxedCommand(ctx context.Context, cfg api.SandboxConfig, command string, args []string) (*exec.Cmd, func(), error) {
+	sandbox, err := api.NewSandbox(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	closeSandbox := func() { _ = sandbox.Close() }
+	if wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox); ok {
+		wrappedCommand, wrappedArgs, wrappedEnv := wrapper.Wrap(command, args, nil)
+		cmd := exec.CommandContext(ctx, wrappedCommand, wrappedArgs...)
+		if len(wrappedEnv) > 0 {
+			cmd.Env = wrappedEnv
+		}
+		return cmd, closeSandbox, nil
+	}
+	return exec.CommandContext(ctx, command, args...), closeSandbox, nil
 }
 
 func cliSandboxConfig(command, cwd string) (sandboxruntime.Config, error) {

--- a/pkg/ai/provider/cli.go
+++ b/pkg/ai/provider/cli.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/commons-db/shell"
 )
 
 func IsCommandNotFound(err error) bool {
@@ -76,8 +77,15 @@ func HandleExitError(exitCode int, stderr string) error {
 	}
 }
 
-func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, cwd string, env []string, sandbox *api.SandboxConfig) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, func(), error) {
-	cmd, closeSandbox, err := newCLICommand(ctx, command, args, cwd, sandbox)
+// startCLIStream launches the CLI through the selected sandbox. It takes the
+// request itself because the sandbox seam needs three distinct things from
+// it: the working directory, the request-DECLARED variables (Setup.EnvVars —
+// what must cross a confinement boundary), and the fully RESOLVED environment
+// (Setup.Env — what the child process runs with). Collapsing those early is
+// how a container ends up receiving either none of the declared variables or
+// the entire host environment.
+func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, req *ai.Request, sandbox *api.SandboxConfig) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, func(), error) {
+	cmd, closeSandbox, err := newCLICommand(ctx, command, args, req, sandbox)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -87,12 +95,6 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 			closeSandbox()
 		}
 	}()
-	if cwd != "" {
-		cmd.Dir = cwd
-	}
-	if len(env) > 0 {
-		cmd.Env = env
-	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %w", err)
@@ -124,12 +126,12 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 
 // newCLICommand builds the CLI process through the selected sandbox adapter.
 // nil means unsandboxed, which resolves the "none" adapter.
-func newCLICommand(ctx context.Context, command string, args []string, cwd string, sandbox *api.SandboxConfig) (*exec.Cmd, func(), error) {
+func newCLICommand(ctx context.Context, command string, args []string, req *ai.Request, sandbox *api.SandboxConfig) (*exec.Cmd, func(), error) {
 	cfg := api.SandboxConfig{Kind: api.SandboxNone}
 	if sandbox != nil {
 		cfg = *sandbox
 	}
-	return newSandboxedCommand(ctx, cfg, command, args, cwd)
+	return newSandboxedCommand(ctx, cfg, command, args, req)
 }
 
 // newSandboxedCommand constructs the selected sandbox adapter and builds the
@@ -138,33 +140,85 @@ func newCLICommand(ctx context.Context, command string, args []string, cwd strin
 // capability falls through to a bare command, which is exactly what the "none"
 // adapter is; an adapter whose wrapping fails aborts the run rather than
 // falling back to an unconfined process.
-func newSandboxedCommand(ctx context.Context, cfg api.SandboxConfig, command string, args []string, cwd string) (*exec.Cmd, func(), error) {
+//
+// The adapter sees the real request via Prepare and only the request-DECLARED
+// variables via Wrap. The command's environment layers, in order: the
+// wrapper's returned env (authoritative when non-empty — a container must
+// supply the docker client's environment wholesale), else the resolved setup
+// environment; then the Prepare session's Env on top, and the session's
+// WorkDir over the request cwd.
+func newSandboxedCommand(ctx context.Context, cfg api.SandboxConfig, command string, args []string, req *ai.Request) (*exec.Cmd, func(), error) {
 	sandbox, err := api.NewSandbox(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 	closeSandbox := func() { _ = sandbox.Close() }
-	spec := &api.Spec{}
-	if cwd != "" {
-		spec.SetCwd(cwd)
-	}
-	if _, err := sandbox.Prepare(ctx, spec); err != nil {
+	session, err := sandbox.Prepare(ctx, req)
+	if err != nil {
 		closeSandbox()
 		return nil, nil, err
 	}
+
+	var resolvedEnv []string
+	if req.Setup != nil {
+		resolvedEnv = req.Setup.Env
+	}
+	cmd := exec.CommandContext(ctx, command, args...)
 	if wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox); ok {
-		wrappedCommand, wrappedArgs, wrappedEnv, err := wrapper.Wrap(ctx, command, args, nil)
+		wrappedCommand, wrappedArgs, wrappedEnv, err := wrapper.Wrap(ctx, command, args, declaredSetupEnv(req.Setup))
 		if err != nil {
 			closeSandbox()
 			return nil, nil, err
 		}
-		cmd := exec.CommandContext(ctx, wrappedCommand, wrappedArgs...)
+		cmd = exec.CommandContext(ctx, wrappedCommand, wrappedArgs...)
 		if len(wrappedEnv) > 0 {
 			cmd.Env = wrappedEnv
 		}
-		return cmd, closeSandbox, nil
 	}
-	return exec.CommandContext(ctx, command, args...), closeSandbox, nil
+	if cmd.Env == nil {
+		if merged := commandEnv(resolvedEnv); len(merged) > 0 {
+			cmd.Env = merged
+		}
+	}
+	if session != nil && len(session.Env) > 0 {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
+		cmd.Env = append(cmd.Env, session.Env...)
+	}
+	cmd.Dir = req.Cwd()
+	if session != nil && session.WorkDir != "" {
+		cmd.Dir = session.WorkDir
+	}
+	return cmd, closeSandbox, nil
+}
+
+// declaredSetupEnv projects the request-declared variables (Setup.EnvVars)
+// onto KEY=VALUE pairs using the values Setup.Resolve produced. Setup.Env
+// itself is the FULL resolved environment — host environ included — so it
+// must never be handed to an adapter as "the declared set": that turns
+// "cross the declared variables into the container" into "cross the entire
+// host environment".
+func declaredSetupEnv(setup *shell.Setup) []string {
+	if setup == nil || len(setup.EnvVars) == 0 {
+		return nil
+	}
+	resolved := map[string]string{}
+	for _, item := range setup.Env {
+		if key, value, ok := strings.Cut(item, "="); ok {
+			resolved[key] = value
+		}
+	}
+	var out []string
+	for _, declared := range setup.EnvVars {
+		if declared.Name == "" {
+			continue
+		}
+		if value, ok := resolved[declared.Name]; ok {
+			out = append(out, declared.Name+"="+value)
+		}
+	}
+	return out
 }
 
 func finishCLIStream(ctx context.Context, cmd *exec.Cmd, stderrBuf *bytes.Buffer) error {

--- a/pkg/ai/provider/cli.go
+++ b/pkg/ai/provider/cli.go
@@ -9,13 +9,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
-	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
 )
 
 func IsCommandNotFound(err error) bool {
@@ -79,15 +76,6 @@ func HandleExitError(exitCode int, stderr string) error {
 	}
 }
 
-type commandSandbox interface {
-	Command(context.Context, string, ...string) (*exec.Cmd, error)
-	Close(context.Context) error
-}
-
-var newCommandSandbox = func(ctx context.Context, cfg sandboxruntime.Config) (commandSandbox, error) {
-	return sandboxruntime.New(ctx, cfg)
-}
-
 func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, cwd string, env []string, sandboxed bool) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, func(), error) {
 	cmd, closeSandbox, err := newCLICommand(ctx, command, args, cwd, sandboxed)
 	if err != nil {
@@ -134,47 +122,43 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 	return cmd, stdout, stderrBuf, closeSandbox, nil
 }
 
+// newCLICommand builds the CLI process through the selected sandbox adapter.
+// The boolean is the legacy srt toggle carried by api.Config.Sandbox; it maps
+// onto the adapter registry rather than a bespoke code path.
 func newCLICommand(ctx context.Context, command string, args []string, cwd string, sandboxed bool) (*exec.Cmd, func(), error) {
-	if !sandboxed {
-		// The legacy boolean still routes srt below; everything else goes through
-		// the adapter registry. Today that resolves the "none" adapter; a kind
-		// whose adapter provides a CommandWrapper gets its argv rewritten here —
-		// the single exec seam shared by claude-cli, codex-cli and gemini-cli.
-		return newSandboxedCommand(ctx, api.SandboxConfig{Kind: api.SandboxNone}, command, args)
+	kind := api.SandboxNone
+	if sandboxed {
+		kind = api.SandboxSRT
 	}
-	cfg, err := cliSandboxConfig(command, cwd)
-	if err != nil {
-		return nil, nil, err
-	}
-	sb, err := newCommandSandbox(ctx, cfg)
-	if err != nil {
-		return nil, nil, fmt.Errorf("initialize sandbox-runtime: %w", err)
-	}
-	closeSandbox := func() {
-		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = sb.Close(closeCtx)
-	}
-	cmd, err := sb.Command(ctx, command, args...)
-	if err != nil {
-		closeSandbox()
-		return nil, nil, fmt.Errorf("wrap %s with sandbox-runtime: %w", command, err)
-	}
-	return cmd, closeSandbox, nil
+	return newSandboxedCommand(ctx, api.SandboxConfig{Kind: kind}, command, args, cwd)
 }
 
 // newSandboxedCommand constructs the selected sandbox adapter and builds the
-// command through its CommandWrapper when it provides one. An adapter without
-// the capability falls through to a bare command, which is exactly what the
-// "none" adapter is.
-func newSandboxedCommand(ctx context.Context, cfg api.SandboxConfig, command string, args []string) (*exec.Cmd, func(), error) {
+// command through its CommandWrapper when it provides one — the single exec
+// seam shared by claude-cli, codex-cli and gemini-cli. An adapter without the
+// capability falls through to a bare command, which is exactly what the "none"
+// adapter is; an adapter whose wrapping fails aborts the run rather than
+// falling back to an unconfined process.
+func newSandboxedCommand(ctx context.Context, cfg api.SandboxConfig, command string, args []string, cwd string) (*exec.Cmd, func(), error) {
 	sandbox, err := api.NewSandbox(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 	closeSandbox := func() { _ = sandbox.Close() }
+	spec := &api.Spec{}
+	if cwd != "" {
+		spec.SetCwd(cwd)
+	}
+	if _, err := sandbox.Prepare(ctx, spec); err != nil {
+		closeSandbox()
+		return nil, nil, err
+	}
 	if wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox); ok {
-		wrappedCommand, wrappedArgs, wrappedEnv := wrapper.Wrap(command, args, nil)
+		wrappedCommand, wrappedArgs, wrappedEnv, err := wrapper.Wrap(ctx, command, args, nil)
+		if err != nil {
+			closeSandbox()
+			return nil, nil, err
+		}
 		cmd := exec.CommandContext(ctx, wrappedCommand, wrappedArgs...)
 		if len(wrappedEnv) > 0 {
 			cmd.Env = wrappedEnv
@@ -182,66 +166,6 @@ func newSandboxedCommand(ctx context.Context, cfg api.SandboxConfig, command str
 		return cmd, closeSandbox, nil
 	}
 	return exec.CommandContext(ctx, command, args...), closeSandbox, nil
-}
-
-func cliSandboxConfig(command, cwd string) (sandboxruntime.Config, error) {
-	if cwd == "" {
-		var err error
-		cwd, err = os.Getwd()
-		if err != nil {
-			return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox working directory: %w", err)
-		}
-	}
-	absoluteCwd, err := filepath.Abs(cwd)
-	if err != nil {
-		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox working directory %q: %w", cwd, err)
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox home directory: %w", err)
-	}
-
-	var domains, passthroughEnv, statePaths []string
-	switch filepath.Base(command) {
-	case "claude":
-		domains = []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}
-		passthroughEnv = []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}
-		statePaths = []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}
-	case "codex":
-		domains = []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}
-		passthroughEnv = []string{"OPENAI_API_KEY"}
-		statePaths = []string{filepath.Join(home, ".codex")}
-	case "gemini":
-		domains = []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}
-		passthroughEnv = []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
-		statePaths = []string{filepath.Join(home, ".gemini")}
-	default:
-		return sandboxruntime.Config{}, fmt.Errorf("sandbox-runtime does not support CLI command %q", command)
-	}
-
-	return sandboxruntime.Config{
-		Network: sandboxruntime.NetworkConfig{
-			AllowedDomains: domains,
-			DeniedDomains:  []string{},
-		},
-		Filesystem: sandboxruntime.FilesystemConfig{
-			AllowWrite: append([]string{absoluteCwd, "/tmp"}, statePaths...),
-			DenyRead: []string{
-				filepath.Join(home, ".ssh"),
-				filepath.Join(home, ".aws"),
-				filepath.Join(home, ".azure"),
-				filepath.Join(home, ".config", "gcloud"),
-				filepath.Join(home, ".kube"),
-				filepath.Join(home, ".docker", "run", "docker.sock"),
-				"/var/run/docker.sock",
-				"/run/docker.sock",
-				"/run/containerd/containerd.sock",
-				"/run/podman/podman.sock",
-			},
-			DenyWrite: []string{},
-		},
-		PassthroughEnv: passthroughEnv,
-	}, nil
 }
 
 func finishCLIStream(ctx context.Context, cmd *exec.Cmd, stderrBuf *bytes.Buffer) error {

--- a/pkg/ai/provider/cli.go
+++ b/pkg/ai/provider/cli.go
@@ -76,8 +76,8 @@ func HandleExitError(exitCode int, stderr string) error {
 	}
 }
 
-func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, cwd string, env []string, sandboxed bool) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, func(), error) {
-	cmd, closeSandbox, err := newCLICommand(ctx, command, args, cwd, sandboxed)
+func startCLIStream(ctx context.Context, command string, args []string, stdinData []byte, cwd string, env []string, sandbox *api.SandboxConfig) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, func(), error) {
+	cmd, closeSandbox, err := newCLICommand(ctx, command, args, cwd, sandbox)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -123,14 +123,13 @@ func startCLIStream(ctx context.Context, command string, args []string, stdinDat
 }
 
 // newCLICommand builds the CLI process through the selected sandbox adapter.
-// The boolean is the legacy srt toggle carried by api.Config.Sandbox; it maps
-// onto the adapter registry rather than a bespoke code path.
-func newCLICommand(ctx context.Context, command string, args []string, cwd string, sandboxed bool) (*exec.Cmd, func(), error) {
-	kind := api.SandboxNone
-	if sandboxed {
-		kind = api.SandboxSRT
+// nil means unsandboxed, which resolves the "none" adapter.
+func newCLICommand(ctx context.Context, command string, args []string, cwd string, sandbox *api.SandboxConfig) (*exec.Cmd, func(), error) {
+	cfg := api.SandboxConfig{Kind: api.SandboxNone}
+	if sandbox != nil {
+		cfg = *sandbox
 	}
-	return newSandboxedCommand(ctx, api.SandboxConfig{Kind: kind}, command, args, cwd)
+	return newSandboxedCommand(ctx, cfg, command, args, cwd)
 }
 
 // newSandboxedCommand constructs the selected sandbox adapter and builds the

--- a/pkg/ai/provider/cli_test.go
+++ b/pkg/ai/provider/cli_test.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/sandbox/adapter"
 	"github.com/flanksource/commons-db/shell"
 	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
 )
@@ -59,12 +59,12 @@ func TestParseStderr(t *testing.T) {
 }
 
 func TestGeminiCLIUsesContextDir(t *testing.T) {
-	original := newCommandSandbox
+	original := adapter.NewSRTRuntime
 	fake := &fakeCommandSandbox{}
-	newCommandSandbox = func(context.Context, sandboxruntime.Config) (commandSandbox, error) {
+	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) {
 		return fake, nil
 	}
-	t.Cleanup(func() { newCommandSandbox = original })
+	t.Cleanup(func() { adapter.NewSRTRuntime = original })
 
 	cwd := filepath.Join(t.TempDir(), "workspace")
 	if err := os.MkdirAll(cwd, 0o755); err != nil {
@@ -111,50 +111,6 @@ func TestGeminiCLIUsesContextDir(t *testing.T) {
 	}
 }
 
-func TestCLISandboxConfig(t *testing.T) {
-	cwd := t.TempDir()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	denyRead := []string{
-		filepath.Join(home, ".ssh"), filepath.Join(home, ".aws"), filepath.Join(home, ".azure"),
-		filepath.Join(home, ".config", "gcloud"), filepath.Join(home, ".kube"),
-		filepath.Join(home, ".docker", "run", "docker.sock"), "/var/run/docker.sock",
-		"/run/docker.sock", "/run/containerd/containerd.sock", "/run/podman/podman.sock",
-	}
-	tests := []struct {
-		command string
-		domains []string
-		env     []string
-		state   []string
-	}{
-		{"claude", []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}, []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}, []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}},
-		{"codex", []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}, []string{"OPENAI_API_KEY"}, []string{filepath.Join(home, ".codex")}},
-		{"gemini", []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}, []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, []string{filepath.Join(home, ".gemini")}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.command, func(t *testing.T) {
-			got, err := cliSandboxConfig(tt.command, cwd)
-			if err != nil {
-				t.Fatal(err)
-			}
-			want := sandboxruntime.Config{
-				Network: sandboxruntime.NetworkConfig{AllowedDomains: tt.domains, DeniedDomains: []string{}},
-				Filesystem: sandboxruntime.FilesystemConfig{
-					AllowWrite: append([]string{cwd, "/tmp"}, tt.state...),
-					DenyRead:   denyRead,
-					DenyWrite:  []string{},
-				},
-				PassthroughEnv: tt.env,
-			}
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("cliSandboxConfig() = %#v, want %#v", got, want)
-			}
-		})
-	}
-}
-
 func TestCLIProviderFactoriesCarrySandbox(t *testing.T) {
 	tests := []struct {
 		backend api.Backend
@@ -179,11 +135,11 @@ func TestCLIProviderFactoriesCarrySandbox(t *testing.T) {
 }
 
 func TestSandboxCommandFailuresClose(t *testing.T) {
-	original := newCommandSandbox
-	t.Cleanup(func() { newCommandSandbox = original })
+	original := adapter.NewSRTRuntime
+	t.Cleanup(func() { adapter.NewSRTRuntime = original })
 
 	fake := &fakeCommandSandbox{commandErr: errors.New("wrap failed")}
-	newCommandSandbox = func(context.Context, sandboxruntime.Config) (commandSandbox, error) { return fake, nil }
+	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) { return fake, nil }
 	if _, _, err := newCLICommand(context.Background(), "codex", nil, t.TempDir(), true); err == nil || !strings.Contains(err.Error(), "wrap codex") {
 		t.Fatalf("err = %v, want sandbox wrapping failure", err)
 	}
@@ -192,7 +148,7 @@ func TestSandboxCommandFailuresClose(t *testing.T) {
 	}
 
 	fake = &fakeCommandSandbox{executable: "captain-command-that-does-not-exist"}
-	newCommandSandbox = func(context.Context, sandboxruntime.Config) (commandSandbox, error) { return fake, nil }
+	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) { return fake, nil }
 	if _, _, _, _, err := startCLIStream(context.Background(), "codex", nil, nil, t.TempDir(), nil, true); err == nil {
 		t.Fatal("expected process start failure")
 	}

--- a/pkg/ai/provider/cli_test.go
+++ b/pkg/ai/provider/cli_test.go
@@ -84,7 +84,7 @@ func TestGeminiCLIUsesContextDir(t *testing.T) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	provider := NewGeminiCLI("gemini-cli-pro")
-	provider.sandbox = true
+	provider.sandbox = &api.SandboxConfig{Kind: api.SandboxSRT}
 	resp, err := provider.Execute(context.Background(), ai.Request{
 		Prompt: api.Prompt{User: "hello"},
 		Setup:  &shell.Setup{Cwd: cwd},
@@ -112,14 +112,17 @@ func TestGeminiCLIUsesContextDir(t *testing.T) {
 }
 
 func TestCLIProviderFactoriesCarrySandbox(t *testing.T) {
+	srtSelected := func(sandbox *api.SandboxConfig) bool {
+		return sandbox != nil && sandbox.Kind == api.SandboxSRT
+	}
 	tests := []struct {
 		backend api.Backend
 		model   string
 		enabled func(api.Provider) bool
 	}{
-		{api.BackendClaudeCLI, "claude-sonnet-5", func(p api.Provider) bool { return p.(*ClaudeCLI).sandbox }},
-		{api.BackendCodexCLI, "gpt-5.5", func(p api.Provider) bool { return p.(*CodexCLI).sandbox }},
-		{api.BackendGeminiCLI, "gemini-3.5-flash", func(p api.Provider) bool { return p.(*GeminiCLI).sandbox }},
+		{api.BackendClaudeCLI, "claude-sonnet-5", func(p api.Provider) bool { return srtSelected(p.(*ClaudeCLI).sandbox) }},
+		{api.BackendCodexCLI, "gpt-5.5", func(p api.Provider) bool { return srtSelected(p.(*CodexCLI).sandbox) }},
+		{api.BackendGeminiCLI, "gemini-3.5-flash", func(p api.Provider) bool { return srtSelected(p.(*GeminiCLI).sandbox) }},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.backend), func(t *testing.T) {
@@ -138,9 +141,10 @@ func TestSandboxCommandFailuresClose(t *testing.T) {
 	original := adapter.NewSRTRuntime
 	t.Cleanup(func() { adapter.NewSRTRuntime = original })
 
+	srt := &api.SandboxConfig{Kind: api.SandboxSRT}
 	fake := &fakeCommandSandbox{commandErr: errors.New("wrap failed")}
 	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) { return fake, nil }
-	if _, _, err := newCLICommand(context.Background(), "codex", nil, t.TempDir(), true); err == nil || !strings.Contains(err.Error(), "wrap codex") {
+	if _, _, err := newCLICommand(context.Background(), "codex", nil, t.TempDir(), srt); err == nil || !strings.Contains(err.Error(), "wrap codex") {
 		t.Fatalf("err = %v, want sandbox wrapping failure", err)
 	}
 	if !fake.closed {
@@ -149,7 +153,7 @@ func TestSandboxCommandFailuresClose(t *testing.T) {
 
 	fake = &fakeCommandSandbox{executable: "captain-command-that-does-not-exist"}
 	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) { return fake, nil }
-	if _, _, _, _, err := startCLIStream(context.Background(), "codex", nil, nil, t.TempDir(), nil, true); err == nil {
+	if _, _, _, _, err := startCLIStream(context.Background(), "codex", nil, nil, t.TempDir(), nil, srt); err == nil {
 		t.Fatal("expected process start failure")
 	}
 	if !fake.closed {

--- a/pkg/ai/provider/cli_test.go
+++ b/pkg/ai/provider/cli_test.go
@@ -144,7 +144,8 @@ func TestSandboxCommandFailuresClose(t *testing.T) {
 	srt := &api.SandboxConfig{Kind: api.SandboxSRT}
 	fake := &fakeCommandSandbox{commandErr: errors.New("wrap failed")}
 	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) { return fake, nil }
-	if _, _, err := newCLICommand(context.Background(), "codex", nil, t.TempDir(), srt); err == nil || !strings.Contains(err.Error(), "wrap codex") {
+	req := &ai.Request{Setup: &shell.Setup{Cwd: t.TempDir()}}
+	if _, _, err := newCLICommand(context.Background(), "codex", nil, req, srt); err == nil || !strings.Contains(err.Error(), "wrap codex") {
 		t.Fatalf("err = %v, want sandbox wrapping failure", err)
 	}
 	if !fake.closed {
@@ -153,7 +154,7 @@ func TestSandboxCommandFailuresClose(t *testing.T) {
 
 	fake = &fakeCommandSandbox{executable: "captain-command-that-does-not-exist"}
 	adapter.NewSRTRuntime = func(context.Context, sandboxruntime.Config) (adapter.Runtime, error) { return fake, nil }
-	if _, _, _, _, err := startCLIStream(context.Background(), "codex", nil, nil, t.TempDir(), nil, srt); err == nil {
+	if _, _, _, _, err := startCLIStream(context.Background(), "codex", nil, nil, req, srt); err == nil {
 		t.Fatal("expected process start failure")
 	}
 	if !fake.closed {

--- a/pkg/ai/provider/codex_cli.go
+++ b/pkg/ai/provider/codex_cli.go
@@ -21,7 +21,7 @@ var codexCLICommand = "codex"
 type CodexCLI struct {
 	model   string
 	apiURL  string
-	sandbox bool
+	sandbox *api.SandboxConfig
 }
 
 func NewCodexCLI(cfg ai.Config) *CodexCLI {
@@ -32,7 +32,7 @@ func NewCodexCLI(cfg ai.Config) *CodexCLI {
 	return &CodexCLI{
 		model:   ai.NormalizeModelForBackend(ai.BackendCodexCLI, model),
 		apiURL:  strings.TrimSpace(cfg.APIURL),
-		sandbox: cfg.Sandbox,
+		sandbox: cfg.ResolvedSandbox(),
 	}
 }
 

--- a/pkg/ai/provider/codex_cli.go
+++ b/pkg/ai/provider/codex_cli.go
@@ -68,11 +68,7 @@ func (c *CodexCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan ai
 	if err != nil {
 		return nil, err
 	}
-	env := []string(nil)
-	if req.Setup != nil {
-		env = commandEnv(req.Setup.Env)
-	}
-	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, codexCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env, c.sandbox)
+	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, codexCLICommand, args, []byte(composePrompt(req)), &req, c.sandbox)
 	if err != nil {
 		cleanup()
 		return nil, err

--- a/pkg/ai/provider/gemini_cli.go
+++ b/pkg/ai/provider/gemini_cli.go
@@ -69,13 +69,9 @@ func (g *GeminiCLI) ExecuteStream(ctx context.Context, req ai.Request) (<-chan a
 	if err != nil {
 		return nil, err
 	}
-	env := []string(nil)
-	if req.Setup != nil {
-		env = commandEnv(req.Setup.Env)
-	}
 	// gemini reads the prompt from stdin and goes headless whenever stdin or
 	// stdout is not a TTY, which piping both guarantees.
-	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, geminiCLICommand, args, []byte(composePrompt(req)), req.Cwd(), env, g.sandbox)
+	cmd, stdout, stderrBuf, closeSandbox, err := startCLIStream(ctx, geminiCLICommand, args, []byte(composePrompt(req)), &req, g.sandbox)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ai/provider/gemini_cli.go
+++ b/pkg/ai/provider/gemini_cli.go
@@ -19,7 +19,7 @@ const geminiCLIDefaultModel = "gemini-3.5-flash"
 
 type GeminiCLI struct {
 	model   string
-	sandbox bool
+	sandbox *api.SandboxConfig
 }
 
 // registry.Google declares Streaming for ModeCLI, and the logging/validating

--- a/pkg/ai/provider/init.go
+++ b/pkg/ai/provider/init.go
@@ -23,7 +23,7 @@ func init() {
 	ai.RegisterProvider(ai.BackendClaudeAgent, func(cfg ai.Config) (ai.Provider, error) { return claudeagent.New(cfg) })
 	ai.RegisterProvider(ai.BackendClaudeCLI, func(cfg ai.Config) (ai.Provider, error) {
 		provider := NewClaudeCLI(cfg.Model.Name)
-		provider.sandbox = cfg.Sandbox
+		provider.sandbox = cfg.ResolvedSandbox()
 		return provider, nil
 	})
 
@@ -38,7 +38,7 @@ func init() {
 
 	ai.RegisterProvider(ai.BackendGeminiCLI, func(cfg ai.Config) (ai.Provider, error) {
 		provider := NewGeminiCLI(cfg.Model.Name)
-		provider.sandbox = cfg.Sandbox
+		provider.sandbox = cfg.ResolvedSandbox()
 		return provider, nil
 	})
 }

--- a/pkg/ai/provider/init.go
+++ b/pkg/ai/provider/init.go
@@ -5,6 +5,10 @@ import (
 	"github.com/flanksource/captain/pkg/ai/provider/claudeagent"
 	"github.com/flanksource/captain/pkg/ai/provider/cmux"
 	"github.com/flanksource/captain/pkg/ai/provider/genkit"
+
+	// Register the sandbox adapters so api.NewSandbox can construct them for
+	// the CLI exec seam (newSandboxedCommand).
+	_ "github.com/flanksource/captain/pkg/sandbox/adapter"
 )
 
 func init() {

--- a/pkg/ai/provider/sandbox_seam_test.go
+++ b/pkg/ai/provider/sandbox_seam_test.go
@@ -22,7 +22,7 @@ func (s *wrapperSandboxStub) Wrap(_ context.Context, cmd string, args, env []str
 }
 
 func TestNewCLICommand_UnsandboxedStaysBare(t *testing.T) {
-	cmd, cleanup, err := newCLICommand(context.Background(), "echo", []string{"hi"}, t.TempDir(), false)
+	cmd, cleanup, err := newCLICommand(context.Background(), "echo", []string{"hi"}, t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ai/provider/sandbox_seam_test.go
+++ b/pkg/ai/provider/sandbox_seam_test.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/sandbox/adapter"
+	"github.com/flanksource/commons-db/shell"
+	"github.com/flanksource/commons-db/types"
 )
 
 // wrapperSandboxStub is a sandbox whose CommandWrapper prefixes the argv, so
 // the test can observe the rewrite at the exec seam.
-type wrapperSandboxStub struct{ closed bool }
+type wrapperSandboxStub struct {
+	closed bool
+	gotEnv []string
+}
 
 func (s *wrapperSandboxStub) Kind() api.SandboxKind { return api.SandboxNone }
 func (s *wrapperSandboxStub) Prepare(context.Context, *api.Spec) (*api.SandboxSession, error) {
@@ -18,11 +24,12 @@ func (s *wrapperSandboxStub) Prepare(context.Context, *api.Spec) (*api.SandboxSe
 }
 func (s *wrapperSandboxStub) Close() error { s.closed = true; return nil }
 func (s *wrapperSandboxStub) Wrap(_ context.Context, cmd string, args, env []string) (string, []string, []string, error) {
+	s.gotEnv = env
 	return "confine", append([]string{"--", cmd}, args...), append(env, "WRAPPED=1"), nil
 }
 
 func TestNewCLICommand_UnsandboxedStaysBare(t *testing.T) {
-	cmd, cleanup, err := newCLICommand(context.Background(), "echo", []string{"hi"}, t.TempDir(), nil)
+	cmd, cleanup, err := newCLICommand(context.Background(), "echo", []string{"hi"}, requestWithCwd(t.TempDir()), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,12 +47,15 @@ func TestNewSandboxedCommand_RoutesThroughCommandWrapper(t *testing.T) {
 	api.RegisterSandbox(api.SandboxNone, func(api.SandboxConfig) (api.Sandbox, error) { return stub, nil })
 	t.Cleanup(func() { api.RegisterSandbox(api.SandboxNone, adapter.None) })
 
-	cmd, cleanup, err := newSandboxedCommand(context.Background(), api.SandboxConfig{Kind: api.SandboxNone}, "claude", []string{"-p"}, t.TempDir())
+	cmd, cleanup, err := newSandboxedCommand(context.Background(), api.SandboxConfig{Kind: api.SandboxNone}, "claude", []string{"-p"}, requestWithSetupVar(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got := cmd.Args; len(got) != 4 || got[0] != "confine" || got[1] != "--" || got[2] != "claude" || got[3] != "-p" {
 		t.Fatalf("args = %v, want the wrapper's rewrite", got)
+	}
+	if len(stub.gotEnv) != 1 || stub.gotEnv[0] != "SETUP_VAR=1" {
+		t.Fatalf("wrapper saw env %v, want the request-declared setup vars", stub.gotEnv)
 	}
 	if len(cmd.Env) == 0 || cmd.Env[len(cmd.Env)-1] != "WRAPPED=1" {
 		t.Fatalf("env = %v, want the wrapper's env applied", cmd.Env)
@@ -54,4 +64,18 @@ func TestNewSandboxedCommand_RoutesThroughCommandWrapper(t *testing.T) {
 	if !stub.closed {
 		t.Fatal("cleanup must close the sandbox")
 	}
+}
+
+func requestWithCwd(cwd string) *ai.Request {
+	return &ai.Request{Setup: &shell.Setup{Cwd: cwd}}
+}
+
+// requestWithSetupVar declares SETUP_VAR and carries its resolved value, the
+// shape Setup.Resolve produces (declared names in EnvVars, values in Env).
+func requestWithSetupVar(cwd string) *ai.Request {
+	return &ai.Request{Setup: &shell.Setup{
+		Cwd:     cwd,
+		EnvVars: []types.EnvVar{{Name: "SETUP_VAR"}},
+		Env:     []string{"SETUP_VAR=1"},
+	}}
 }

--- a/pkg/ai/provider/sandbox_seam_test.go
+++ b/pkg/ai/provider/sandbox_seam_test.go
@@ -17,8 +17,8 @@ func (s *wrapperSandboxStub) Prepare(context.Context, *api.Spec) (*api.SandboxSe
 	return &api.SandboxSession{}, nil
 }
 func (s *wrapperSandboxStub) Close() error { s.closed = true; return nil }
-func (s *wrapperSandboxStub) Wrap(cmd string, args, env []string) (string, []string, []string) {
-	return "confine", append([]string{"--", cmd}, args...), append(env, "WRAPPED=1")
+func (s *wrapperSandboxStub) Wrap(_ context.Context, cmd string, args, env []string) (string, []string, []string, error) {
+	return "confine", append([]string{"--", cmd}, args...), append(env, "WRAPPED=1"), nil
 }
 
 func TestNewCLICommand_UnsandboxedStaysBare(t *testing.T) {
@@ -40,7 +40,7 @@ func TestNewSandboxedCommand_RoutesThroughCommandWrapper(t *testing.T) {
 	api.RegisterSandbox(api.SandboxNone, func(api.SandboxConfig) (api.Sandbox, error) { return stub, nil })
 	t.Cleanup(func() { api.RegisterSandbox(api.SandboxNone, adapter.None) })
 
-	cmd, cleanup, err := newSandboxedCommand(context.Background(), api.SandboxConfig{Kind: api.SandboxNone}, "claude", []string{"-p"})
+	cmd, cleanup, err := newSandboxedCommand(context.Background(), api.SandboxConfig{Kind: api.SandboxNone}, "claude", []string{"-p"}, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ai/provider/sandbox_seam_test.go
+++ b/pkg/ai/provider/sandbox_seam_test.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/sandbox/adapter"
+)
+
+// wrapperSandboxStub is a sandbox whose CommandWrapper prefixes the argv, so
+// the test can observe the rewrite at the exec seam.
+type wrapperSandboxStub struct{ closed bool }
+
+func (s *wrapperSandboxStub) Kind() api.SandboxKind { return api.SandboxNone }
+func (s *wrapperSandboxStub) Prepare(context.Context, *api.Spec) (*api.SandboxSession, error) {
+	return &api.SandboxSession{}, nil
+}
+func (s *wrapperSandboxStub) Close() error { s.closed = true; return nil }
+func (s *wrapperSandboxStub) Wrap(cmd string, args, env []string) (string, []string, []string) {
+	return "confine", append([]string{"--", cmd}, args...), append(env, "WRAPPED=1")
+}
+
+func TestNewCLICommand_UnsandboxedStaysBare(t *testing.T) {
+	cmd, cleanup, err := newCLICommand(context.Background(), "echo", []string{"hi"}, t.TempDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if len(cmd.Args) != 2 || cmd.Args[0] != "echo" || cmd.Args[1] != "hi" {
+		t.Fatalf("args = %v, want the bare argv untouched", cmd.Args)
+	}
+	if cmd.Env != nil {
+		t.Fatalf("env = %v, want inherited (nil)", cmd.Env)
+	}
+}
+
+func TestNewSandboxedCommand_RoutesThroughCommandWrapper(t *testing.T) {
+	stub := &wrapperSandboxStub{}
+	api.RegisterSandbox(api.SandboxNone, func(api.SandboxConfig) (api.Sandbox, error) { return stub, nil })
+	t.Cleanup(func() { api.RegisterSandbox(api.SandboxNone, adapter.None) })
+
+	cmd, cleanup, err := newSandboxedCommand(context.Background(), api.SandboxConfig{Kind: api.SandboxNone}, "claude", []string{"-p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cmd.Args; len(got) != 4 || got[0] != "confine" || got[1] != "--" || got[2] != "claude" || got[3] != "-p" {
+		t.Fatalf("args = %v, want the wrapper's rewrite", got)
+	}
+	if len(cmd.Env) == 0 || cmd.Env[len(cmd.Env)-1] != "WRAPPED=1" {
+		t.Fatalf("env = %v, want the wrapper's env applied", cmd.Env)
+	}
+	cleanup()
+	if !stub.closed {
+		t.Fatal("cleanup must close the sandbox")
+	}
+}

--- a/pkg/api/registry/sandboxes.go
+++ b/pkg/api/registry/sandboxes.go
@@ -19,7 +19,7 @@ var (
 	SRTSandbox = &Sandbox{
 		Kind:         SandboxSRT,
 		Description:  "Confine the agent with sandbox-runtime (filesystem and network policy)",
-		Capabilities: []SandboxCapability{CapabilityWrapCommand, CapabilityEgressProxy},
+		Capabilities: []SandboxCapability{CapabilityWrapCommand},
 		Modes:        []RuntimeMode{ModeCLI},
 	}
 

--- a/pkg/api/runtime_config.go
+++ b/pkg/api/runtime_config.go
@@ -60,12 +60,12 @@ type Config struct {
 	// this and the legacy Sandbox boolean are set, this wins.
 	SandboxSelection *SandboxConfig
 	CacheDBPath      string
-	CacheTTL      time.Duration
-	NoCache       bool
-	MaxConcurrent int
-	SessionID     string
-	ProjectName   string
-	SchemaRepair  SchemaRepairConfig
+	CacheTTL         time.Duration
+	NoCache          bool
+	MaxConcurrent    int
+	SessionID        string
+	ProjectName      string
+	SchemaRepair     SchemaRepairConfig
 
 	// CanUseTool, when set, brokers tool permissions over the stream-json control
 	// protocol: the streaming provider asks this callback before a tool that needs

--- a/pkg/api/runtime_config.go
+++ b/pkg/api/runtime_config.go
@@ -53,8 +53,13 @@ type Config struct {
 	APIURL string
 	// Sandbox runs local agent CLI processes through sandbox-runtime. Provider
 	// selection must resolve to CLI mode so the flag cannot be silently ignored.
-	Sandbox       bool
-	CacheDBPath   string
+	// It is the legacy boolean shorthand for SandboxSelection = {kind: srt}.
+	Sandbox bool
+	// SandboxSelection is the resolved sandbox for the run — kind, configured
+	// backend name, and that backend's options. nil means unsandboxed. When both
+	// this and the legacy Sandbox boolean are set, this wins.
+	SandboxSelection *SandboxConfig
+	CacheDBPath      string
 	CacheTTL      time.Duration
 	NoCache       bool
 	MaxConcurrent int
@@ -75,4 +80,16 @@ type Config struct {
 	// the genkit API backends) honour them; other providers, which bring their
 	// own tool ecosystems, ignore the field. Never serialized (Go closures).
 	Tools []ToolDefinition `json:"-"`
+}
+
+// ResolvedSandbox returns the sandbox selection for the run, folding the legacy
+// boolean onto the srt kind. nil means run unsandboxed.
+func (c Config) ResolvedSandbox() *SandboxConfig {
+	if c.SandboxSelection != nil {
+		return c.SandboxSelection
+	}
+	if c.Sandbox {
+		return &SandboxConfig{Kind: SandboxSRT}
+	}
+	return nil
 }

--- a/pkg/api/runtime_registry.go
+++ b/pkg/api/runtime_registry.go
@@ -49,6 +49,18 @@ func NewProvider(cfg Config) (Provider, error) {
 	if cfg.Sandbox && backend.Mode() != registry.ModeCLI {
 		return nil, fmt.Errorf("sandbox-runtime requires a CLI backend, got %s", backend)
 	}
+	// An unsupported sandbox × backend pairing is a validation error, not a
+	// silent no-op: the adapter would have no seam to act on, and running
+	// unsandboxed anyway is the failure this check exists to prevent.
+	if cfg.SandboxSelection != nil {
+		descriptor, ok := registry.SandboxFor(cfg.SandboxSelection.Kind)
+		if !ok {
+			return nil, fmt.Errorf("unknown sandbox kind %q; want one of: %s", cfg.SandboxSelection.Kind, registry.SandboxKindList())
+		}
+		if err := descriptor.ValidateMode(backend.Mode()); err != nil {
+			return nil, err
+		}
+	}
 
 	factory, ok := factories[backend]
 	if !ok {

--- a/pkg/api/runtime_registry.go
+++ b/pkg/api/runtime_registry.go
@@ -46,7 +46,10 @@ func NewProvider(cfg Config) (Provider, error) {
 		}
 	}
 	cfg.Model.Backend = backend
-	if cfg.Sandbox && backend.Mode() != registry.ModeCLI {
+	// The legacy boolean only speaks when no explicit selection was made:
+	// ResolvedSandbox gives SandboxSelection precedence, so a caller selecting
+	// e.g. "none" alongside a stale Sandbox=true must not be rejected as srt.
+	if cfg.SandboxSelection == nil && cfg.Sandbox && backend.Mode() != registry.ModeCLI {
 		return nil, fmt.Errorf("sandbox-runtime requires a CLI backend, got %s", backend)
 	}
 	// An unsupported sandbox × backend pairing is a validation error, not a

--- a/pkg/api/sandbox.go
+++ b/pkg/api/sandbox.go
@@ -75,9 +75,12 @@ type SandboxUnwrapper interface {
 
 // CommandWrapper is the capability of adapters that confine a local process by
 // rewriting its argv/env before exec (srt, container). The returned values
-// replace the originals wholesale.
+// replace the originals wholesale. It takes a context and returns an error
+// because wrapping may require constructing live confinement state; an adapter
+// that cannot wrap MUST fail here — falling through to an unwrapped command
+// would silently run unsandboxed.
 type CommandWrapper interface {
-	Wrap(cmd string, args, env []string) (string, []string, []string)
+	Wrap(ctx context.Context, cmd string, args, env []string) (string, []string, []string, error)
 }
 
 // RemoteExecutor is the capability of adapters that do not wrap a local exec at

--- a/pkg/api/sandbox.go
+++ b/pkg/api/sandbox.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+
+	"github.com/flanksource/captain/pkg/api/registry"
+)
+
+// Sandbox identity and the static descriptor table live in pkg/api/registry —
+// the same split, for the same reason, as Model/Backend (see aliases.go). The
+// registry.Sandbox descriptor is re-exported as SandboxDescriptor because the
+// api.Sandbox name belongs to the behavioural contract below.
+
+type (
+	SandboxKind       = registry.SandboxKind
+	SandboxCapability = registry.SandboxCapability
+	SandboxDescriptor = registry.Sandbox
+)
+
+const (
+	SandboxNone      = registry.SandboxNone
+	SandboxSRT       = registry.SandboxSRT
+	SandboxContainer = registry.SandboxContainer
+	SandboxGitAgent  = registry.SandboxGitAgent
+
+	CapabilityWrapCommand      = registry.CapabilityWrapCommand
+	CapabilityRemoteExec       = registry.CapabilityRemoteExec
+	CapabilityIsolateWorkspace = registry.CapabilityIsolateWorkspace
+	CapabilityEgressProxy      = registry.CapabilityEgressProxy
+)
+
+// ParseSandboxKind normalizes a kind token; empty resolves to SandboxNone.
+func ParseSandboxKind(s string) (SandboxKind, bool) { return registry.ParseSandboxKind(s) }
+
+// SandboxFor returns the static descriptor for a kind.
+func SandboxFor(kind SandboxKind) (*SandboxDescriptor, bool) { return registry.SandboxFor(kind) }
+
+// AllSandboxes lists every sandbox adapter descriptor in canonical order.
+func AllSandboxes() []*SandboxDescriptor { return registry.AllSandboxes() }
+
+// SandboxKindList renders the adapter kinds as comma-separated text for
+// help/error strings.
+func SandboxKindList() string { return registry.SandboxKindList() }
+
+// Sandbox is the behavioural contract of one sandbox adapter — the mechanism a
+// run's agent process executes under. Instances come from NewSandbox; what an
+// instance can actually do is discovered with SandboxAs against the capability
+// interfaces below, never by switching on Kind.
+type Sandbox interface {
+	// Kind names the adapter, matching its registry descriptor.
+	Kind() SandboxKind
+	// Prepare establishes per-run state for one spec. It is called once per run,
+	// before execution; the returned session carries whatever the exec site must
+	// apply to the agent process.
+	Prepare(ctx context.Context, spec *Spec) (*SandboxSession, error)
+	// Close releases state the adapter holds across runs.
+	Close() error
+}
+
+// SandboxSession is the per-run state Prepare establishes. Zero-valued fields
+// mean "no change": the exec site applies only what is set.
+type SandboxSession struct {
+	// WorkDir, when non-empty, overrides the working directory the agent process
+	// runs in.
+	WorkDir string
+	// Env are additional environment variables (KEY=VALUE) for the agent process.
+	Env []string
+}
+
+// SandboxUnwrapper is implemented by decorating adapters so SandboxAs can find
+// a capability behind them. Mirrors ProviderUnwrapper.
+type SandboxUnwrapper interface {
+	Unwrap() Sandbox
+}
+
+// CommandWrapper is the capability of adapters that confine a local process by
+// rewriting its argv/env before exec (srt, container). The returned values
+// replace the originals wholesale.
+type CommandWrapper interface {
+	Wrap(cmd string, args, env []string) (string, []string, []string)
+}
+
+// RemoteExecutor is the capability of adapters that do not wrap a local exec at
+// all but relocate the whole run elsewhere (git-agent). An adapter with this
+// capability replaces provider execution for the run.
+type RemoteExecutor interface {
+	Execute(ctx context.Context, spec Spec) (*Response, error)
+}
+
+// SandboxAs resolves a capability from a sandbox, walking SandboxUnwrapper
+// chains so a capability is found behind decorators. Mirrors ProviderAs.
+func SandboxAs[T any](sandbox Sandbox) (T, bool) {
+	for sandbox != nil {
+		if capability, ok := any(sandbox).(T); ok {
+			return capability, true
+		}
+		wrapper, ok := sandbox.(SandboxUnwrapper)
+		if !ok {
+			break
+		}
+		sandbox = wrapper.Unwrap()
+	}
+	var zero T
+	return zero, false
+}

--- a/pkg/api/sandbox_ginkgo_test.go
+++ b/pkg/api/sandbox_ginkgo_test.go
@@ -112,6 +112,17 @@ var _ = Describe("NewSandbox", func() {
 	})
 })
 
+var _ = Describe("NewProvider sandbox validation", func() {
+	It("rejects an unsupported sandbox × backend pairing before construction", func() {
+		_, err := api.NewProvider(api.Config{
+			Model:            api.Model{Name: "claude-sonnet-5", Backend: api.BackendClaudeAgent},
+			SandboxSelection: &api.SandboxConfig{Kind: api.SandboxSRT},
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("does not support runtime mode")))
+	})
+})
+
 var _ = Describe("RegisterSandbox", func() {
 	It("panics on a kind with no descriptor", func() {
 		Expect(func() {

--- a/pkg/api/sandbox_ginkgo_test.go
+++ b/pkg/api/sandbox_ginkgo_test.go
@@ -121,6 +121,27 @@ var _ = Describe("NewProvider sandbox validation", func() {
 
 		Expect(err).To(MatchError(ContainSubstring("does not support runtime mode")))
 	})
+
+	It("lets an explicit selection override a stale legacy boolean", func() {
+		// Sandbox=true would demand a CLI backend, but the explicit "none"
+		// selection has precedence — the run must get past the sandbox guards
+		// (failing later only because no provider factory is registered here).
+		_, err := api.NewProvider(api.Config{
+			Model:            api.Model{Name: "claude-sonnet-5", Backend: api.BackendClaudeAgent},
+			Sandbox:          true,
+			SandboxSelection: &api.SandboxConfig{Kind: api.SandboxNone},
+		})
+
+		Expect(err).NotTo(MatchError(ContainSubstring("sandbox-runtime requires a CLI backend")))
+	})
+
+	It("rejects a factory returning a nil instance", func() {
+		api.RegisterSandbox(api.SandboxNone, func(api.SandboxConfig) (api.Sandbox, error) { return nil, nil })
+
+		_, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxNone})
+
+		Expect(err).To(MatchError(ContainSubstring("returned no instance")))
+	})
 })
 
 var _ = Describe("RegisterSandbox", func() {

--- a/pkg/api/sandbox_ginkgo_test.go
+++ b/pkg/api/sandbox_ginkgo_test.go
@@ -99,6 +99,21 @@ var _ = Describe("NewSandbox", func() {
 		Expect(err).To(MatchError(ContainSubstring(`declares capability "wrap-command"`)))
 	})
 
+	It("rejects a declared capability with no construction verifier", func() {
+		descriptor, ok := api.SandboxFor(api.SandboxSRT)
+		Expect(ok).To(BeTrue())
+		original := append([]api.SandboxCapability(nil), descriptor.Capabilities...)
+		descriptor.Capabilities = append(descriptor.Capabilities, api.CapabilityEgressProxy)
+		DeferCleanup(func() { descriptor.Capabilities = original })
+		api.RegisterSandbox(api.SandboxSRT, func(cfg api.SandboxConfig) (api.Sandbox, error) {
+			return wrappingSandboxStub{sandboxStub{kind: api.SandboxSRT}}, nil
+		})
+
+		_, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxSRT})
+
+		Expect(err).To(MatchError(ContainSubstring(`capability "egress-proxy" but no construction-time verifier`)))
+	})
+
 	It("accepts an adapter that implements its declared capabilities", func() {
 		api.RegisterSandbox(api.SandboxSRT, func(cfg api.SandboxConfig) (api.Sandbox, error) {
 			return wrappingSandboxStub{sandboxStub{kind: api.SandboxSRT}}, nil

--- a/pkg/api/sandbox_ginkgo_test.go
+++ b/pkg/api/sandbox_ginkgo_test.go
@@ -1,0 +1,122 @@
+package api_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/flanksource/captain/pkg/api"
+)
+
+type sandboxStub struct{ kind api.SandboxKind }
+
+func (s sandboxStub) Kind() api.SandboxKind { return s.kind }
+func (s sandboxStub) Prepare(context.Context, *api.Spec) (*api.SandboxSession, error) {
+	return &api.SandboxSession{}, nil
+}
+func (s sandboxStub) Close() error { return nil }
+
+type wrappingSandboxStub struct{ sandboxStub }
+
+func (wrappingSandboxStub) Wrap(cmd string, args, env []string) (string, []string, []string) {
+	return "wrapped-" + cmd, args, env
+}
+
+type sandboxDecorator struct{ inner api.Sandbox }
+
+func (d sandboxDecorator) Kind() api.SandboxKind { return d.inner.Kind() }
+func (d sandboxDecorator) Prepare(ctx context.Context, spec *api.Spec) (*api.SandboxSession, error) {
+	return d.inner.Prepare(ctx, spec)
+}
+func (d sandboxDecorator) Close() error        { return d.inner.Close() }
+func (d sandboxDecorator) Unwrap() api.Sandbox { return d.inner }
+
+var _ = Describe("SandboxAs", func() {
+	It("finds a capability through nested decorators", func() {
+		sandbox := sandboxDecorator{inner: sandboxDecorator{inner: wrappingSandboxStub{sandboxStub{kind: api.SandboxSRT}}}}
+
+		wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox)
+
+		Expect(ok).To(BeTrue())
+		cmd, _, _ := wrapper.Wrap("claude", nil, nil)
+		Expect(cmd).To(Equal("wrapped-claude"))
+	})
+
+	It("reports absence when no layer implements the capability", func() {
+		sandbox := sandboxDecorator{inner: sandboxStub{kind: api.SandboxNone}}
+
+		_, ok := api.SandboxAs[api.RemoteExecutor](sandbox)
+
+		Expect(ok).To(BeFalse())
+	})
+})
+
+var _ = Describe("NewSandbox", func() {
+	It("constructs the registered adapter for a kind", func() {
+		api.RegisterSandbox(api.SandboxNone, func(cfg api.SandboxConfig) (api.Sandbox, error) {
+			return sandboxStub{kind: api.SandboxNone}, nil
+		})
+
+		sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxNone})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sandbox.Kind()).To(Equal(api.SandboxNone))
+	})
+
+	It("defaults an empty kind to none", func() {
+		api.RegisterSandbox(api.SandboxNone, func(cfg api.SandboxConfig) (api.Sandbox, error) {
+			return sandboxStub{kind: api.SandboxNone}, nil
+		})
+
+		sandbox, err := api.NewSandbox(api.SandboxConfig{})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sandbox.Kind()).To(Equal(api.SandboxNone))
+	})
+
+	It("rejects an unknown kind, naming the valid set", func() {
+		_, err := api.NewSandbox(api.SandboxConfig{Kind: "warp-drive"})
+
+		Expect(err).To(MatchError(ContainSubstring(`unknown sandbox kind "warp-drive"`)))
+		Expect(err).To(MatchError(ContainSubstring("none, srt, container, git-agent")))
+	})
+
+	It("rejects a known kind with no registered adapter", func() {
+		_, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxGitAgent})
+
+		Expect(err).To(MatchError(ContainSubstring(`no sandbox adapter registered for kind "git-agent"`)))
+	})
+
+	It("rejects an adapter that does not implement a declared capability", func() {
+		api.RegisterSandbox(api.SandboxSRT, func(cfg api.SandboxConfig) (api.Sandbox, error) {
+			return sandboxStub{kind: api.SandboxSRT}, nil // srt declares wrap-command; stub lacks Wrap
+		})
+
+		_, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxSRT})
+
+		Expect(err).To(MatchError(ContainSubstring(`declares capability "wrap-command"`)))
+	})
+
+	It("accepts an adapter that implements its declared capabilities", func() {
+		api.RegisterSandbox(api.SandboxSRT, func(cfg api.SandboxConfig) (api.Sandbox, error) {
+			return wrappingSandboxStub{sandboxStub{kind: api.SandboxSRT}}, nil
+		})
+
+		sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxSRT})
+
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := api.SandboxAs[api.CommandWrapper](sandbox)
+		Expect(ok).To(BeTrue())
+	})
+})
+
+var _ = Describe("RegisterSandbox", func() {
+	It("panics on a kind with no descriptor", func() {
+		Expect(func() {
+			api.RegisterSandbox("warp-drive", func(cfg api.SandboxConfig) (api.Sandbox, error) {
+				return nil, nil
+			})
+		}).To(PanicWith(ContainSubstring(`kind "warp-drive" has no descriptor`)))
+	})
+})

--- a/pkg/api/sandbox_ginkgo_test.go
+++ b/pkg/api/sandbox_ginkgo_test.go
@@ -19,8 +19,8 @@ func (s sandboxStub) Close() error { return nil }
 
 type wrappingSandboxStub struct{ sandboxStub }
 
-func (wrappingSandboxStub) Wrap(cmd string, args, env []string) (string, []string, []string) {
-	return "wrapped-" + cmd, args, env
+func (wrappingSandboxStub) Wrap(_ context.Context, cmd string, args, env []string) (string, []string, []string, error) {
+	return "wrapped-" + cmd, args, env, nil
 }
 
 type sandboxDecorator struct{ inner api.Sandbox }
@@ -39,7 +39,8 @@ var _ = Describe("SandboxAs", func() {
 		wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox)
 
 		Expect(ok).To(BeTrue())
-		cmd, _, _ := wrapper.Wrap("claude", nil, nil)
+		cmd, _, _, err := wrapper.Wrap(context.Background(), "claude", nil, nil)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(cmd).To(Equal("wrapped-claude"))
 	})
 

--- a/pkg/api/sandbox_ref.go
+++ b/pkg/api/sandbox_ref.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -58,13 +59,22 @@ func (r SandboxRef) MarshalJSON() ([]byte, error) {
 }
 
 func (r *SandboxRef) UnmarshalJSON(data []byte) error {
+	// An explicit null leaves the receiver untouched — it is "unset", not an
+	// empty ref that would later resolve to nothing.
+	if string(bytes.TrimSpace(data)) == "null" {
+		return nil
+	}
 	var scalar string
 	if err := json.Unmarshal(data, &scalar); err == nil {
 		*r = SandboxRef{Backend: scalar}
 		return nil
 	}
+	// Strict decode, mirroring the YAML path: a typo'd key ("backed") must not
+	// silently yield an empty ref and a run with no sandbox.
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
 	var alias sandboxRefAlias
-	if err := json.Unmarshal(data, &alias); err != nil {
+	if err := decoder.Decode(&alias); err != nil {
 		return err
 	}
 	*r = SandboxRef(alias)
@@ -166,12 +176,17 @@ func (SandboxRef) JSONSchema() *jsonschema.Schema {
 	}
 }
 
-// Validate rejects references that resolve to nothing: overrides with no
-// backend to apply them to, and a negative attempt bound. Backend-name
-// resolution belongs to the config layer, which knows the configured names.
+// Validate rejects references that resolve to nothing: an empty backend
+// (`sandbox: ""` is present-but-selecting-nothing, almost certainly a
+// mistake), overrides with no backend to apply them to, and a negative
+// attempt bound. Backend-name resolution belongs to the config layer, which
+// knows the configured names.
 func (r SandboxRef) Validate() error {
-	if r.Backend == "" && !r.isScalar() {
-		return fmt.Errorf("sandbox overrides (agent/policy) require a backend")
+	if r.Backend == "" {
+		if !r.isScalar() {
+			return fmt.Errorf("sandbox overrides (agent/policy) require a backend")
+		}
+		return fmt.Errorf("sandbox must name a backend or adapter kind (one of: %s)", SandboxKindList())
 	}
 	if r.Policy != nil && r.Policy.MaxAttempts < 0 {
 		return fmt.Errorf("sandbox policy maxAttempts must be >= 0, got %d", r.Policy.MaxAttempts)

--- a/pkg/api/sandbox_ref.go
+++ b/pkg/api/sandbox_ref.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/invopop/jsonschema"
 	"gopkg.in/yaml.v3"
 )
 
@@ -86,12 +87,83 @@ func (r *SandboxRef) UnmarshalYAML(value *yaml.Node) error {
 		*r = SandboxRef{Backend: scalar}
 		return nil
 	}
-	var alias sandboxRefAlias
-	if err := value.Decode(&alias); err != nil {
-		return err
+	// Decode key-by-key rather than through yaml.Node.Decode: Decode spins up a
+	// NON-strict decoder, silently dropping the outer KnownFields(true) — a
+	// typo'd key ("backed:") would otherwise yield an empty ref and a run with
+	// no sandbox at all.
+	*r = SandboxRef{}
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("sandbox must be a backend name or a mapping, got %s", value.Tag)
 	}
-	*r = SandboxRef(alias)
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		key, val := value.Content[i].Value, value.Content[i+1]
+		switch key {
+		case "backend":
+			if err := val.Decode(&r.Backend); err != nil {
+				return err
+			}
+		case "agent":
+			if err := val.Decode(&r.Agent); err != nil {
+				return err
+			}
+		case "policy":
+			r.Policy = &SandboxPolicy{}
+			if err := r.Policy.unmarshalStrict(val); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown sandbox key %q (valid: backend, agent, policy)", key)
+		}
+	}
 	return nil
+}
+
+func (p *SandboxPolicy) unmarshalStrict(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("sandbox policy must be a mapping, got %s", value.Tag)
+	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		key, val := value.Content[i].Value, value.Content[i+1]
+		switch key {
+		case "paths":
+			if err := val.Decode(&p.Paths); err != nil {
+				return err
+			}
+		case "maxAttempts":
+			if err := val.Decode(&p.MaxAttempts); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown sandbox policy key %q (valid: paths, maxAttempts)", key)
+		}
+	}
+	return nil
+}
+
+// JSONSchema declares both accepted forms — the scalar backend-name shorthand
+// and the object form — which reflection cannot see past the custom
+// marshalers: without this the generated schema said "object" only.
+func (SandboxRef) JSONSchema() *jsonschema.Schema {
+	policyProperties := jsonschema.NewProperties()
+	policyProperties.Set("paths", &jsonschema.Schema{Type: "array", Items: &jsonschema.Schema{Type: "string"},
+		Description: "Path allow/deny list, gitignore syntax with ! negating"})
+	policyProperties.Set("maxAttempts", &jsonschema.Schema{Type: "integer", Minimum: json.Number("0"),
+		Description: "Bound on submit cycles per task"})
+
+	properties := jsonschema.NewProperties()
+	properties.Set("backend", &jsonschema.Schema{Type: "string",
+		Description: "Configured sandbox backend from ~/.captain.yaml, or a bare adapter kind"})
+	properties.Set("agent", &jsonschema.Schema{Type: "string",
+		Description: "Pin one enrolled agent of a git-agent backend"})
+	properties.Set("policy", &jsonschema.Schema{Type: "object", Properties: policyProperties, AdditionalProperties: jsonschema.FalseSchema})
+
+	return &jsonschema.Schema{
+		Description: "Sandbox the run executes under: a backend name, or an object with overrides",
+		OneOf: []*jsonschema.Schema{
+			{Type: "string", Description: "Backend name or adapter kind (none, srt, container, git-agent)"},
+			{Type: "object", Properties: properties, AdditionalProperties: jsonschema.FalseSchema},
+		},
+	}
 }
 
 // Validate rejects references that resolve to nothing: overrides with no

--- a/pkg/api/sandbox_ref.go
+++ b/pkg/api/sandbox_ref.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SandboxRef selects the sandbox for one run. It accepts two forms, following
+// the Permissions.Tools precedent:
+//
+//	sandbox: git-agent            # scalar: a kind or a configured backend name
+//
+//	sandbox:                      # object: backend plus overrides
+//	  backend: prod-pool
+//	  agent: worker-01
+//	  policy: {paths: ["pkg/**"], maxAttempts: 3}
+//
+// The scalar form is sugar for {backend: <value>}. Whether the name is a bare
+// adapter kind or a configured backend is resolved at the config layer, which
+// knows the configured names; this type only carries the reference.
+type SandboxRef struct {
+	// Backend names a configured sandbox backend from ~/.captain.yaml, or a bare
+	// adapter kind (none, srt, container, git-agent).
+	Backend string `json:"backend,omitempty" yaml:"backend,omitempty"`
+	// Agent optionally pins one enrolled agent of a git-agent backend.
+	Agent string `json:"agent,omitempty" yaml:"agent,omitempty"`
+	// Policy optionally overrides the backend's dispatch policy for this run.
+	Policy *SandboxPolicy `json:"policy,omitempty" yaml:"policy,omitempty"`
+}
+
+// SandboxPolicy bounds what a dispatched run may touch and how often it may
+// retry. Zero values inherit the backend's configured policy.
+type SandboxPolicy struct {
+	// Paths is the path allow/deny list, gitignore syntax with ! negating.
+	Paths []string `json:"paths,omitempty" yaml:"paths,omitempty"`
+	// MaxAttempts bounds submit cycles per task.
+	MaxAttempts int `json:"maxAttempts,omitempty" yaml:"maxAttempts,omitempty"`
+}
+
+// sandboxRefAlias breaks marshal recursion: it has SandboxRef's fields but none
+// of its methods.
+type sandboxRefAlias SandboxRef
+
+// isScalar reports whether the ref carries only a backend name and so can
+// round-trip through the scalar form.
+func (r SandboxRef) isScalar() bool {
+	return r.Agent == "" && r.Policy == nil
+}
+
+func (r SandboxRef) MarshalJSON() ([]byte, error) {
+	if r.isScalar() {
+		return json.Marshal(r.Backend)
+	}
+	return json.Marshal(sandboxRefAlias(r))
+}
+
+func (r *SandboxRef) UnmarshalJSON(data []byte) error {
+	var scalar string
+	if err := json.Unmarshal(data, &scalar); err == nil {
+		*r = SandboxRef{Backend: scalar}
+		return nil
+	}
+	var alias sandboxRefAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*r = SandboxRef(alias)
+	return nil
+}
+
+func (r SandboxRef) MarshalYAML() (any, error) {
+	if r.isScalar() {
+		return r.Backend, nil
+	}
+	return sandboxRefAlias(r), nil
+}
+
+func (r *SandboxRef) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		var scalar string
+		if err := value.Decode(&scalar); err != nil {
+			return err
+		}
+		*r = SandboxRef{Backend: scalar}
+		return nil
+	}
+	var alias sandboxRefAlias
+	if err := value.Decode(&alias); err != nil {
+		return err
+	}
+	*r = SandboxRef(alias)
+	return nil
+}
+
+// Validate rejects references that resolve to nothing: overrides with no
+// backend to apply them to, and a negative attempt bound. Backend-name
+// resolution belongs to the config layer, which knows the configured names.
+func (r SandboxRef) Validate() error {
+	if r.Backend == "" && !r.isScalar() {
+		return fmt.Errorf("sandbox overrides (agent/policy) require a backend")
+	}
+	if r.Policy != nil && r.Policy.MaxAttempts < 0 {
+		return fmt.Errorf("sandbox policy maxAttempts must be >= 0, got %d", r.Policy.MaxAttempts)
+	}
+	return nil
+}

--- a/pkg/api/sandbox_ref_ginkgo_test.go
+++ b/pkg/api/sandbox_ref_ginkgo_test.go
@@ -54,6 +54,23 @@ var _ = Describe("SandboxRef", func() {
 		Expect(err).To(MatchError(ContainSubstring(`unknown sandbox key "backed"`)))
 	})
 
+	It("rejects unknown object keys in JSON too", func() {
+		var ref SandboxRef
+		err := json.Unmarshal([]byte(`{"backed":"container"}`), &ref)
+		Expect(err).To(MatchError(ContainSubstring("unknown field")))
+	})
+
+	It("leaves the receiver unset on explicit JSON null", func() {
+		ref := SandboxRef{Backend: "keep"}
+		Expect(json.Unmarshal([]byte(`null`), &ref)).To(Succeed())
+		Expect(ref.Backend).To(Equal("keep"))
+	})
+
+	It("rejects an empty scalar backend", func() {
+		err := SandboxRef{}.Validate()
+		Expect(err).To(MatchError(ContainSubstring("must name a backend or adapter kind")))
+	})
+
 	It("rejects unknown policy keys", func() {
 		var ref SandboxRef
 		err := yaml.Unmarshal([]byte("backend: p\npolicy: {maxAttempt: 3}"), &ref)

--- a/pkg/api/sandbox_ref_ginkgo_test.go
+++ b/pkg/api/sandbox_ref_ginkgo_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+var _ = Describe("SandboxRef", func() {
+	DescribeTable("round-trips the scalar form",
+		func(marshal func(any) ([]byte, error), decode func([]byte, any) error) {
+			var ref SandboxRef
+			Expect(decode(mustMarshal(marshal, SandboxRef{Backend: "git-agent"}), &ref)).To(Succeed())
+			Expect(ref).To(Equal(SandboxRef{Backend: "git-agent"}))
+		},
+		Entry("JSON", json.Marshal, json.Unmarshal),
+		Entry("YAML", yaml.Marshal, yaml.Unmarshal),
+	)
+
+	DescribeTable("round-trips the object form",
+		func(marshal func(any) ([]byte, error), decode func([]byte, any) error) {
+			full := SandboxRef{
+				Backend: "prod-pool",
+				Agent:   "worker-01",
+				Policy:  &SandboxPolicy{Paths: []string{"pkg/**", "!**/*.pem"}, MaxAttempts: 3},
+			}
+			var ref SandboxRef
+			Expect(decode(mustMarshal(marshal, full), &ref)).To(Succeed())
+			Expect(ref).To(Equal(full))
+		},
+		Entry("JSON", json.Marshal, json.Unmarshal),
+		Entry("YAML", yaml.Marshal, yaml.Unmarshal),
+	)
+
+	It("decodes a bare YAML scalar", func() {
+		var ref SandboxRef
+		Expect(yaml.Unmarshal([]byte(`git-agent`), &ref)).To(Succeed())
+		Expect(ref).To(Equal(SandboxRef{Backend: "git-agent"}))
+	})
+
+	It("emits the scalar form when only the backend is set", func() {
+		encoded, err := yaml.Marshal(SandboxRef{Backend: "prod-pool"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(encoded))).To(Equal("prod-pool"))
+	})
+
+	It("rejects overrides with no backend", func() {
+		err := SandboxRef{Agent: "worker-01"}.Validate()
+		Expect(err).To(MatchError(ContainSubstring("require a backend")))
+	})
+
+	It("rejects a negative attempt bound", func() {
+		err := SandboxRef{Backend: "p", Policy: &SandboxPolicy{MaxAttempts: -1}}.Validate()
+		Expect(err).To(MatchError(ContainSubstring("maxAttempts")))
+	})
+})
+
+var _ = Describe("Spec.Sandbox", func() {
+	DescribeTable("survives a Spec marshal round-trip",
+		func(marshal func(any) ([]byte, error), decode func([]byte, any) error) {
+			spec := Spec{Sandbox: &SandboxRef{Backend: "prod-pool", Agent: "worker-01"}}
+			var decoded Spec
+			Expect(decode(mustMarshal(marshal, spec), &decoded)).To(Succeed())
+			Expect(decoded.Sandbox).To(Equal(spec.Sandbox))
+		},
+		Entry("JSON", json.Marshal, json.Unmarshal),
+		Entry("YAML", yaml.Marshal, yaml.Unmarshal),
+	)
+
+	It("replaces wholesale on merge rather than merging key-wise", func() {
+		base := Spec{Sandbox: &SandboxRef{Backend: "prod-pool", Agent: "worker-01"}}
+		override := Spec{Sandbox: &SandboxRef{Backend: "local-docker"}}
+
+		merged := base.Merge(override)
+
+		Expect(merged.Sandbox).To(Equal(&SandboxRef{Backend: "local-docker"}))
+	})
+
+	It("keeps the base sandbox when the override has none", func() {
+		base := Spec{Sandbox: &SandboxRef{Backend: "prod-pool"}}
+
+		merged := base.Merge(Spec{})
+
+		Expect(merged.Sandbox).To(Equal(&SandboxRef{Backend: "prod-pool"}))
+	})
+})
+
+// specMarshal is a hand-maintained mirror of Spec; a field present in one and
+// absent from the other silently disappears on marshal. This test turns that
+// silent loss into a failure.
+var _ = Describe("Spec/specMarshal mirror", func() {
+	It("declares the same serialized fields in both structs", func() {
+		Expect(jsonTagSet(reflect.TypeOf(Spec{}))).To(
+			ConsistOf(jsonTagSet(reflect.TypeOf(specMarshal{}))))
+	})
+})
+
+func jsonTagSet(t reflect.Type) []string {
+	var tags []string
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		tag, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if tag == "" && field.Anonymous {
+			tag = "(inline)" + field.Type.Name()
+		}
+		tags = append(tags, tag)
+	}
+	return tags
+}
+
+func mustMarshal(marshal func(any) ([]byte, error), v any) []byte {
+	encoded, err := marshal(v)
+	Expect(err).NotTo(HaveOccurred())
+	return encoded
+}

--- a/pkg/api/sandbox_ref_ginkgo_test.go
+++ b/pkg/api/sandbox_ref_ginkgo_test.go
@@ -48,6 +48,25 @@ var _ = Describe("SandboxRef", func() {
 		Expect(strings.TrimSpace(string(encoded))).To(Equal("prod-pool"))
 	})
 
+	It("rejects unknown object keys despite the custom unmarshaler", func() {
+		var ref SandboxRef
+		err := yaml.Unmarshal([]byte("backed: container"), &ref)
+		Expect(err).To(MatchError(ContainSubstring(`unknown sandbox key "backed"`)))
+	})
+
+	It("rejects unknown policy keys", func() {
+		var ref SandboxRef
+		err := yaml.Unmarshal([]byte("backend: p\npolicy: {maxAttempt: 3}"), &ref)
+		Expect(err).To(MatchError(ContainSubstring(`unknown sandbox policy key "maxAttempt"`)))
+	})
+
+	It("declares both forms in its JSON schema", func() {
+		schema := SandboxRef{}.JSONSchema()
+		Expect(schema.OneOf).To(HaveLen(2))
+		Expect(schema.OneOf[0].Type).To(Equal("string"))
+		Expect(schema.OneOf[1].Type).To(Equal("object"))
+	})
+
 	It("rejects overrides with no backend", func() {
 		err := SandboxRef{Agent: "worker-01"}.Validate()
 		Expect(err).To(MatchError(ContainSubstring("require a backend")))

--- a/pkg/api/sandbox_registry.go
+++ b/pkg/api/sandbox_registry.go
@@ -40,9 +40,12 @@ func RegisterSandbox(kind SandboxKind, factory SandboxFactory) {
 }
 
 // NewSandbox constructs the registered adapter for cfg's kind and verifies the
-// instance against its descriptor: a declared capability the instance does not
-// implement is a construction error, so a descriptor can never promise what an
-// adapter fails to deliver.
+// instance against its descriptor: a declared capability whose seam interface
+// lives in this package (wrap-command, remote-exec) and is not implemented is
+// a construction error. Capabilities whose seams live elsewhere
+// (isolate-workspace is pkg/ai/agent's; egress-proxy is provided by the
+// confinement runtime itself) are declarations for THOSE seams to verify —
+// this check deliberately does not pretend to cover them.
 func NewSandbox(cfg SandboxConfig) (Sandbox, error) {
 	kind := cfg.Kind
 	if kind == "" {

--- a/pkg/api/sandbox_registry.go
+++ b/pkg/api/sandbox_registry.go
@@ -48,12 +48,9 @@ func RegisterSandbox(kind SandboxKind, factory SandboxFactory) {
 }
 
 // NewSandbox constructs the registered adapter for cfg's kind and verifies the
-// instance against its descriptor: a declared capability whose seam interface
-// lives in this package (wrap-command, remote-exec) and is not implemented is
-// a construction error. Capabilities whose seams live elsewhere
-// (isolate-workspace is pkg/ai/agent's; egress-proxy is provided by the
-// confinement runtime itself) are declarations for THOSE seams to verify —
-// this check deliberately does not pretend to cover them.
+// instance against its descriptor. Every declared capability must have a
+// construction-time checker and the instance must satisfy it; a future adapter
+// cannot advertise a capability before its seam and verifier land.
 func NewSandbox(cfg SandboxConfig) (Sandbox, error) {
 	kind := cfg.Kind
 	if kind == "" {
@@ -83,10 +80,10 @@ func NewSandbox(cfg SandboxConfig) (Sandbox, error) {
 	return sandbox, nil
 }
 
-// sandboxCapabilityChecks maps each capability with an api-level interface to
-// its type assertion. Capabilities whose interfaces live above pkg/api
-// (workspace isolation is pkg/ai/agent's; the egress proxy has no interface
-// yet) are declared in the descriptor and verified at their own seam.
+// sandboxCapabilityChecks is the complete construction-time verifier table for
+// capabilities adapters may currently advertise. Adding a descriptor
+// capability and its behavioral seam is one change: NewSandbox fails closed
+// when this table does not know how to prove the declaration.
 var sandboxCapabilityChecks = map[SandboxCapability]func(Sandbox) bool{
 	CapabilityWrapCommand: func(s Sandbox) bool { _, ok := SandboxAs[CommandWrapper](s); return ok },
 	CapabilityRemoteExec:  func(s Sandbox) bool { _, ok := SandboxAs[RemoteExecutor](s); return ok },
@@ -96,7 +93,8 @@ func verifySandboxCapabilities(descriptor *SandboxDescriptor, sandbox Sandbox) e
 	for _, capability := range descriptor.Capabilities {
 		check, ok := sandboxCapabilityChecks[capability]
 		if !ok {
-			continue
+			return fmt.Errorf("sandbox %q declares capability %q but no construction-time verifier is registered",
+				descriptor.Kind, capability)
 		}
 		if !check(sandbox) {
 			return fmt.Errorf("sandbox %q declares capability %q but its adapter does not implement it",

--- a/pkg/api/sandbox_registry.go
+++ b/pkg/api/sandbox_registry.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/flanksource/captain/pkg/api/registry"
 )
@@ -25,8 +26,13 @@ type SandboxFactory func(cfg SandboxConfig) (Sandbox, error)
 
 // sandboxFactories is the process-global adapter registry. Unexported for the
 // same reason the provider factories map is (see runtime_registry.go): mutated
-// only through RegisterSandbox, read only through NewSandbox.
-var sandboxFactories = map[SandboxKind]SandboxFactory{}
+// only through RegisterSandbox, read only through NewSandbox. The mutex exists
+// for tests, which re-register stubs while other tests construct sandboxes;
+// production writes all happen in init().
+var (
+	sandboxFactoriesMu sync.RWMutex
+	sandboxFactories   = map[SandboxKind]SandboxFactory{}
+)
 
 // RegisterSandbox registers a factory for a kind. Adapter packages call it from
 // init(). A kind with no registry descriptor panics: it means the descriptor
@@ -36,6 +42,8 @@ func RegisterSandbox(kind SandboxKind, factory SandboxFactory) {
 	if _, ok := registry.SandboxFor(kind); !ok {
 		panic(fmt.Sprintf("RegisterSandbox: kind %q has no descriptor in pkg/api/registry", kind))
 	}
+	sandboxFactoriesMu.Lock()
+	defer sandboxFactoriesMu.Unlock()
 	sandboxFactories[kind] = factory
 }
 
@@ -55,13 +63,18 @@ func NewSandbox(cfg SandboxConfig) (Sandbox, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown sandbox kind %q; want one of: %s", kind, SandboxKindList())
 	}
+	sandboxFactoriesMu.RLock()
 	factory, ok := sandboxFactories[kind]
+	sandboxFactoriesMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("no sandbox adapter registered for kind %q", kind)
 	}
 	sandbox, err := factory(cfg)
 	if err != nil {
 		return nil, err
+	}
+	if sandbox == nil {
+		return nil, fmt.Errorf("sandbox adapter for kind %q returned no instance", kind)
 	}
 	if err := verifySandboxCapabilities(descriptor, sandbox); err != nil {
 		_ = sandbox.Close()

--- a/pkg/api/sandbox_registry.go
+++ b/pkg/api/sandbox_registry.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/flanksource/captain/pkg/api/registry"
+)
+
+// SandboxConfig selects and parameterizes one sandbox adapter. It is the
+// resolved form of a `sandbox:` selection — after precedence between flag,
+// frontmatter and global config has been applied.
+type SandboxConfig struct {
+	// Kind selects the adapter. Empty means SandboxNone.
+	Kind SandboxKind `json:"kind" yaml:"kind"`
+	// Name is the configured backend this config came from (e.g. "prod-pool"),
+	// empty for ad-hoc construction. It exists for errors and logs.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Options carries the kind-specific settings verbatim. Each adapter decodes
+	// its own; an unknown key is the adapter's error to raise, not this layer's.
+	Options map[string]any `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+// SandboxFactory constructs a Sandbox from a SandboxConfig.
+type SandboxFactory func(cfg SandboxConfig) (Sandbox, error)
+
+// sandboxFactories is the process-global adapter registry. Unexported for the
+// same reason the provider factories map is (see runtime_registry.go): mutated
+// only through RegisterSandbox, read only through NewSandbox.
+var sandboxFactories = map[SandboxKind]SandboxFactory{}
+
+// RegisterSandbox registers a factory for a kind. Adapter packages call it from
+// init(). A kind with no registry descriptor panics: it means the descriptor
+// table and an implementation disagree, which must fail at process start rather
+// than at first use.
+func RegisterSandbox(kind SandboxKind, factory SandboxFactory) {
+	if _, ok := registry.SandboxFor(kind); !ok {
+		panic(fmt.Sprintf("RegisterSandbox: kind %q has no descriptor in pkg/api/registry", kind))
+	}
+	sandboxFactories[kind] = factory
+}
+
+// NewSandbox constructs the registered adapter for cfg's kind and verifies the
+// instance against its descriptor: a declared capability the instance does not
+// implement is a construction error, so a descriptor can never promise what an
+// adapter fails to deliver.
+func NewSandbox(cfg SandboxConfig) (Sandbox, error) {
+	kind := cfg.Kind
+	if kind == "" {
+		kind = SandboxNone
+	}
+	descriptor, ok := SandboxFor(kind)
+	if !ok {
+		return nil, fmt.Errorf("unknown sandbox kind %q; want one of: %s", kind, SandboxKindList())
+	}
+	factory, ok := sandboxFactories[kind]
+	if !ok {
+		return nil, fmt.Errorf("no sandbox adapter registered for kind %q", kind)
+	}
+	sandbox, err := factory(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifySandboxCapabilities(descriptor, sandbox); err != nil {
+		_ = sandbox.Close()
+		return nil, err
+	}
+	return sandbox, nil
+}
+
+// sandboxCapabilityChecks maps each capability with an api-level interface to
+// its type assertion. Capabilities whose interfaces live above pkg/api
+// (workspace isolation is pkg/ai/agent's; the egress proxy has no interface
+// yet) are declared in the descriptor and verified at their own seam.
+var sandboxCapabilityChecks = map[SandboxCapability]func(Sandbox) bool{
+	CapabilityWrapCommand: func(s Sandbox) bool { _, ok := SandboxAs[CommandWrapper](s); return ok },
+	CapabilityRemoteExec:  func(s Sandbox) bool { _, ok := SandboxAs[RemoteExecutor](s); return ok },
+}
+
+func verifySandboxCapabilities(descriptor *SandboxDescriptor, sandbox Sandbox) error {
+	for _, capability := range descriptor.Capabilities {
+		check, ok := sandboxCapabilityChecks[capability]
+		if !ok {
+			continue
+		}
+		if !check(sandbox) {
+			return fmt.Errorf("sandbox %q declares capability %q but its adapter does not implement it",
+				descriptor.Kind, capability)
+		}
+	}
+	return nil
+}

--- a/pkg/api/spec.go
+++ b/pkg/api/spec.go
@@ -30,6 +30,10 @@ type Spec struct {
 	ToolApproval    *ToolApprovalResume `json:"toolApproval,omitempty" yaml:"toolApproval,omitempty" pretty:"-"`
 	Setup           *shell.Setup        `json:"setup,omitempty" yaml:"setup,omitempty"`
 
+	// Sandbox selects the sandbox backend the run executes under. Absent = the
+	// configured default, ultimately "none".
+	Sandbox *SandboxRef `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
+
 	// Workflow declares the generate→verify loop (verification + finalize) around
 	// the run. Absent = single generation, no verification.
 	Workflow *Workflow `json:"workflow,omitempty" yaml:"workflow,omitempty"`
@@ -53,6 +57,7 @@ type specMarshal struct {
 	Preferences *ToolPreferences    `json:"toolPreferences,omitempty" yaml:"toolPreferences,omitempty"`
 	Approval    *ToolApprovalResume `json:"toolApproval,omitempty" yaml:"toolApproval,omitempty"`
 	Setup       *shell.Setup        `json:"setup,omitempty" yaml:"setup,omitempty"`
+	Sandbox     *SandboxRef         `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
 	Workflow    *Workflow           `json:"workflow,omitempty" yaml:"workflow,omitempty"`
 	SessionID   string              `json:"sessionId,omitempty" yaml:"sessionId,omitempty"`
 	CLIArgs     map[string]any      `json:"cliArgs,omitempty" yaml:"cliArgs,omitempty"`
@@ -143,6 +148,7 @@ func (s Spec) marshalValue() specMarshal {
 		Preferences: omitEmptyValue(s.ToolPreferences),
 		Approval:    omitEmptyPointer(s.ToolApproval),
 		Setup:       omitEmptyPointer(s.Setup),
+		Sandbox:     omitEmptyPointer(s.Sandbox),
 		Workflow:    omitEmptyPointer(s.Workflow),
 		SessionID:   s.SessionID,
 		CLIArgs:     s.CLIArgs,
@@ -202,6 +208,11 @@ func (s Spec) Validate() error {
 	}
 	if err := s.Workflow.Validate(); err != nil {
 		return fmt.Errorf("workflow: %w", err)
+	}
+	if s.Sandbox != nil {
+		if err := s.Sandbox.Validate(); err != nil {
+			return fmt.Errorf("sandbox: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/api/spec_merge.go
+++ b/pkg/api/spec_merge.go
@@ -12,7 +12,9 @@ import (
 // zero (a *bool false, a *int 0) counts as set instead of being read as unset.
 // Tool-approval resume state is indivisible: it is a snapshot of one suspended
 // turn, and half of one snapshot layered over half of another describes no turn
-// that ever happened.
+// that ever happened. A sandbox ref is indivisible for the same reason: a
+// per-prompt sandbox replaces the global one wholesale, never key-wise — half
+// of one backend's selection over half of another names no backend at all.
 func MergePolicy() merge.Policy {
 	return registry.MergePolicy().With(merge.Policy{
 		Replace: []any{
@@ -22,6 +24,7 @@ func MergePolicy() merge.Policy {
 			(*uint)(nil),
 			(*string)(nil),
 			(*ToolApprovalResume)(nil),
+			(*SandboxRef)(nil),
 		},
 	})
 }

--- a/pkg/api/spec_merge_differential_test.go
+++ b/pkg/api/spec_merge_differential_test.go
@@ -42,6 +42,9 @@ func legacyMerge(s, override Spec) Spec {
 	if override.Setup != nil {
 		s.Setup = override.Setup
 	}
+	if override.Sandbox != nil {
+		s.Sandbox = override.Sandbox
+	}
 	if override.Workflow != nil {
 		s.Workflow = override.Workflow
 	}

--- a/pkg/api/workflow.go
+++ b/pkg/api/workflow.go
@@ -1,6 +1,9 @@
 package api
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Workflow declares the generate→verify loop around a run as hook
 // declarations: an optional verification stage (commands run after each
@@ -39,6 +42,11 @@ type Verify struct {
 	// for the SpecRuntimeEditor, but does not execute it — only gavel runs
 	// fixtures.
 	Fixture string `json:"fixture,omitempty" yaml:"fixture,omitempty"`
+	// Prompts are .prompt template paths run as LLM-judge checks: each renders
+	// against the run's context and must yield {ok, reason, feedback}; a false
+	// verdict's feedback drives the re-run like a failing command's output.
+	// Maps to agent/verify.LLMJudgeVerifier.
+	Prompts []string `json:"prompts,omitempty" yaml:"prompts,omitempty"`
 	// Scope narrows verification to changed files vs the whole tree.
 	Scope VerifyScope `json:"scope,omitempty" yaml:"scope,omitempty" jsonschema:"enum=,enum=all,enum=changed"`
 	// MaxIterations caps the generate→verify loop; 0 means the run default (1).
@@ -63,6 +71,11 @@ func (w *Workflow) Validate() error {
 	}
 	if w.Verify.MaxIterations < 0 {
 		return fmt.Errorf("workflow.verify.maxIterations must be >= 0")
+	}
+	for i, p := range w.Verify.Prompts {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("workflow.verify.prompts[%d] is empty", i)
+		}
 	}
 	return nil
 }

--- a/pkg/api/workflow_test.go
+++ b/pkg/api/workflow_test.go
@@ -13,6 +13,7 @@ func TestWorkflowSpecRoundTrip(t *testing.T) {
 		Workflow: &Workflow{
 			Verify: &Verify{
 				Commands:      []string{"go test ./...", "go vet ./..."},
+				Prompts:       []string{"review-diff.prompt"},
 				Fixture:       "- [ ] covers the edge case",
 				Scope:         VerifyScopeChanged,
 				MaxIterations: 3,
@@ -39,6 +40,9 @@ func TestWorkflowSpecRoundTrip(t *testing.T) {
 	}
 	if got.Workflow.Verify.Fixture != spec.Workflow.Verify.Fixture || len(got.Workflow.Verify.Commands) != 2 {
 		t.Errorf("verify commands/fixture not preserved: %+v", got.Workflow.Verify)
+	}
+	if len(got.Workflow.Verify.Prompts) != 1 || got.Workflow.Verify.Prompts[0] != "review-diff.prompt" {
+		t.Errorf("verify prompts not preserved: %+v", got.Workflow.Verify.Prompts)
 	}
 	if len(got.Workflow.Commits) != 1 || got.Workflow.Commits[0].On != CommitOnTurn || got.Workflow.Commits[0].Message != "apply" {
 		t.Errorf("commits not preserved: %+v", got.Workflow.Commits)
@@ -99,5 +103,13 @@ func TestVerifyScopeValidate(t *testing.T) {
 	}
 	if err := VerifyScope("sometimes").Validate(); err == nil {
 		t.Errorf("unknown scope should fail validation")
+	}
+}
+
+func TestWorkflowValidate_RejectsBlankVerifyPrompt(t *testing.T) {
+	wf := &Workflow{Verify: &Verify{Prompts: []string{"review.prompt", "   "}}}
+	err := wf.Validate()
+	if err == nil || !strings.Contains(err.Error(), "prompts[1] is empty") {
+		t.Fatalf("err = %v, want blank prompt rejection", err)
 	}
 }

--- a/pkg/captainconfig/config.go
+++ b/pkg/captainconfig/config.go
@@ -22,6 +22,66 @@ type Config struct {
 	AI          AIDefaults         `yaml:"ai"`
 	Prompts     PromptDefaults     `yaml:"prompts"`
 	Attachments AttachmentDefaults `yaml:"attachments"`
+	Sandbox     SandboxDefaults    `yaml:"sandbox,omitempty"`
+}
+
+// SandboxDefaults is the sandbox block of ~/.captain.yaml: a default selector
+// plus a name→config map, shaped like AIDefaults' DefaultProvider + Providers.
+type SandboxDefaults struct {
+	// Default is the sandbox applied when neither the CLI flag nor the prompt
+	// frontmatter selects one. Empty means none.
+	Default string `yaml:"default,omitempty"`
+	// Backends are the named sandbox configurations, keyed by the name written
+	// in `sandbox:` frontmatter or passed to --sandbox.
+	Backends map[string]SandboxBackend `yaml:"backends,omitempty"`
+}
+
+// IsZero lets yaml omit an empty sandbox block instead of writing `sandbox: {}`.
+func (s SandboxDefaults) IsZero() bool {
+	return s.Default == "" && len(s.Backends) == 0
+}
+
+// SandboxBackend is one named sandbox configuration. Kind selects the adapter;
+// everything else is the adapter's own settings, carried verbatim for it to
+// decode — this package deliberately knows nothing about what they mean.
+type SandboxBackend struct {
+	Kind    string         `yaml:"kind"`
+	Options map[string]any `yaml:",inline"`
+}
+
+// SandboxSelection is a resolved sandbox choice: the adapter kind, the
+// configured backend name it came from (empty when a bare kind was named), and
+// that backend's settings.
+type SandboxSelection struct {
+	Kind    registry.SandboxKind
+	Name    string
+	Options map[string]any
+}
+
+// Resolve maps a selector — a configured backend name, or a bare adapter kind —
+// to its selection. An empty selector falls back to Default, and an empty
+// Default to "none". A selector that names neither a configured backend nor a
+// kind is an error, as is a configured backend whose kind is unknown: silently
+// running unsandboxed is the failure this method exists to prevent.
+func (s SandboxDefaults) Resolve(selector string) (SandboxSelection, error) {
+	name := strings.TrimSpace(selector)
+	if name == "" {
+		name = strings.TrimSpace(s.Default)
+	}
+	if backend, ok := s.Backends[name]; ok {
+		kind, valid := registry.ParseSandboxKind(backend.Kind)
+		if !valid {
+			return SandboxSelection{}, fmt.Errorf("sandbox backend %q has invalid kind %q (valid: %s)",
+				name, backend.Kind, registry.SandboxKindList())
+		}
+		return SandboxSelection{Kind: kind, Name: name, Options: backend.Options}, nil
+	}
+	kind, ok := registry.ParseSandboxKind(name)
+	if !ok {
+		return SandboxSelection{}, fmt.Errorf("unknown sandbox %q: neither a configured backend nor an adapter kind (kinds: %s)",
+			name, registry.SandboxKindList())
+	}
+	return SandboxSelection{Kind: kind}, nil
 }
 
 type AttachmentDefaults struct {

--- a/pkg/captainconfig/config.go
+++ b/pkg/captainconfig/config.go
@@ -69,6 +69,13 @@ func (s SandboxDefaults) Resolve(selector string) (SandboxSelection, error) {
 		name = strings.TrimSpace(s.Default)
 	}
 	if backend, ok := s.Backends[name]; ok {
+		// An empty kind must not fall through ParseSandboxKind, where empty
+		// deliberately means "none": a backend whose kind is missing or
+		// misspelled would silently disable confinement.
+		if strings.TrimSpace(backend.Kind) == "" {
+			return SandboxSelection{}, fmt.Errorf("sandbox backend %q declares no kind (valid: %s)",
+				name, registry.SandboxKindList())
+		}
 		kind, valid := registry.ParseSandboxKind(backend.Kind)
 		if !valid {
 			return SandboxSelection{}, fmt.Errorf("sandbox backend %q has invalid kind %q (valid: %s)",

--- a/pkg/captainconfig/sandbox_test.go
+++ b/pkg/captainconfig/sandbox_test.go
@@ -1,0 +1,110 @@
+package captainconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/api/registry"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSandboxDefaults_Resolve(t *testing.T) {
+	defaults := SandboxDefaults{
+		Default: "prod-pool",
+		Backends: map[string]SandboxBackend{
+			"prod-pool":    {Kind: "git-agent", Options: map[string]any{"relay": "sync"}},
+			"local-docker": {Kind: "container"},
+			"broken":       {Kind: "warp-drive"},
+		},
+	}
+
+	t.Run("resolves a configured backend with its options", func(t *testing.T) {
+		got, err := defaults.Resolve("prod-pool")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Kind != registry.SandboxGitAgent || got.Name != "prod-pool" || got.Options["relay"] != "sync" {
+			t.Fatalf("selection = %+v", got)
+		}
+	})
+
+	t.Run("resolves a bare kind with no backend name", func(t *testing.T) {
+		got, err := defaults.Resolve("srt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Kind != registry.SandboxSRT || got.Name != "" || got.Options != nil {
+			t.Fatalf("selection = %+v", got)
+		}
+	})
+
+	t.Run("empty selector falls back to the default", func(t *testing.T) {
+		got, err := defaults.Resolve("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Name != "prod-pool" {
+			t.Fatalf("selection = %+v, want the configured default", got)
+		}
+	})
+
+	t.Run("empty selector and empty default resolve to none", func(t *testing.T) {
+		got, err := SandboxDefaults{}.Resolve("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Kind != registry.SandboxNone {
+			t.Fatalf("kind = %q, want none", got.Kind)
+		}
+	})
+
+	t.Run("unknown selector fails loud", func(t *testing.T) {
+		_, err := defaults.Resolve("nope")
+		if err == nil || !strings.Contains(err.Error(), `unknown sandbox "nope"`) {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("configured backend with an invalid kind fails loud", func(t *testing.T) {
+		_, err := defaults.Resolve("broken")
+		if err == nil || !strings.Contains(err.Error(), `invalid kind "warp-drive"`) {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+func TestSandboxBackend_InlineOptions(t *testing.T) {
+	raw := `
+default: prod-pool
+backends:
+  prod-pool:
+    kind: git-agent
+    relay: sync
+    mailbox: ~/.captain/sandbox/mailbox.git
+  local-docker:
+    kind: container
+    presets: [golang, git]
+`
+	var defaults SandboxDefaults
+	if err := yaml.Unmarshal([]byte(raw), &defaults); err != nil {
+		t.Fatal(err)
+	}
+	pool := defaults.Backends["prod-pool"]
+	if pool.Kind != "git-agent" || pool.Options["relay"] != "sync" {
+		t.Fatalf("prod-pool = %+v: kind-specific keys must land in Options verbatim", pool)
+	}
+	presets, ok := defaults.Backends["local-docker"].Options["presets"].([]any)
+	if !ok || len(presets) != 2 {
+		t.Fatalf("local-docker options = %+v", defaults.Backends["local-docker"].Options)
+	}
+}
+
+func TestSandboxDefaults_OmittedWhenEmpty(t *testing.T) {
+	encoded, err := yaml.Marshal(Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "sandbox") {
+		t.Fatalf("empty sandbox block must be omitted from the config file, got:\n%s", encoded)
+	}
+}

--- a/pkg/captainconfig/sandbox_test.go
+++ b/pkg/captainconfig/sandbox_test.go
@@ -108,3 +108,13 @@ func TestSandboxDefaults_OmittedWhenEmpty(t *testing.T) {
 		t.Fatalf("empty sandbox block must be omitted from the config file, got:\n%s", encoded)
 	}
 }
+
+func TestSandboxDefaults_MissingKindFailsLoud(t *testing.T) {
+	defaults := SandboxDefaults{Backends: map[string]SandboxBackend{
+		"pool": {Options: map[string]any{"image": "img"}}, // kind forgotten
+	}}
+	_, err := defaults.Resolve("pool")
+	if err == nil || !strings.Contains(err.Error(), `declares no kind`) {
+		t.Fatalf("err = %v, want missing-kind rejection (empty must NOT mean none)", err)
+	}
+}

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -106,17 +106,17 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 	// warn-and-continue policy for a broken config stays here (loadSavedConfig), so
 	// aiflags can hand the error back instead of swallowing it.
 	flags := o.ModelFlags
-	if sandbox.Kind == registry.SandboxSRT {
+	if forced := sandboxForcedMode(sandbox.Kind); forced != "" {
 		if value := strings.TrimSpace(flags.Mode); value != "" {
 			mode, ok := registry.ParseRuntimeMode(value)
 			if !ok {
 				return ai.Config{}, fmt.Errorf("invalid --mode %q (valid: %s)", value, registry.RuntimeModeList())
 			}
-			if mode != registry.ModeCLI {
-				return ai.Config{}, fmt.Errorf("sandbox %q requires CLI mode, but --mode is %q", sandbox.Kind, mode)
+			if mode != forced {
+				return ai.Config{}, fmt.Errorf("sandbox %q requires %s mode, but --mode is %q", sandbox.Kind, forced, mode)
 			}
 		}
-		flags.Mode = string(registry.ModeCLI)
+		flags.Mode = string(forced)
 	}
 	m, err := flags.ResolveWith(saved)
 	if err != nil {

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -54,7 +54,9 @@ type AIProviderOptions struct {
 }
 
 // SandboxSelector normalizes --sandbox. The flag was previously a boolean that
-// toggled sandbox-runtime, so the boolean spellings keep their old meaning.
+// toggled sandbox-runtime; the explicit boolean spellings (--sandbox=true,
+// --sandbox=false) keep their old meaning. A bare valueless --sandbox no
+// longer parses — the flag is a string selector now, so a value is required.
 func (o AIProviderOptions) SandboxSelector() string {
 	value := strings.TrimSpace(o.Sandbox)
 	switch strings.ToLower(value) {

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -123,13 +123,14 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 		return ai.Config{}, err
 	}
 	return ai.Config{
-		Model:        m,
-		Budget:       api.Budget{Cost: budget},
-		APIKey:       o.APIKey,
-		APIURL:       strings.TrimSpace(o.APIURL),
-		Sandbox:      sandbox.Kind == registry.SandboxSRT,
-		NoCache:      o.NoCache || saved.NoCache,
-		SchemaRepair: schemaRepairConfig(savedCfg.Prompts.SchemaRepair),
+		Model:            m,
+		Budget:           api.Budget{Cost: budget},
+		APIKey:           o.APIKey,
+		APIURL:           strings.TrimSpace(o.APIURL),
+		Sandbox:          sandbox.Kind == registry.SandboxSRT,
+		SandboxSelection: sandboxSelectionConfig(sandbox),
+		NoCache:          o.NoCache || saved.NoCache,
+		SchemaRepair:     schemaRepairConfig(savedCfg.Prompts.SchemaRepair),
 	}, nil
 }
 

--- a/pkg/cli/ai.go
+++ b/pkg/cli/ai.go
@@ -50,7 +50,20 @@ type AIProviderOptions struct {
 	APIKey  string `flag:"api-key" help:"API key (env: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, DEEPSEEK_API_KEY)"`
 	APIURL  string `flag:"api-url" help:"Override the backend endpoint, e.g. a 'captain ai mock' URL. Required for codex-cli, which ignores OPENAI_BASE_URL when a ChatGPT credential is stored"`
 	Budget  string `flag:"budget" help:"Max spend in USD, 0=unlimited" default:"0"`
-	Sandbox bool   `flag:"sandbox" help:"Run the local agent CLI in an OS-level sandbox"`
+	Sandbox string `flag:"sandbox" help:"Sandbox for the run: an adapter kind (none|srt|container|git-agent) or a backend configured under sandbox.backends in ~/.captain.yaml"`
+}
+
+// SandboxSelector normalizes --sandbox. The flag was previously a boolean that
+// toggled sandbox-runtime, so the boolean spellings keep their old meaning.
+func (o AIProviderOptions) SandboxSelector() string {
+	value := strings.TrimSpace(o.Sandbox)
+	switch strings.ToLower(value) {
+	case "true", "1", "yes":
+		return string(registry.SandboxSRT)
+	case "false", "0", "no":
+		return string(registry.SandboxNone)
+	}
+	return value
 }
 
 // BudgetUSD parses --budget, failing loud on malformed input.
@@ -82,18 +95,25 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 		budget = saved.BudgetUSD
 	}
 
+	// Sandbox precedence here is flag > global default > none: this path has no
+	// prompt file, so there is no frontmatter layer (that one is overlayCLI's).
+	sandbox, err := resolveSandboxSelection(o.SandboxSelector(), nil, savedCfg.Sandbox)
+	if err != nil {
+		return ai.Config{}, err
+	}
+
 	// One resolve: flags → Model → saved per-provider defaults → catalog. The
 	// warn-and-continue policy for a broken config stays here (loadSavedConfig), so
 	// aiflags can hand the error back instead of swallowing it.
 	flags := o.ModelFlags
-	if o.Sandbox {
+	if sandbox.Kind == registry.SandboxSRT {
 		if value := strings.TrimSpace(flags.Mode); value != "" {
 			mode, ok := registry.ParseRuntimeMode(value)
 			if !ok {
 				return ai.Config{}, fmt.Errorf("invalid --mode %q (valid: %s)", value, registry.RuntimeModeList())
 			}
 			if mode != registry.ModeCLI {
-				return ai.Config{}, fmt.Errorf("--sandbox requires CLI mode, but --mode is %q", mode)
+				return ai.Config{}, fmt.Errorf("sandbox %q requires CLI mode, but --mode is %q", sandbox.Kind, mode)
 			}
 		}
 		flags.Mode = string(registry.ModeCLI)
@@ -107,7 +127,7 @@ func (o AIProviderOptions) ToConfig() (ai.Config, error) {
 		Budget:       api.Budget{Cost: budget},
 		APIKey:       o.APIKey,
 		APIURL:       strings.TrimSpace(o.APIURL),
-		Sandbox:      o.Sandbox,
+		Sandbox:      sandbox.Kind == registry.SandboxSRT,
 		NoCache:      o.NoCache || saved.NoCache,
 		SchemaRepair: schemaRepairConfig(savedCfg.Prompts.SchemaRepair),
 	}, nil

--- a/pkg/cli/ai_prompt_file.go
+++ b/pkg/cli/ai_prompt_file.go
@@ -198,10 +198,11 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	cfg.Budget = req.Budget
 	cfg.APIKey = o.APIKey
 	cfg.APIURL = firstNonEmpty(strings.TrimSpace(o.APIURL), baseCfg.APIURL)
-	cfg.Sandbox = sandbox.Kind == registry.SandboxSRT || baseCfg.Sandbox
-	if selection := sandboxSelectionConfig(sandbox); selection != nil {
-		cfg.SandboxSelection = selection
-	}
+	// The overlay's resolution saw every layer (flag > frontmatter > default),
+	// so it overwrites rather than ORs with baseCfg: an explicit "none" must be
+	// able to turn an inherited srt selection OFF.
+	cfg.Sandbox = sandbox.Kind == registry.SandboxSRT
+	cfg.SandboxSelection = sandboxSelectionConfig(sandbox)
 	cfg.NoCache = req.NoCache
 	return req, cfg, nil
 }

--- a/pkg/cli/ai_prompt_file.go
+++ b/pkg/cli/ai_prompt_file.go
@@ -199,6 +199,9 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	cfg.APIKey = o.APIKey
 	cfg.APIURL = firstNonEmpty(strings.TrimSpace(o.APIURL), baseCfg.APIURL)
 	cfg.Sandbox = sandbox.Kind == registry.SandboxSRT || baseCfg.Sandbox
+	if selection := sandboxSelectionConfig(sandbox); selection != nil {
+		cfg.SandboxSelection = selection
+	}
 	cfg.NoCache = req.NoCache
 	return req, cfg, nil
 }

--- a/pkg/cli/ai_prompt_file.go
+++ b/pkg/cli/ai_prompt_file.go
@@ -108,11 +108,11 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 	if err != nil {
 		return base, baseCfg, err
 	}
-	if sandbox.Kind == registry.SandboxSRT {
-		if requestedMode != "" && requestedMode != registry.ModeCLI {
-			return base, baseCfg, fmt.Errorf("sandbox %q requires CLI mode, but --mode is %q", sandbox.Kind, requestedMode)
+	if forced := sandboxForcedMode(sandbox.Kind); forced != "" {
+		if requestedMode != "" && requestedMode != forced {
+			return base, baseCfg, fmt.Errorf("sandbox %q requires %s mode, but --mode is %q", sandbox.Kind, forced, requestedMode)
 		}
-		requestedMode = registry.ModeCLI
+		requestedMode = forced
 	}
 	if requestedMode != "" {
 		m.Mode = ""

--- a/pkg/cli/ai_prompt_file.go
+++ b/pkg/cli/ai_prompt_file.go
@@ -103,9 +103,14 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 			return base, baseCfg, fmt.Errorf("invalid --mode %q (valid: %s)", o.Mode, registry.RuntimeModeList())
 		}
 	}
-	if o.Sandbox {
+	// Sandbox precedence: --sandbox > frontmatter (base.Sandbox) > global default.
+	sandbox, err := resolveSandboxSelection(o.SandboxSelector(), base.Sandbox, loadSavedConfig().Sandbox)
+	if err != nil {
+		return base, baseCfg, err
+	}
+	if sandbox.Kind == registry.SandboxSRT {
 		if requestedMode != "" && requestedMode != registry.ModeCLI {
-			return base, baseCfg, fmt.Errorf("--sandbox requires CLI mode, but --mode is %q", requestedMode)
+			return base, baseCfg, fmt.Errorf("sandbox %q requires CLI mode, but --mode is %q", sandbox.Kind, requestedMode)
 		}
 		requestedMode = registry.ModeCLI
 	}
@@ -181,13 +186,19 @@ func overlayCLI(base ai.Request, baseCfg ai.Config, o AIPromptOptions) (ai.Reque
 		req.SessionID = o.Resume
 	}
 
+	// Record the winning sandbox on the request when the flag overrode it, so the
+	// serialized spec carries the choice the run was actually made with.
+	if selector := o.SandboxSelector(); selector != "" {
+		req.Sandbox = &api.SandboxRef{Backend: selector}
+	}
+
 	// Config mirrors the resolved model + budget; runtime-only knobs from CLI+saved.
 	cfg := baseCfg
 	cfg.Model = req.Model
 	cfg.Budget = req.Budget
 	cfg.APIKey = o.APIKey
 	cfg.APIURL = firstNonEmpty(strings.TrimSpace(o.APIURL), baseCfg.APIURL)
-	cfg.Sandbox = o.Sandbox || baseCfg.Sandbox
+	cfg.Sandbox = sandbox.Kind == registry.SandboxSRT || baseCfg.Sandbox
 	cfg.NoCache = req.NoCache
 	return req, cfg, nil
 }

--- a/pkg/cli/ai_prompt_file_test.go
+++ b/pkg/cli/ai_prompt_file_test.go
@@ -150,7 +150,7 @@ func TestOverlayCLI_CLIOverridesFrontmatter(t *testing.T) {
 func TestOverlayCLI_Sandbox(t *testing.T) {
 	for _, tt := range []struct{ name, mode, wantErr string }{
 		{name: "selects CLI for frontmatter model"},
-		{name: "rejects explicit API mode", mode: "api", wantErr: "requires CLI mode"},
+		{name: "rejects explicit API mode", mode: "api", wantErr: "requires cli mode"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			isolateSavedAI(t)

--- a/pkg/cli/ai_prompt_file_test.go
+++ b/pkg/cli/ai_prompt_file_test.go
@@ -150,13 +150,14 @@ func TestOverlayCLI_CLIOverridesFrontmatter(t *testing.T) {
 func TestOverlayCLI_Sandbox(t *testing.T) {
 	for _, tt := range []struct{ name, mode, wantErr string }{
 		{name: "selects CLI for frontmatter model"},
-		{name: "rejects explicit API mode", mode: "api", wantErr: "--sandbox requires CLI mode"},
+		{name: "rejects explicit API mode", mode: "api", wantErr: "requires CLI mode"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			isolateSavedAI(t)
 			base := baseFileReq()
 			base.Model.Backend = api.BackendAnthropic
-			opts := AIPromptOptions{AIRuntimeOptions: AIRuntimeOptions{AIProviderOptions: AIProviderOptions{Sandbox: true}}}
+			// The legacy boolean spelling must keep meaning srt.
+			opts := AIPromptOptions{AIRuntimeOptions: AIRuntimeOptions{AIProviderOptions: AIProviderOptions{Sandbox: "true"}}}
 			opts.Mode = tt.mode
 			req, cfg, err := overlayCLI(base, ai.Config{}, opts)
 			if tt.wantErr != "" {

--- a/pkg/cli/ai_prompt_file_test.go
+++ b/pkg/cli/ai_prompt_file_test.go
@@ -176,6 +176,26 @@ func TestOverlayCLI_Sandbox(t *testing.T) {
 	}
 }
 
+// An explicit --sandbox=none must turn OFF a sandbox the base config carried:
+// the overlay resolved every layer, so it overwrites instead of ORing.
+func TestOverlayCLI_SandboxNoneClearsInherited(t *testing.T) {
+	isolateSavedAI(t)
+	base := baseFileReq()
+	baseCfg := ai.Config{Sandbox: true, SandboxSelection: &api.SandboxConfig{Kind: api.SandboxSRT}}
+	opts := AIPromptOptions{AIRuntimeOptions: AIRuntimeOptions{AIProviderOptions: AIProviderOptions{Sandbox: "none"}}}
+
+	_, cfg, err := overlayCLI(base, baseCfg, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sandbox || cfg.SandboxSelection != nil {
+		t.Fatalf("sandbox=%v selection=%v, want both cleared by the explicit none", cfg.Sandbox, cfg.SandboxSelection)
+	}
+	if resolved := cfg.ResolvedSandbox(); resolved != nil {
+		t.Fatalf("ResolvedSandbox = %+v, want nil", resolved)
+	}
+}
+
 // --api-url is what points a run at a `captain ai mock` endpoint, so it has to
 // survive the overlay; a prompt file may pin its own endpoint, and the flag wins.
 func TestOverlayCLI_APIURLFlagBeatsFrontmatter(t *testing.T) {

--- a/pkg/cli/ai_sandbox.go
+++ b/pkg/cli/ai_sandbox.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/api/registry"
+	"github.com/flanksource/captain/pkg/captainconfig"
+)
+
+// resolveSandboxSelection applies the sandbox precedence chain — CLI flag >
+// prompt frontmatter > global default > none — and resolves the winner against
+// the backends configured in ~/.captain.yaml.
+//
+// Kinds whose execution seam is not wired yet fail loud here rather than
+// resolving successfully and then silently running unsandboxed; each adapter
+// removes itself from the guard when its wiring lands.
+func resolveSandboxSelection(flagSelector string, ref *api.SandboxRef, defaults captainconfig.SandboxDefaults) (captainconfig.SandboxSelection, error) {
+	selector := strings.TrimSpace(flagSelector)
+	if selector == "" && ref != nil {
+		selector = strings.TrimSpace(ref.Backend)
+	}
+	selection, err := defaults.Resolve(selector)
+	if err != nil {
+		return captainconfig.SandboxSelection{}, err
+	}
+	switch selection.Kind {
+	case registry.SandboxNone, registry.SandboxSRT:
+		return selection, nil
+	default:
+		return captainconfig.SandboxSelection{}, fmt.Errorf(
+			"sandbox kind %q is not wired to execution yet (supported today: %s, %s)",
+			selection.Kind, registry.SandboxNone, registry.SandboxSRT)
+	}
+}

--- a/pkg/cli/ai_sandbox.go
+++ b/pkg/cli/ai_sandbox.go
@@ -34,3 +34,13 @@ func resolveSandboxSelection(flagSelector string, ref *api.SandboxRef, defaults 
 			selection.Kind, registry.SandboxNone, registry.SandboxSRT)
 	}
 }
+
+// sandboxSelectionConfig projects a resolved selection onto the runtime
+// config. "none" stays nil, so an unsandboxed run carries no selection at all
+// and the exec seam's nil check keeps its meaning.
+func sandboxSelectionConfig(selection captainconfig.SandboxSelection) *api.SandboxConfig {
+	if selection.Kind == registry.SandboxNone {
+		return nil
+	}
+	return &api.SandboxConfig{Kind: selection.Kind, Name: selection.Name, Options: selection.Options}
+}

--- a/pkg/cli/ai_sandbox.go
+++ b/pkg/cli/ai_sandbox.go
@@ -26,13 +26,27 @@ func resolveSandboxSelection(flagSelector string, ref *api.SandboxRef, defaults 
 		return captainconfig.SandboxSelection{}, err
 	}
 	switch selection.Kind {
-	case registry.SandboxNone, registry.SandboxSRT:
+	case registry.SandboxNone, registry.SandboxSRT, registry.SandboxContainer:
 		return selection, nil
 	default:
 		return captainconfig.SandboxSelection{}, fmt.Errorf(
-			"sandbox kind %q is not wired to execution yet (supported today: %s, %s)",
-			selection.Kind, registry.SandboxNone, registry.SandboxSRT)
+			"sandbox kind %q is not wired to execution yet (supported today: %s, %s, %s)",
+			selection.Kind, registry.SandboxNone, registry.SandboxSRT, registry.SandboxContainer)
 	}
+}
+
+// sandboxForcedMode returns the single runtime mode a sandbox kind can serve,
+// or "" when the kind serves several (or is none). Argv-wrapping adapters are
+// CLI-only, so selecting one forces CLI mode the way --sandbox always has.
+func sandboxForcedMode(kind registry.SandboxKind) registry.RuntimeMode {
+	if kind == registry.SandboxNone {
+		return ""
+	}
+	descriptor, ok := registry.SandboxFor(kind)
+	if !ok || len(descriptor.Modes) != 1 {
+		return ""
+	}
+	return descriptor.Modes[0]
 }
 
 // sandboxSelectionConfig projects a resolved selection onto the runtime

--- a/pkg/cli/ai_sandbox_test.go
+++ b/pkg/cli/ai_sandbox_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/api/registry"
+	"github.com/flanksource/captain/pkg/captainconfig"
+)
+
+func TestResolveSandboxSelection_Precedence(t *testing.T) {
+	defaults := captainconfig.SandboxDefaults{
+		Default: "srt",
+		Backends: map[string]captainconfig.SandboxBackend{
+			"pool": {Kind: "srt", Options: map[string]any{"tier": "pool"}},
+		},
+	}
+
+	t.Run("flag beats frontmatter", func(t *testing.T) {
+		got, err := resolveSandboxSelection("none", &api.SandboxRef{Backend: "pool"}, defaults)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Kind != registry.SandboxNone {
+			t.Fatalf("kind = %q, want the flag's", got.Kind)
+		}
+	})
+
+	t.Run("frontmatter beats the global default", func(t *testing.T) {
+		got, err := resolveSandboxSelection("", &api.SandboxRef{Backend: "pool"}, defaults)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Name != "pool" {
+			t.Fatalf("selection = %+v, want the frontmatter backend", got)
+		}
+	})
+
+	t.Run("global default applies when nothing else selects", func(t *testing.T) {
+		got, err := resolveSandboxSelection("", nil, defaults)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Kind != registry.SandboxSRT {
+			t.Fatalf("kind = %q, want the default's", got.Kind)
+		}
+	})
+
+	t.Run("everything empty resolves to none", func(t *testing.T) {
+		got, err := resolveSandboxSelection("", nil, captainconfig.SandboxDefaults{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Kind != registry.SandboxNone {
+			t.Fatalf("kind = %q, want none", got.Kind)
+		}
+	})
+
+	t.Run("an unwired kind fails loud instead of running unsandboxed", func(t *testing.T) {
+		_, err := resolveSandboxSelection("git-agent", nil, defaults)
+		if err == nil || !strings.Contains(err.Error(), "not wired to execution yet") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("an unknown selector fails loud", func(t *testing.T) {
+		_, err := resolveSandboxSelection("nope", nil, defaults)
+		if err == nil || !strings.Contains(err.Error(), `unknown sandbox "nope"`) {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+func TestSandboxSelector_LegacySpellings(t *testing.T) {
+	for flag, want := range map[string]string{
+		"true": "srt", "1": "srt", "yes": "srt",
+		"false": "none", "0": "none", "no": "none",
+		"prod-pool": "prod-pool", "": "",
+	} {
+		if got := (AIProviderOptions{Sandbox: flag}).SandboxSelector(); got != want {
+			t.Errorf("SandboxSelector(%q) = %q, want %q", flag, got, want)
+		}
+	}
+}

--- a/pkg/cli/ai_sandbox_test.go
+++ b/pkg/cli/ai_sandbox_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/api/registry"
 	"github.com/flanksource/captain/pkg/captainconfig"
@@ -70,6 +71,29 @@ func TestResolveSandboxSelection_Precedence(t *testing.T) {
 			t.Fatalf("err = %v", err)
 		}
 	})
+}
+
+// The prompt run/render action path decodes flags from a string map; --mode
+// must survive that decoding, or an explicit "--mode api --sandbox container"
+// silently resolves CLI mode instead of being rejected as a contradiction.
+func TestActionFlags_ModeSandboxConflictRejected(t *testing.T) {
+	isolateSavedAI(t)
+	opts, err := actionFlagsToOptions(map[string]string{
+		"model":   "gemini-3.5-flash",
+		"mode":    "api",
+		"sandbox": "container",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Mode != "api" {
+		t.Fatalf("Mode = %q: --mode must survive actionFlagsToOptions", opts.Mode)
+	}
+
+	_, _, err = overlayCLI(baseFileReq(), ai.Config{}, opts)
+	if err == nil || !strings.Contains(err.Error(), "requires cli mode") {
+		t.Fatalf("err = %v, want the API-mode × container-sandbox contradiction rejected", err)
+	}
 }
 
 func TestSandboxSelector_LegacySpellings(t *testing.T) {

--- a/pkg/cli/ai_test.go
+++ b/pkg/cli/ai_test.go
@@ -271,7 +271,7 @@ func TestAIProviderOptions_ToConfig_Sandbox(t *testing.T) {
 	}{
 		{name: "selects CLI without changing model", flags: aiflags.ModelFlags{Model: "claude-sonnet-5"}, wantName: "claude-sonnet-5", backends: []api.Backend{api.BackendClaudeCLI}},
 		{name: "rejects explicit API backend", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"}, wantErr: "contradicts backend"},
-		{name: "rejects explicit API mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"}, wantErr: "requires CLI mode"},
+		{name: "rejects explicit API mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"}, wantErr: "requires cli mode"},
 		{name: "overrides saved runtime", saved: "ai:\n  model: opus\n  backend: claude-agent\n", backends: []api.Backend{api.BackendClaudeCLI}},
 		{name: "resolves fallbacks in CLI mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5,gpt-5.5", Fallback: []string{"gemini-3.5-flash"}}, backends: []api.Backend{api.BackendClaudeCLI, api.BackendCodexCLI, api.BackendGeminiCLI}},
 	}

--- a/pkg/cli/ai_test.go
+++ b/pkg/cli/ai_test.go
@@ -271,7 +271,7 @@ func TestAIProviderOptions_ToConfig_Sandbox(t *testing.T) {
 	}{
 		{name: "selects CLI without changing model", flags: aiflags.ModelFlags{Model: "claude-sonnet-5"}, wantName: "claude-sonnet-5", backends: []api.Backend{api.BackendClaudeCLI}},
 		{name: "rejects explicit API backend", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Backend: "anthropic"}, wantErr: "contradicts backend"},
-		{name: "rejects explicit API mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"}, wantErr: "--sandbox requires CLI mode"},
+		{name: "rejects explicit API mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5", Mode: "api"}, wantErr: "requires CLI mode"},
 		{name: "overrides saved runtime", saved: "ai:\n  model: opus\n  backend: claude-agent\n", backends: []api.Backend{api.BackendClaudeCLI}},
 		{name: "resolves fallbacks in CLI mode", flags: aiflags.ModelFlags{Model: "claude-sonnet-5,gpt-5.5", Fallback: []string{"gemini-3.5-flash"}}, backends: []api.Backend{api.BackendClaudeCLI, api.BackendCodexCLI, api.BackendGeminiCLI}},
 	}
@@ -282,7 +282,7 @@ func TestAIProviderOptions_ToConfig_Sandbox(t *testing.T) {
 			} else {
 				seedSavedAI(t, tt.saved)
 			}
-			cfg, err := (AIProviderOptions{ModelFlags: tt.flags, Sandbox: true}).ToConfig()
+			cfg, err := (AIProviderOptions{ModelFlags: tt.flags, Sandbox: "srt"}).ToConfig()
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("err = %v, want %q", err, tt.wantErr)

--- a/pkg/cli/prompt_run.go
+++ b/pkg/cli/prompt_run.go
@@ -154,7 +154,7 @@ func executeSyncRunSingleDirect(ctx context.Context, t *task.Task, rendered Prom
 	// provider call below never constructs verify/commit/judge hooks, so taking
 	// it would complete the run with every declared check silently skipped.
 	if workflowConfigured(rendered.Input.Workflow) {
-		return executeSyncWorkflowRun(t, rendered, binding)
+		return executeSyncWorkflowRun(t, rendered, opts.NoStream, binding)
 	}
 	out, err := executePromptRequestFunc(ctx, rendered.Input, rendered.Config, runtimeTimeout(rendered.Input.Budget.Timeout), opts.NoStream)
 	if err != nil {
@@ -185,14 +185,21 @@ func executeSyncRunSingleDirect(ctx context.Context, t *task.Task, rendered Prom
 // stream/runner machinery the server path uses, so hooks behave identically on
 // both surfaces. A run whose verification fails returns an error: a declared
 // check that does not pass must fail the command, not decorate its output.
-func executeSyncWorkflowRun(t *task.Task, rendered PromptRenderResult, binding *promptSessionBinding) (PromptRunResult, error) {
+func executeSyncWorkflowRun(t *task.Task, rendered PromptRenderResult, noStream bool, binding *promptSessionBinding) (PromptRunResult, error) {
 	runID := uuid.NewString()
 	stream := promptRuns.create(runID)
 	// Nothing subscribes to a synchronous run's stream, and the broker's prune
 	// loop only runs under `captain serve` — deregister so embedders don't
 	// accumulate finished runs.
 	defer promptRuns.remove(runID)
-	summary, err := runPromptStream(t, rendered, runtimeTimeout(rendered.Input.Budget.Timeout), runID, stream, binding)
+	timeout := runtimeTimeout(rendered.Input.Budget.Timeout)
+	var summary PromptRunSummary
+	var err error
+	if noStream {
+		summary, err = runPromptBufferedWorkflow(t, rendered, timeout, runID, stream, binding)
+	} else {
+		summary, err = runPromptStream(t, rendered, timeout, runID, stream, binding)
+	}
 	if err != nil {
 		return PromptRunResult{}, err
 	}

--- a/pkg/cli/prompt_run.go
+++ b/pkg/cli/prompt_run.go
@@ -29,6 +29,11 @@ type PromptRunSummary struct {
 	Duration     string  `json:"duration,omitempty"`
 	Success      bool    `json:"success"`
 	Error        string  `json:"error,omitempty"`
+	// Text and StructuredOutput carry the final response so a synchronous CLI
+	// run routed through the stream path can return it; stream consumers read
+	// the same values from the frames.
+	Text             string         `json:"text,omitempty"`
+	StructuredOutput map[string]any `json:"structuredOutput,omitempty"`
 }
 
 // runPromptAction renders the prompt (from an id | discovered name | .prompt
@@ -139,12 +144,18 @@ func executeSyncRunSingle(ctx context.Context, rendered PromptRenderResult, opts
 	)
 	run := group.Add("execute "+rendered.Backend+":"+rendered.Model, func(_ flanksourceContext.Context, t *task.Task) (PromptRunResult, error) {
 		taskCtx := ai.ContextWithLogger(t.Context(), t)
-		return executeSyncRunSingleDirect(taskCtx, rendered, opts, nil)
+		return executeSyncRunSingleDirect(taskCtx, t, rendered, opts, nil)
 	}, task.WithModel(rendered.Model), task.WithPrompt(rendered.Input.Prompt.User))
 	return run.GetResult()
 }
 
-func executeSyncRunSingleDirect(ctx context.Context, rendered PromptRenderResult, opts AIPromptOptions, binding *promptSessionBinding) (PromptRunResult, error) {
+func executeSyncRunSingleDirect(ctx context.Context, t *task.Task, rendered PromptRenderResult, opts AIPromptOptions, binding *promptSessionBinding) (PromptRunResult, error) {
+	// A configured workflow must go through the runner-backed path: the direct
+	// provider call below never constructs verify/commit/judge hooks, so taking
+	// it would complete the run with every declared check silently skipped.
+	if workflowConfigured(rendered.Input.Workflow) {
+		return executeSyncWorkflowRun(t, rendered, binding)
+	}
 	out, err := executePromptRequestFunc(ctx, rendered.Input, rendered.Config, runtimeTimeout(rendered.Input.Budget.Timeout), opts.NoStream)
 	if err != nil {
 		return PromptRunResult{}, err
@@ -167,6 +178,35 @@ func executeSyncRunSingleDirect(ctx context.Context, rendered PromptRenderResult
 		OutputTokens:     r.Output,
 		CostUSD:          r.CostUSD,
 		Duration:         r.Duration,
+	}, nil
+}
+
+// executeSyncWorkflowRun executes a workflow-bearing CLI run through the same
+// stream/runner machinery the server path uses, so hooks behave identically on
+// both surfaces. A run whose verification fails returns an error: a declared
+// check that does not pass must fail the command, not decorate its output.
+func executeSyncWorkflowRun(t *task.Task, rendered PromptRenderResult, binding *promptSessionBinding) (PromptRunResult, error) {
+	runID := uuid.NewString()
+	stream := promptRuns.create(runID)
+	summary, err := runPromptStream(t, rendered, runtimeTimeout(rendered.Input.Budget.Timeout), runID, stream, binding)
+	if err != nil {
+		return PromptRunResult{}, err
+	}
+	if !summary.Success {
+		return PromptRunResult{}, errors.New(firstNonEmpty(summary.Error, "verification failed"))
+	}
+	return PromptRunResult{
+		Status:           "completed",
+		RunID:            summary.RunID,
+		Model:            summary.Model,
+		Backend:          summary.Backend,
+		Text:             summary.Text,
+		StructuredOutput: summary.StructuredOutput,
+		SessionID:        summary.SessionID,
+		InputTokens:      summary.InputTokens,
+		OutputTokens:     summary.OutputTokens,
+		CostUSD:          summary.CostUSD,
+		Duration:         summary.Duration,
 	}, nil
 }
 
@@ -244,7 +284,7 @@ func executeSyncBatch(ctx context.Context, rendered PromptRenderResult, opts AIP
 			taskCtx := ai.ContextWithLogger(t.Context(), t)
 			binding := promptBinding(batch, i)
 			updatePromptSessionLifecycle(context.WithoutCancel(taskCtx), binding.SessionID, database.SessionLifecycleRunning, "")
-			result, err := executeSyncRunSingleDirect(taskCtx, variant, variantOpts, binding)
+			result, err := executeSyncRunSingleDirect(taskCtx, t, variant, variantOpts, binding)
 			item := PromptRunItem{
 				RunID:    binding.SessionID.String(),
 				Selector: selector,

--- a/pkg/cli/prompt_run.go
+++ b/pkg/cli/prompt_run.go
@@ -188,6 +188,10 @@ func executeSyncRunSingleDirect(ctx context.Context, t *task.Task, rendered Prom
 func executeSyncWorkflowRun(t *task.Task, rendered PromptRenderResult, binding *promptSessionBinding) (PromptRunResult, error) {
 	runID := uuid.NewString()
 	stream := promptRuns.create(runID)
+	// Nothing subscribes to a synchronous run's stream, and the broker's prune
+	// loop only runs under `captain serve` — deregister so embedders don't
+	// accumulate finished runs.
+	defer promptRuns.remove(runID)
 	summary, err := runPromptStream(t, rendered, runtimeTimeout(rendered.Input.Budget.Timeout), runID, stream, binding)
 	if err != nil {
 		return PromptRunResult{}, err

--- a/pkg/cli/prompt_run_live.go
+++ b/pkg/cli/prompt_run_live.go
@@ -36,6 +36,11 @@ func runPromptStream(t *task.Task, rendered PromptRenderResult, timeout time.Dur
 		return failRun(t, stream, fmt.Errorf("backend %s does not support streaming", rendered.Backend))
 	}
 
+	judgeHooks, err := verify.PromptHooksForWorkflow(req.Workflow, p)
+	if err != nil {
+		return failRun(t, stream, err)
+	}
+
 	start := time.Now()
 	acc := newPromptEventAccumulator(stream.publish, t, rendered.Model, rendered.Backend)
 	acc.cwd = req.Cwd()
@@ -45,7 +50,7 @@ func runPromptStream(t *task.Task, rendered PromptRenderResult, timeout time.Dur
 		Request:  req,
 		// Commit hooks lead so that at PhaseRun they squash before any teardown
 		// hook (a worktree merge) runs and takes the result.
-		Hooks:         append(commit.HooksForWorkflow(req.Workflow), verify.HooksForWorkflow(req.Workflow)...),
+		Hooks:         append(append(commit.HooksForWorkflow(req.Workflow), verify.HooksForWorkflow(req.Workflow)...), judgeHooks...),
 		MaxIterations: verify.MaxIterationsForWorkflow(req.Workflow),
 		Repo:          req.Cwd(),
 		Cwd:           req.Cwd(),

--- a/pkg/cli/prompt_run_live.go
+++ b/pkg/cli/prompt_run_live.go
@@ -95,15 +95,17 @@ func runPromptStream(t *task.Task, rendered PromptRenderResult, timeout time.Dur
 		summarySessionID = binding.SessionID.String()
 	}
 	summary := PromptRunSummary{
-		RunID:        runID,
-		SessionID:    summarySessionID,
-		Model:        model,
-		Backend:      rendered.Backend,
-		InputTokens:  usage.InputTokens,
-		OutputTokens: usage.OutputTokens,
-		CostUSD:      cost,
-		Duration:     time.Since(start).Round(time.Millisecond).String(),
-		Success:      passed,
+		RunID:            runID,
+		SessionID:        summarySessionID,
+		Model:            model,
+		Backend:          rendered.Backend,
+		InputTokens:      usage.InputTokens,
+		OutputTokens:     usage.OutputTokens,
+		CostUSD:          cost,
+		Duration:         time.Since(start).Round(time.Millisecond).String(),
+		Success:          passed,
+		Text:             resultText,
+		StructuredOutput: structuredOutput,
 	}
 	if !passed {
 		summary.Error = verifyReason(runResult.Verdicts)

--- a/pkg/cli/prompt_run_live.go
+++ b/pkg/cli/prompt_run_live.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -14,6 +15,14 @@ import (
 )
 
 func runPromptStream(t *task.Task, rendered PromptRenderResult, timeout time.Duration, runID string, stream *runStream, binding *promptSessionBinding) (PromptRunSummary, error) {
+	return runPromptWorkflow(t, rendered, timeout, runID, stream, binding, false)
+}
+
+func runPromptBufferedWorkflow(t *task.Task, rendered PromptRenderResult, timeout time.Duration, runID string, stream *runStream, binding *promptSessionBinding) (PromptRunSummary, error) {
+	return runPromptWorkflow(t, rendered, timeout, runID, stream, binding, true)
+}
+
+func runPromptWorkflow(t *task.Task, rendered PromptRenderResult, timeout time.Duration, runID string, stream *runStream, binding *promptSessionBinding, noStream bool) (PromptRunSummary, error) {
 	ctx, cancel := runContext(t.Context(), rendered.Input, timeout)
 	stream.setCancel(cancel)
 	defer cancel()
@@ -31,9 +40,9 @@ func runPromptStream(t *task.Task, rendered PromptRenderResult, timeout time.Dur
 	defer cleanup()
 	defer closeProvider(p)
 
-	streamer, ok := p.(ai.StreamingProvider)
-	if !ok && !req.IsVerifyOnly() {
-		return failRun(t, stream, fmt.Errorf("backend %s does not support streaming", rendered.Backend))
+	streamer, err := workflowRunnerProvider(p, noStream, req.IsVerifyOnly())
+	if err != nil {
+		return failRun(t, stream, err)
 	}
 
 	judgeHooks, err := verify.PromptHooksForWorkflow(req.Workflow, p)
@@ -113,6 +122,70 @@ func runPromptStream(t *task.Task, rendered PromptRenderResult, timeout time.Dur
 	stream.complete(summary)
 	t.Success()
 	return summary, nil
+}
+
+func workflowRunnerProvider(provider ai.Provider, noStream, verifyOnly bool) (ai.StreamingProvider, error) {
+	if noStream {
+		return bufferedWorkflowProvider{Provider: provider}, nil
+	}
+	streamer, ok := provider.(ai.StreamingProvider)
+	if !ok && !verifyOnly {
+		return nil, fmt.Errorf("backend %s does not support streaming", provider.GetBackend())
+	}
+	return streamer, nil
+}
+
+// bufferedWorkflowProvider preserves the agent runner's event contract while
+// forcing generation through Provider.Execute. It emits only completed response
+// events, so --no-stream never invokes an underlying ExecuteStream method.
+type bufferedWorkflowProvider struct {
+	ai.Provider
+}
+
+func (p bufferedWorkflowProvider) ExecuteStream(ctx context.Context, req ai.Request) (<-chan ai.Event, error) {
+	resp, err := p.Execute(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, errors.New("buffered workflow provider returned a nil response")
+	}
+	structured, err := bufferedStructuredData(resp.StructuredData)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make(chan ai.Event, 3)
+	if resp.Workspace != nil && resp.Workspace.SessionID != "" {
+		events <- ai.Event{Kind: ai.EventSystem, SessionID: resp.Workspace.SessionID, Model: resp.Model}
+	}
+	if resp.Text != "" {
+		events <- ai.Event{Kind: ai.EventText, Text: resp.Text, Model: resp.Model}
+	}
+	usage := resp.Usage
+	events <- ai.Event{
+		Kind: ai.EventResult, Success: true, Model: resp.Model, Usage: &usage,
+		CostUSD: resp.CostUSD, StructuredData: structured, ToolApproval: resp.ToolApproval,
+	}
+	close(events)
+	return events, nil
+}
+
+func bufferedStructuredData(value any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if raw, ok := value.(json.RawMessage); ok {
+		return raw, nil
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode buffered workflow structured output: %w", err)
+	}
+	if string(raw) == "null" {
+		return nil, nil
+	}
+	return raw, nil
 }
 
 func failRun(t *task.Task, stream *runStream, err error) (PromptRunSummary, error) {

--- a/pkg/cli/prompt_run_stream.go
+++ b/pkg/cli/prompt_run_stream.go
@@ -423,3 +423,12 @@ func writeTerminal(w http.ResponseWriter, summary *PromptRunSummary, errMsg stri
 		writeSSE(w, "done", map[string]string{"status": "completed"})
 	}
 }
+
+// remove drops a run's stream from the broker. Synchronous CLI runs that
+// borrow the stream machinery deregister on completion — nothing will ever
+// subscribe, and prune() only runs under `captain serve`.
+func (b *runBroker) remove(runID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.runs, runID)
+}

--- a/pkg/cli/prompt_run_workflow_test.go
+++ b/pkg/cli/prompt_run_workflow_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/api"
+)
+
+// workflowRendered builds a rendered CLI run carrying a workflow. The prompt
+// body is empty so the run is verify-only: hooks execute with no model call.
+func workflowRendered(verify *api.Verify) PromptRenderResult {
+	model := api.Model{Name: "claude-sonnet-5", Backend: api.BackendClaudeCLI}
+	return PromptRenderResult{
+		Name:    "workflow-test",
+		Model:   model.Name,
+		Backend: string(model.Backend),
+		Input: ai.Request{
+			Model:    model,
+			Workflow: &api.Workflow{Verify: verify},
+		},
+		Config: ai.Config{Model: model},
+	}
+}
+
+// The CLI path must execute declared hooks, not skip them: a verify command
+// that fails has to fail the run.
+func TestExecuteSyncRun_CLIRunsVerifyHooks(t *testing.T) {
+	isolateSavedAI(t)
+	rendered := workflowRendered(&api.Verify{Commands: []string{"sh -c 'echo not done; exit 1'"}})
+	rendered.Input.SetCwd(t.TempDir())
+
+	_, err := executeSyncRunSingle(context.Background(), rendered, AIPromptOptions{})
+
+	if err == nil || !strings.Contains(err.Error(), "failed") {
+		t.Fatalf("err = %v, want the failing verify command to fail the CLI run", err)
+	}
+}
+
+func TestExecuteSyncRun_CLIVerifyHooksPass(t *testing.T) {
+	isolateSavedAI(t)
+	rendered := workflowRendered(&api.Verify{Commands: []string{"true"}})
+	rendered.Input.SetCwd(t.TempDir())
+
+	result, err := executeSyncRunSingle(context.Background(), rendered, AIPromptOptions{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q", result.Status)
+	}
+}
+
+// The reviewer's repro: a workflow naming a nonexistent judge prompt must fail
+// the run loudly, not complete as if the check had passed.
+func TestExecuteSyncRun_MissingJudgePromptFailsLoud(t *testing.T) {
+	isolateSavedAI(t)
+	rendered := workflowRendered(&api.Verify{Prompts: []string{"/does/not/exist.prompt"}})
+	rendered.Input.SetCwd(t.TempDir())
+
+	_, err := executeSyncRunSingle(context.Background(), rendered, AIPromptOptions{})
+
+	if err == nil || !strings.Contains(err.Error(), "/does/not/exist.prompt") {
+		t.Fatalf("err = %v, want a loud failure naming the missing prompt", err)
+	}
+}

--- a/pkg/cli/prompt_run_workflow_test.go
+++ b/pkg/cli/prompt_run_workflow_test.go
@@ -25,6 +25,81 @@ func workflowRendered(verify *api.Verify) PromptRenderResult {
 	}
 }
 
+type bufferedOnlyWorkflowProvider struct {
+	executeCalls int
+}
+
+func (p *bufferedOnlyWorkflowProvider) GetModel() string       { return "buffered-model" }
+func (p *bufferedOnlyWorkflowProvider) GetBackend() ai.Backend { return api.BackendDeepSeek }
+func (p *bufferedOnlyWorkflowProvider) Execute(context.Context, ai.Request) (*ai.Response, error) {
+	p.executeCalls++
+	return &ai.Response{
+		Text:           "done",
+		StructuredData: map[string]any{"status": "ok"},
+		Model:          "buffered-model",
+		Backend:        api.BackendDeepSeek,
+		Usage:          ai.Usage{InputTokens: 2, OutputTokens: 3},
+		CostUSD:        0.01,
+	}, nil
+}
+
+type streamingWorkflowProvider struct {
+	bufferedOnlyWorkflowProvider
+	streamCalls int
+}
+
+func (p *streamingWorkflowProvider) ExecuteStream(context.Context, ai.Request) (<-chan ai.Event, error) {
+	p.streamCalls++
+	events := make(chan ai.Event, 1)
+	events <- ai.Event{Kind: ai.EventResult, Success: true}
+	close(events)
+	return events, nil
+}
+
+func TestWorkflowRunnerProviderHonorsNoStream(t *testing.T) {
+	t.Run("buffered-only provider", func(t *testing.T) {
+		provider := &bufferedOnlyWorkflowProvider{}
+		runner, err := workflowRunnerProvider(provider, true, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		events, err := runner.ExecuteStream(context.Background(), ai.Request{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []ai.Event
+		for event := range events {
+			got = append(got, event)
+		}
+		if provider.executeCalls != 1 {
+			t.Fatalf("Execute calls = %d, want 1", provider.executeCalls)
+		}
+		if len(got) != 2 || got[0].Kind != ai.EventText || got[0].Text != "done" || got[1].Kind != ai.EventResult {
+			t.Fatalf("events = %+v, want final text and result", got)
+		}
+		if string(got[1].StructuredData) != `{"status":"ok"}` || got[1].Usage == nil || got[1].Usage.InputTokens != 2 || got[1].CostUSD != 0.01 {
+			t.Fatalf("result event = %+v", got[1])
+		}
+	})
+
+	t.Run("streaming remains unchanged", func(t *testing.T) {
+		provider := &streamingWorkflowProvider{}
+		runner, err := workflowRunnerProvider(provider, false, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		events, err := runner.ExecuteStream(context.Background(), ai.Request{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range events {
+		}
+		if provider.streamCalls != 1 || provider.executeCalls != 0 {
+			t.Fatalf("stream calls = %d, execute calls = %d", provider.streamCalls, provider.executeCalls)
+		}
+	})
+}
+
 // The CLI path must execute declared hooks, not skip them: a verify command
 // that fails has to fail the run.
 func TestExecuteSyncRun_CLIRunsVerifyHooks(t *testing.T) {

--- a/pkg/cli/prompt_schema.go
+++ b/pkg/cli/prompt_schema.go
@@ -74,7 +74,7 @@ func PromptSchemaDocument() (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return buildPromptSchemaDocument(adapters)
+	return buildPromptSchemaDocument(adapters, loadSavedConfig().Sandbox)
 }
 
 // schemaAdapters sources the probed adapters through pkg/ai's cache. It is a

--- a/pkg/cli/prompt_schema_build.go
+++ b/pkg/cli/prompt_schema_build.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/captainconfig"
 	clickyrpc "github.com/flanksource/clicky/rpc"
 )
 
 // buildPromptSchemaDocument is the pure assembler (no I/O), taking a probed
-// adapter set so tests can drive it with a deterministic, network-free stub.
-func buildPromptSchemaDocument(adapters []AdapterStatus) (map[string]any, error) {
+// adapter set and resolved sandbox defaults so tests can drive it with
+// deterministic, network-free inputs.
+func buildPromptSchemaDocument(adapters []AdapterStatus, sandboxes captainconfig.SandboxDefaults) (map[string]any, error) {
 	adapters = enabledAdapters(adapters)
 	reflected, err := reflectedSchemas()
 	if err != nil {
@@ -33,6 +35,9 @@ func buildPromptSchemaDocument(adapters []AdapterStatus) (map[string]any, error)
 		return nil, fmt.Errorf("decode promptAction schema: %w", err)
 	}
 
+	if err := injectSandboxBackendEnum(specMap, sandboxes); err != nil {
+		return nil, err
+	}
 	if err := injectSpecConditionals(specMap, adapters, reflected.args); err != nil {
 		return nil, err
 	}
@@ -55,6 +60,72 @@ func buildPromptSchemaDocument(adapters []AdapterStatus) (map[string]any, error)
 			"spec": promptSchemaExampleSpec(),
 		},
 	}, nil
+}
+
+// injectSandboxBackendEnum constrains both SandboxRef forms to the selectors
+// the runtime can resolve: built-in kinds plus backend names from the user's
+// config. Keeping the two oneOf branches identical prevents the shorthand and
+// object forms from drifting apart in the workbench.
+func injectSandboxBackendEnum(spec map[string]any, defaults captainconfig.SandboxDefaults) error {
+	scalar, backend, err := sandboxBackendSchemaTargets(spec)
+	if err != nil {
+		return err
+	}
+	enum := toAnySlice(sandboxSelectors(defaults))
+	scalar["enum"] = enum
+	backend["enum"] = slices.Clone(enum)
+	return nil
+}
+
+func sandboxBackendSchemaTargets(spec map[string]any) (map[string]any, map[string]any, error) {
+	defs, ok := spec["$defs"].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("spec schema has no $defs")
+	}
+	sandboxRef, ok := defs["SandboxRef"].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("spec schema has no SandboxRef definition")
+	}
+	oneOf, ok := sandboxRef["oneOf"].([]any)
+	if !ok || len(oneOf) != 2 {
+		return nil, nil, fmt.Errorf("SandboxRef schema has %d forms, want scalar and object", len(oneOf))
+	}
+	scalar, ok := oneOf[0].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("SandboxRef scalar schema has unexpected type %T", oneOf[0])
+	}
+	object, ok := oneOf[1].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("SandboxRef object schema has unexpected type %T", oneOf[1])
+	}
+	properties, ok := object["properties"].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("SandboxRef object schema has no properties")
+	}
+	backend, ok := properties["backend"].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("SandboxRef object schema has no backend property")
+	}
+	return scalar, backend, nil
+}
+
+func sandboxSelectors(defaults captainconfig.SandboxDefaults) []string {
+	selectors := make([]string, 0, len(api.AllSandboxes())+len(defaults.Backends))
+	seen := map[string]struct{}{}
+	for _, descriptor := range api.AllSandboxes() {
+		selector := string(descriptor.Kind)
+		selectors = append(selectors, selector)
+		seen[selector] = struct{}{}
+	}
+	configured := make([]string, 0, len(defaults.Backends))
+	for name := range defaults.Backends {
+		if _, exists := seen[name]; !exists {
+			configured = append(configured, name)
+		}
+	}
+	slices.Sort(configured)
+	selectors = append(selectors, configured...)
+	return selectors
 }
 
 // enabledRuntimes is the provider×mode descriptor the workbench's runtime picker

--- a/pkg/cli/prompt_schema_test.go
+++ b/pkg/cli/prompt_schema_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flanksource/captain/pkg/ai"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/captainconfig"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +37,7 @@ func stubbedSchemaAdapters(t *testing.T) []AdapterStatus {
 }
 
 func TestPromptSchemaDocumentBackendsAndConditionals(t *testing.T) {
-	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t))
+	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t), captainconfig.SandboxDefaults{})
 	if err != nil {
 		t.Fatalf("buildPromptSchemaDocument: %v", err)
 	}
@@ -156,6 +157,32 @@ func TestPromptSchemaDocumentBackendsAndConditionals(t *testing.T) {
 	}
 }
 
+func TestPromptSchemaDocumentSandboxEnumIncludesConfiguredBackends(t *testing.T) {
+	defaults := captainconfig.SandboxDefaults{Backends: map[string]captainconfig.SandboxBackend{
+		"prod-pool":    {Kind: "git-agent"},
+		"local-docker": {Kind: "container"},
+		"srt":          {Kind: "srt"}, // a configured name must not duplicate a bare kind
+	}}
+	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t), defaults)
+	if err != nil {
+		t.Fatalf("buildPromptSchemaDocument: %v", err)
+	}
+
+	spec := doc["spec"].(map[string]any)
+	ref := spec["$defs"].(map[string]any)["SandboxRef"].(map[string]any)
+	forms := ref["oneOf"].([]any)
+	scalar := forms[0].(map[string]any)
+	object := forms[1].(map[string]any)
+	backend := object["properties"].(map[string]any)["backend"].(map[string]any)
+	want := []any{"none", "srt", "container", "git-agent", "local-docker", "prod-pool"}
+	if !reflect.DeepEqual(scalar["enum"], want) {
+		t.Errorf("scalar sandbox enum = %v, want %v", scalar["enum"], want)
+	}
+	if !reflect.DeepEqual(backend["enum"], want) {
+		t.Errorf("object backend enum = %v, want %v", backend["enum"], want)
+	}
+}
+
 // TestPromptSchemaDocumentDropsDisabledEntries covers the opposite policy to
 // whoami: a schema that still offered a disabled backend, model or tier would
 // let a run pick something the user opted out of.
@@ -164,7 +191,7 @@ func TestPromptSchemaDocumentDropsDisabledEntries(t *testing.T) {
 		[]string{"cmux"}, nil, nil, []string{"codex-cli/gpt-5.6-sol"}, []string{"ultra"}))
 	t.Cleanup(func() { api.SetDisabled(api.DisabledSet{}) })
 
-	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t))
+	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t), captainconfig.SandboxDefaults{})
 	if err != nil {
 		t.Fatalf("buildPromptSchemaDocument: %v", err)
 	}
@@ -215,7 +242,7 @@ func TestPromptSchemaDocumentDropsDisabledEntries(t *testing.T) {
 // runtime picker stop shipping its own family list: the document already carries
 // every provider×mode pair and the model each one seeds with.
 func TestPromptSchemaDocumentServesTheRuntimeCatalog(t *testing.T) {
-	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t))
+	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t), captainconfig.SandboxDefaults{})
 	if err != nil {
 		t.Fatalf("buildPromptSchemaDocument: %v", err)
 	}
@@ -241,7 +268,7 @@ func TestPromptSchemaDocumentServesTheRuntimeCatalog(t *testing.T) {
 }
 
 func TestPromptSchemaDocumentServesTheEffortUniverse(t *testing.T) {
-	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t))
+	doc, err := buildPromptSchemaDocument(stubbedSchemaAdapters(t), captainconfig.SandboxDefaults{})
 	if err != nil {
 		t.Fatalf("buildPromptSchemaDocument: %v", err)
 	}

--- a/pkg/cli/prompt_source.go
+++ b/pkg/cli/prompt_source.go
@@ -118,6 +118,7 @@ func actionFlagsToOptions(f map[string]string) (AIPromptOptions, error) {
 	o.Model = f["model"]
 	o.Fallback = flagSlice(f["fallback"])
 	o.Backend = f["backend"]
+	o.Mode = f["mode"]
 	o.APIKey = f["api-key"]
 	o.APIURL = f["api-url"]
 	o.NoCache = flagBool(f["no-cache"])

--- a/pkg/cli/prompt_source.go
+++ b/pkg/cli/prompt_source.go
@@ -122,7 +122,7 @@ func actionFlagsToOptions(f map[string]string) (AIPromptOptions, error) {
 	o.APIURL = f["api-url"]
 	o.NoCache = flagBool(f["no-cache"])
 	o.Budget = f["budget"]
-	o.Sandbox = flagBool(f["sandbox"])
+	o.Sandbox = f["sandbox"]
 	mt, err := flagInt("max-tokens", f["max-tokens"])
 	if err != nil {
 		return o, err

--- a/pkg/cli/prompt_source_test.go
+++ b/pkg/cli/prompt_source_test.go
@@ -26,7 +26,7 @@ func TestActionFlagsToOptions_DecodesSlicesBoolsInts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("actionFlagsToOptions: %v", err)
 	}
-	if o.Model != "gpt-4o" || o.Backend != "openai" || o.Prompt != "hi" || o.PermissionMode != "plan" || !o.Sandbox {
+	if o.Model != "gpt-4o" || o.Backend != "openai" || o.Prompt != "hi" || o.PermissionMode != "plan" || o.Sandbox != "true" {
 		t.Fatalf("scalars = %+v", o)
 	}
 	if !o.NoStream || !o.Edit {

--- a/pkg/cli/prompt_workflow.go
+++ b/pkg/cli/prompt_workflow.go
@@ -6,7 +6,9 @@ import (
 )
 
 // verifyPassed reports whether the last verify verdict passed. With no verify
-// hooks, the run passed.
+// hooks, the run passed. The last-verdict read is sound because the runner
+// stops each verification round at its first failure (see agent.verifyPassed),
+// so the list's final entry is always the final round's outcome.
 func verifyPassed(verdicts []agent.VerifyResult) bool {
 	if len(verdicts) == 0 {
 		return true

--- a/pkg/sandbox/adapter/cli_env.go
+++ b/pkg/sandbox/adapter/cli_env.go
@@ -9,9 +9,9 @@ import "path/filepath"
 func cliCredentialEnv(command string) []string {
 	switch filepath.Base(command) {
 	case "claude":
-		return []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}
+		return []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "CLAUDE_CODE_OAUTH_TOKEN"}
 	case "codex":
-		return []string{"OPENAI_API_KEY"}
+		return []string{"OPENAI_API_KEY", "OPENAI_BASE_URL"}
 	case "gemini":
 		return []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
 	}

--- a/pkg/sandbox/adapter/cli_env.go
+++ b/pkg/sandbox/adapter/cli_env.go
@@ -1,0 +1,19 @@
+package adapter
+
+import "path/filepath"
+
+// cliCredentialEnv is the credential environment variables each supported
+// agent CLI needs passed through into its confinement. One list, shared by
+// every adapter, so a variable added for a new CLI cannot reach one sandbox
+// kind and silently miss another.
+func cliCredentialEnv(command string) []string {
+	switch filepath.Base(command) {
+	case "claude":
+		return []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}
+	case "codex":
+		return []string{"OPENAI_API_KEY"}
+	case "gemini":
+		return []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
+	}
+	return nil
+}

--- a/pkg/sandbox/adapter/container.go
+++ b/pkg/sandbox/adapter/container.go
@@ -1,0 +1,108 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/container"
+)
+
+// containerSandbox runs the agent CLI inside a container image built by
+// `captain container` (pkg/container). It wraps the argv with an ephemeral
+// `docker run` assembled from the same configuration the generated sbx-*
+// scripts use: the project's .container-sandbox.yaml, overridable by the
+// backend's options in ~/.captain.yaml.
+type containerSandbox struct {
+	options map[string]any
+
+	cwd string
+	cfg container.SandboxConfig
+}
+
+// Container is the SandboxFactory for the container adapter.
+func Container(cfg api.SandboxConfig) (api.Sandbox, error) {
+	return &containerSandbox{options: cfg.Options}, nil
+}
+
+func init() { api.RegisterSandbox(api.SandboxContainer, Container) }
+
+func (c *containerSandbox) Kind() api.SandboxKind { return api.SandboxContainer }
+
+func (c *containerSandbox) Prepare(_ context.Context, spec *api.Spec) (*api.SandboxSession, error) {
+	c.cwd = spec.Cwd()
+	if c.cwd == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("resolve container working directory: %w", err)
+		}
+		c.cwd = cwd
+	}
+
+	// The project's generated config is the base; backend options override it.
+	configPath := filepath.Join(c.cwd, ".container-sandbox.yaml")
+	if _, err := os.Stat(configPath); err == nil {
+		cfg, err := container.LoadSandboxConfig(configPath)
+		if err != nil {
+			return nil, err
+		}
+		c.cfg = cfg
+	}
+	if image, ok := c.options["image"].(string); ok && image != "" {
+		c.cfg.Image = image
+	}
+	if presets, ok := c.options["presets"].([]any); ok {
+		c.cfg.Presets = nil
+		for _, preset := range presets {
+			if name, ok := preset.(string); ok {
+				c.cfg.Presets = append(c.cfg.Presets, name)
+			}
+		}
+	}
+	return &api.SandboxSession{}, nil
+}
+
+func (c *containerSandbox) Wrap(_ context.Context, command string, args, env []string) (string, []string, []string, error) {
+	if c.cfg.Image == "" {
+		return "", nil, nil, fmt.Errorf(
+			"container sandbox has no image: run `captain container` in %s to generate .container-sandbox.yaml, or set image on the sandbox backend", c.cwd)
+	}
+
+	dockerArgs := []string{"run", "--rm", "-i", "-w", c.cwd, "-v", c.cwd + ":" + c.cwd}
+
+	// Credential env rides by name (-e KEY), so the value comes from the docker
+	// client's environment and never appears in the argv.
+	for _, name := range append(cliCredentialEnv(command), c.cfg.EnvPassthrough...) {
+		if os.Getenv(name) != "" {
+			dockerArgs = append(dockerArgs, "-e", name)
+		}
+	}
+	for key, value := range c.cfg.Env {
+		dockerArgs = append(dockerArgs, "-e", key+"="+os.ExpandEnv(value))
+	}
+
+	home := container.HostUser{Username: c.cfg.User.Username, UID: c.cfg.User.UID, GID: c.cfg.User.GID}.ContainerHome()
+	presetEnv, presetVolumes := container.ResolveSandboxEnv(c.cfg.Presets, home)
+	for _, item := range presetEnv {
+		dockerArgs = append(dockerArgs, "-e", item)
+	}
+	for _, volume := range append(presetVolumes, container.ResolveDependencyVolumes(c.cfg.Presets, c.cwd, home)...) {
+		dockerArgs = append(dockerArgs, "-v", volume.Source+":"+volume.Target)
+	}
+	for _, volume := range c.cfg.Volumes {
+		mount := volume.Source + ":" + volume.Target
+		if volume.ReadOnly {
+			mount += ":ro"
+		}
+		dockerArgs = append(dockerArgs, "-v", mount)
+	}
+
+	dockerArgs = append(dockerArgs, c.cfg.Image)
+	dockerArgs = append(dockerArgs, command)
+	dockerArgs = append(dockerArgs, args...)
+	return "docker", dockerArgs, env, nil
+}
+
+func (c *containerSandbox) Close() error { return nil }

--- a/pkg/sandbox/adapter/container.go
+++ b/pkg/sandbox/adapter/container.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,9 +20,8 @@ import (
 //     config, trusted: image, presets, env, envPassthrough, volumes.
 //   - The project's .container-sandbox.yaml — REPOSITORY content, untrusted:
 //     a cloned repo must not be able to reach the host through it. Its image,
-//     presets and cwd-contained volumes are honoured; env, envPassthrough and
-//     volumes outside the project directory are refused loudly, naming the
-//     trusted place to declare them.
+//     and cwd-contained volumes are honoured; presets, ambient env and outside
+//     volumes are refused loudly, naming the trusted place to declare them.
 type containerSandbox struct {
 	options map[string]any
 
@@ -114,30 +114,61 @@ func rejectUntrustedContainerConfig(cfg container.SandboxConfig, cwd string) err
 	return nil
 }
 
-// pathWithin reports whether path (symlinks resolved) is inside root. A
-// relative path is anchored on root — NOT the process working directory —
-// because root is the project the config came from, and docker would treat a
-// relative source as a named volume anyway (see the normalization in Prepare).
+// pathWithin anchors relative paths on root and resolves every existing
+// symlink component. A missing leaf is allowed because Docker creates bind
+// sources, but its existing parent must still be canonicalized.
 func pathWithin(path, root string) (bool, error) {
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(root, path)
-	}
-	absolute, err := filepath.Abs(path)
+	resolvedRoot, err := filepath.Abs(root)
 	if err != nil {
 		return false, err
 	}
-	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
-		absolute = resolved
-	}
-	resolvedRoot, err := filepath.EvalSymlinks(root)
+	resolvedRoot, err = filepath.EvalSymlinks(resolvedRoot)
 	if err != nil {
-		resolvedRoot = root
+		return false, fmt.Errorf("resolve project directory: %w", err)
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(resolvedRoot, path)
+	}
+	absolute, err := resolvePathAllowMissing(path)
+	if err != nil {
+		return false, err
 	}
 	relative, err := filepath.Rel(resolvedRoot, absolute)
 	if err != nil {
 		return false, err
 	}
 	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)), nil
+}
+
+// resolvePathAllowMissing resolves symlinks in the longest existing prefix and
+// reattaches any missing suffix. This prevents a missing bind source below an
+// outward-pointing symlink from passing a lexical containment check.
+func resolvePathAllowMissing(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	current := absolute
+	var missing []string
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", err
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }
 
 // loadTrustedOptions decodes the backend's own env/envPassthrough/volumes —
@@ -185,34 +216,11 @@ func (c *containerSandbox) Wrap(_ context.Context, command string, args, declare
 	}
 
 	dockerArgs := []string{"run", "--rm", "-i", "-w", c.cwd, "-v", c.cwd + ":" + c.cwd}
-	clientEnv := os.Environ()
-
-	appendByName := func(name string) {
-		dockerArgs = append(dockerArgs, "-e", name)
-	}
-	for _, name := range append(cliCredentialEnv(command), c.optionPassthrough...) {
-		if os.Getenv(name) != "" {
-			appendByName(name)
-		}
-	}
-	// Request-declared setup variables (KEY=VALUE, resolved by the seam).
-	for _, item := range declaredEnv {
-		if key, _, ok := strings.Cut(item, "="); ok && key != "" {
-			appendByName(key)
-			clientEnv = append(clientEnv, item)
-		}
-	}
-	// Trusted backend-option env.
-	for key, value := range c.optionEnv {
-		appendByName(key)
-		clientEnv = append(clientEnv, key+"="+value)
-	}
 
 	home := container.HostUser{Username: c.cfg.User.Username, UID: c.cfg.User.UID, GID: c.cfg.User.GID}.ContainerHome()
 	presetEnv, presetVolumes := container.ResolveSandboxEnv(c.cfg.Presets, home)
-	for _, item := range presetEnv {
-		dockerArgs = append(dockerArgs, "-e", item)
-	}
+	envArgs, clientEnv := c.dockerEnv(command, declaredEnv, presetEnv)
+	dockerArgs = append(dockerArgs, envArgs...)
 	for _, volume := range append(presetVolumes, container.ResolveDependencyVolumes(c.cfg.Presets, c.cwd, home)...) {
 		dockerArgs = append(dockerArgs, "-v", volume.Source+":"+volume.Target)
 	}
@@ -231,6 +239,57 @@ func (c *containerSandbox) Wrap(_ context.Context, command string, args, declare
 	dockerArgs = append(dockerArgs, command)
 	dockerArgs = append(dockerArgs, args...)
 	return "docker", dockerArgs, clientEnv, nil
+}
+
+// dockerEnv separates the Docker wire format from its client environment:
+// argv receives names only, while resolved values replace entries in Env.
+func (c *containerSandbox) dockerEnv(command string, declaredEnv, presetEnv []string) ([]string, []string) {
+	clientEnv := os.Environ()
+	var args []string
+	passed := map[string]struct{}{}
+	pass := func(name string) {
+		if _, exists := passed[name]; exists {
+			return
+		}
+		passed[name] = struct{}{}
+		args = append(args, "-e", name)
+	}
+	for _, name := range append(cliCredentialEnv(command), c.optionPassthrough...) {
+		if os.Getenv(name) != "" {
+			pass(name)
+		}
+	}
+	for _, item := range declaredEnv {
+		if key, _, ok := strings.Cut(item, "="); ok && key != "" {
+			pass(key)
+			clientEnv = setEnvValue(clientEnv, item)
+		}
+	}
+	for key, value := range c.optionEnv {
+		pass(key)
+		clientEnv = setEnvValue(clientEnv, key+"="+value)
+	}
+	for _, item := range presetEnv {
+		if key, _, ok := strings.Cut(item, "="); ok && key != "" {
+			pass(key)
+			clientEnv = setEnvValue(clientEnv, item)
+		}
+	}
+	return args, clientEnv
+}
+
+func setEnvValue(env []string, item string) []string {
+	key, _, ok := strings.Cut(item, "=")
+	if !ok || key == "" {
+		return env
+	}
+	for i, existing := range env {
+		if existingKey, _, ok := strings.Cut(existing, "="); ok && existingKey == key {
+			env[i] = item
+			return env
+		}
+	}
+	return append(env, item)
 }
 
 func prefixEach(flag string, values []string) []string {

--- a/pkg/sandbox/adapter/container.go
+++ b/pkg/sandbox/adapter/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/container"
@@ -12,14 +13,24 @@ import (
 
 // containerSandbox runs the agent CLI inside a container image built by
 // `captain container` (pkg/container). It wraps the argv with an ephemeral
-// `docker run` assembled from the same configuration the generated sbx-*
-// scripts use: the project's .container-sandbox.yaml, overridable by the
-// backend's options in ~/.captain.yaml.
+// `docker run` assembled from two sources with different trust levels:
+//
+//   - The backend's options in ~/.captain.yaml — the USER's own machine
+//     config, trusted: image, presets, env, envPassthrough, volumes.
+//   - The project's .container-sandbox.yaml — REPOSITORY content, untrusted:
+//     a cloned repo must not be able to reach the host through it. Its image,
+//     presets and cwd-contained volumes are honoured; env, envPassthrough and
+//     volumes outside the project directory are refused loudly, naming the
+//     trusted place to declare them.
 type containerSandbox struct {
 	options map[string]any
 
 	cwd string
 	cfg container.SandboxConfig
+
+	optionEnv         map[string]string
+	optionPassthrough []string
+	optionVolumes     []string
 }
 
 // Container is the SandboxFactory for the container adapter.
@@ -48,6 +59,9 @@ func (c *containerSandbox) Prepare(_ context.Context, spec *api.Spec) (*api.Sand
 		if err != nil {
 			return nil, err
 		}
+		if err := rejectUntrustedContainerConfig(cfg, c.cwd); err != nil {
+			return nil, err
+		}
 		c.cfg = cfg
 	}
 	if image, ok := c.options["image"].(string); ok && image != "" {
@@ -61,26 +75,118 @@ func (c *containerSandbox) Prepare(_ context.Context, spec *api.Spec) (*api.Sand
 			}
 		}
 	}
+	if err := c.loadTrustedOptions(); err != nil {
+		return nil, err
+	}
 	return &api.SandboxSession{}, nil
 }
 
-func (c *containerSandbox) Wrap(_ context.Context, command string, args, env []string) (string, []string, []string, error) {
+// rejectUntrustedContainerConfig refuses the repository-supplied settings that
+// would reach the host: ambient environment access and out-of-project mounts.
+// Refusing beats filtering — a cloned repo silently granting itself less than
+// it asked for still granted itself something the user never saw.
+func rejectUntrustedContainerConfig(cfg container.SandboxConfig, cwd string) error {
+	if len(cfg.Env) > 0 || len(cfg.EnvPassthrough) > 0 {
+		return fmt.Errorf(".container-sandbox.yaml declares env/envPassthrough, which reads the host environment; declare them on the sandbox backend in ~/.captain.yaml instead")
+	}
+	for _, volume := range cfg.Volumes {
+		inside, err := pathWithin(volume.Source, cwd)
+		if err != nil {
+			return fmt.Errorf(".container-sandbox.yaml volume %q: %w", volume.Source, err)
+		}
+		if !inside {
+			return fmt.Errorf(".container-sandbox.yaml mounts %q, outside the project directory; declare host mounts on the sandbox backend in ~/.captain.yaml instead", volume.Source)
+		}
+	}
+	return nil
+}
+
+// pathWithin reports whether path (symlinks resolved) is inside root.
+func pathWithin(path, root string) (bool, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = resolved
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		resolvedRoot = root
+	}
+	relative, err := filepath.Rel(resolvedRoot, absolute)
+	if err != nil {
+		return false, err
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)), nil
+}
+
+// loadTrustedOptions decodes the backend's own env/envPassthrough/volumes —
+// user machine config, so host access is theirs to grant.
+func (c *containerSandbox) loadTrustedOptions() error {
+	c.optionEnv = map[string]string{}
+	if raw, ok := c.options["env"].(map[string]any); ok {
+		for key, value := range raw {
+			text, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("sandbox backend env %q must be a string", key)
+			}
+			c.optionEnv[key] = os.ExpandEnv(text)
+		}
+	}
+	c.optionPassthrough = nil
+	if raw, ok := c.options["envPassthrough"].([]any); ok {
+		for _, item := range raw {
+			if name, ok := item.(string); ok && name != "" {
+				c.optionPassthrough = append(c.optionPassthrough, name)
+			}
+		}
+	}
+	c.optionVolumes = nil
+	if raw, ok := c.options["volumes"].([]any); ok {
+		for _, item := range raw {
+			mount, ok := item.(string)
+			if !ok || strings.Count(mount, ":") < 1 {
+				return fmt.Errorf("sandbox backend volume %v must be a \"source:target[:ro]\" string", item)
+			}
+			c.optionVolumes = append(c.optionVolumes, mount)
+		}
+	}
+	return nil
+}
+
+// Wrap builds the docker argv. Every environment value stays OUT of the argv:
+// variables cross into the container by name only (-e KEY), and docker
+// resolves each name from the client process environment, which Wrap returns
+// as the authoritative env for the docker client.
+func (c *containerSandbox) Wrap(_ context.Context, command string, args, declaredEnv []string) (string, []string, []string, error) {
 	if c.cfg.Image == "" {
 		return "", nil, nil, fmt.Errorf(
 			"container sandbox has no image: run `captain container` in %s to generate .container-sandbox.yaml, or set image on the sandbox backend", c.cwd)
 	}
 
 	dockerArgs := []string{"run", "--rm", "-i", "-w", c.cwd, "-v", c.cwd + ":" + c.cwd}
+	clientEnv := os.Environ()
 
-	// Credential env rides by name (-e KEY), so the value comes from the docker
-	// client's environment and never appears in the argv.
-	for _, name := range append(cliCredentialEnv(command), c.cfg.EnvPassthrough...) {
+	appendByName := func(name string) {
+		dockerArgs = append(dockerArgs, "-e", name)
+	}
+	for _, name := range append(cliCredentialEnv(command), c.optionPassthrough...) {
 		if os.Getenv(name) != "" {
-			dockerArgs = append(dockerArgs, "-e", name)
+			appendByName(name)
 		}
 	}
-	for key, value := range c.cfg.Env {
-		dockerArgs = append(dockerArgs, "-e", key+"="+os.ExpandEnv(value))
+	// Request-declared setup variables (KEY=VALUE, resolved by the seam).
+	for _, item := range declaredEnv {
+		if key, _, ok := strings.Cut(item, "="); ok && key != "" {
+			appendByName(key)
+			clientEnv = append(clientEnv, item)
+		}
+	}
+	// Trusted backend-option env.
+	for key, value := range c.optionEnv {
+		appendByName(key)
+		clientEnv = append(clientEnv, key+"="+value)
 	}
 
 	home := container.HostUser{Username: c.cfg.User.Username, UID: c.cfg.User.UID, GID: c.cfg.User.GID}.ContainerHome()
@@ -91,6 +197,8 @@ func (c *containerSandbox) Wrap(_ context.Context, command string, args, env []s
 	for _, volume := range append(presetVolumes, container.ResolveDependencyVolumes(c.cfg.Presets, c.cwd, home)...) {
 		dockerArgs = append(dockerArgs, "-v", volume.Source+":"+volume.Target)
 	}
+	// Repo-declared volumes were containment-checked in Prepare; trusted
+	// backend-option volumes are the user's own grant.
 	for _, volume := range c.cfg.Volumes {
 		mount := volume.Source + ":" + volume.Target
 		if volume.ReadOnly {
@@ -98,11 +206,20 @@ func (c *containerSandbox) Wrap(_ context.Context, command string, args, env []s
 		}
 		dockerArgs = append(dockerArgs, "-v", mount)
 	}
+	dockerArgs = append(dockerArgs, prefixEach("-v", c.optionVolumes)...)
 
 	dockerArgs = append(dockerArgs, c.cfg.Image)
 	dockerArgs = append(dockerArgs, command)
 	dockerArgs = append(dockerArgs, args...)
-	return "docker", dockerArgs, env, nil
+	return "docker", dockerArgs, clientEnv, nil
+}
+
+func prefixEach(flag string, values []string) []string {
+	var out []string
+	for _, value := range values {
+		out = append(out, flag, value)
+	}
+	return out
 }
 
 func (c *containerSandbox) Close() error { return nil }

--- a/pkg/sandbox/adapter/container.go
+++ b/pkg/sandbox/adapter/container.go
@@ -62,6 +62,14 @@ func (c *containerSandbox) Prepare(_ context.Context, spec *api.Spec) (*api.Sand
 		if err := rejectUntrustedContainerConfig(cfg, c.cwd); err != nil {
 			return nil, err
 		}
+		// Normalize relative volume sources onto the project directory: docker
+		// would otherwise treat them as named volumes, mounting something other
+		// than the path the containment check above approved.
+		for i, volume := range cfg.Volumes {
+			if !filepath.IsAbs(volume.Source) {
+				cfg.Volumes[i].Source = filepath.Join(c.cwd, volume.Source)
+			}
+		}
 		c.cfg = cfg
 	}
 	if image, ok := c.options["image"].(string); ok && image != "" {
@@ -82,12 +90,17 @@ func (c *containerSandbox) Prepare(_ context.Context, spec *api.Spec) (*api.Sand
 }
 
 // rejectUntrustedContainerConfig refuses the repository-supplied settings that
-// would reach the host: ambient environment access and out-of-project mounts.
-// Refusing beats filtering — a cloned repo silently granting itself less than
-// it asked for still granted itself something the user never saw.
+// would reach the host: ambient environment access, out-of-project mounts, and
+// presets — whose expansion mounts host cache directories and passes
+// credential env through. Refusing beats filtering — a cloned repo silently
+// granting itself less than it asked for still granted itself something the
+// user never saw.
 func rejectUntrustedContainerConfig(cfg container.SandboxConfig, cwd string) error {
 	if len(cfg.Env) > 0 || len(cfg.EnvPassthrough) > 0 {
 		return fmt.Errorf(".container-sandbox.yaml declares env/envPassthrough, which reads the host environment; declare them on the sandbox backend in ~/.captain.yaml instead")
+	}
+	if len(cfg.Presets) > 0 {
+		return fmt.Errorf(".container-sandbox.yaml declares presets, whose expansion mounts host caches and passes credentials through; declare presets on the sandbox backend in ~/.captain.yaml instead")
 	}
 	for _, volume := range cfg.Volumes {
 		inside, err := pathWithin(volume.Source, cwd)
@@ -101,8 +114,14 @@ func rejectUntrustedContainerConfig(cfg container.SandboxConfig, cwd string) err
 	return nil
 }
 
-// pathWithin reports whether path (symlinks resolved) is inside root.
+// pathWithin reports whether path (symlinks resolved) is inside root. A
+// relative path is anchored on root — NOT the process working directory —
+// because root is the project the config came from, and docker would treat a
+// relative source as a named volume anyway (see the normalization in Prepare).
 func pathWithin(path, root string) (bool, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
 	absolute, err := filepath.Abs(path)
 	if err != nil {
 		return false, err

--- a/pkg/sandbox/adapter/container_test.go
+++ b/pkg/sandbox/adapter/container_test.go
@@ -13,22 +13,21 @@ import (
 
 func prepareContainer(t *testing.T, cwd string, options map[string]any) api.Sandbox {
 	t.Helper()
-	sandbox, err := newContainer(t, options)
-	if _, err2 := sandbox.Prepare(context.Background(), specWithCwd(cwd)); err2 != nil {
-		t.Fatal(err2)
+	sandbox := newContainer(t, options)
+	if _, err := sandbox.Prepare(context.Background(), specWithCwd(cwd)); err != nil {
+		t.Fatal(err)
 	}
-	_ = err
 	return sandbox
 }
 
-func newContainer(t *testing.T, options map[string]any) (api.Sandbox, error) {
+func newContainer(t *testing.T, options map[string]any) api.Sandbox {
 	t.Helper()
 	sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxContainer, Options: options})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = sandbox.Close() })
-	return sandbox, nil
+	return sandbox
 }
 
 func wrap(t *testing.T, sandbox api.Sandbox, command string, args []string) (string, []string) {
@@ -111,7 +110,7 @@ func TestContainerAdapter_UntrustedProjectConfigRejected(t *testing.T) {
 	t.Run("envPassthrough refused", func(t *testing.T) {
 		cwd := t.TempDir()
 		writeProjectConfig(t, cwd, "image: img\nenvPassthrough: [AWS_SECRET_ACCESS_KEY]\n")
-		sandbox, _ := newContainer(t, nil)
+		sandbox := newContainer(t, nil)
 		_, err := sandbox.Prepare(context.Background(), specWithCwd(cwd))
 		if err == nil || !strings.Contains(err.Error(), "~/.captain.yaml") {
 			t.Fatalf("err = %v, want refusal naming the trusted config", err)
@@ -121,7 +120,7 @@ func TestContainerAdapter_UntrustedProjectConfigRejected(t *testing.T) {
 	t.Run("out-of-project volume refused", func(t *testing.T) {
 		cwd := t.TempDir()
 		writeProjectConfig(t, cwd, "image: img\nvolumes:\n  - source: /\n    target: /host\n")
-		sandbox, _ := newContainer(t, nil)
+		sandbox := newContainer(t, nil)
 		_, err := sandbox.Prepare(context.Background(), specWithCwd(cwd))
 		if err == nil || !strings.Contains(err.Error(), "outside the project directory") {
 			t.Fatalf("err = %v, want out-of-project mount refusal", err)

--- a/pkg/sandbox/adapter/container_test.go
+++ b/pkg/sandbox/adapter/container_test.go
@@ -1,0 +1,111 @@
+package adapter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/api"
+)
+
+func prepareContainer(t *testing.T, cwd string, options map[string]any) api.Sandbox {
+	t.Helper()
+	sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxContainer, Options: options})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sandbox.Close() })
+	if _, err := sandbox.Prepare(context.Background(), specWithCwd(cwd)); err != nil {
+		t.Fatal(err)
+	}
+	return sandbox
+}
+
+func wrap(t *testing.T, sandbox api.Sandbox, command string, args []string) (string, []string) {
+	t.Helper()
+	wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox)
+	if !ok {
+		t.Fatal("container must provide a CommandWrapper (its descriptor declares it)")
+	}
+	cmd, wrappedArgs, _, err := wrapper.Wrap(context.Background(), command, args, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cmd, wrappedArgs
+}
+
+func TestContainerAdapter_WrapsWithDockerRun(t *testing.T) {
+	cwd := t.TempDir()
+	sandbox := prepareContainer(t, cwd, map[string]any{"image": "claude-env:golang"})
+
+	command, args := wrap(t, sandbox, "claude", []string{"-p", "hi"})
+
+	if command != "docker" {
+		t.Fatalf("command = %q", command)
+	}
+	argv := strings.Join(args, " ")
+	for _, want := range []string{
+		"run --rm -i",
+		"-w " + cwd,
+		"-v " + cwd + ":" + cwd,
+		"claude-env:golang claude -p hi",
+	} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("argv %q missing %q", argv, want)
+		}
+	}
+}
+
+func TestContainerAdapter_PassesCredentialEnvByName(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	sandbox := prepareContainer(t, t.TempDir(), map[string]any{"image": "img"})
+
+	_, args := wrap(t, sandbox, "claude", nil)
+
+	if i := slices.Index(args, "ANTHROPIC_API_KEY"); i < 1 || args[i-1] != "-e" {
+		t.Fatalf("argv %v must pass ANTHROPIC_API_KEY by name via -e", args)
+	}
+	if strings.Contains(strings.Join(args, " "), "sk-test") {
+		t.Fatal("credential value must never appear in the argv")
+	}
+}
+
+func TestContainerAdapter_LoadsProjectConfig(t *testing.T) {
+	cwd := t.TempDir()
+	config := `
+image: claude-env:custom
+envPassthrough: [MY_TOKEN]
+volumes:
+  - source: /data
+    target: /data
+    readOnly: true
+`
+	if err := os.WriteFile(filepath.Join(cwd, ".container-sandbox.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MY_TOKEN", "value")
+	sandbox := prepareContainer(t, cwd, nil)
+
+	_, args := wrap(t, sandbox, "claude", nil)
+
+	argv := strings.Join(args, " ")
+	for _, want := range []string{"claude-env:custom", "-e MY_TOKEN", "-v /data:/data:ro"} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("argv %q missing %q", argv, want)
+		}
+	}
+}
+
+func TestContainerAdapter_NoImageFailsLoud(t *testing.T) {
+	sandbox := prepareContainer(t, t.TempDir(), nil)
+
+	wrapper, _ := api.SandboxAs[api.CommandWrapper](sandbox)
+	_, _, _, err := wrapper.Wrap(context.Background(), "claude", nil, nil)
+
+	if err == nil || !strings.Contains(err.Error(), "no image") {
+		t.Fatalf("err = %v, want a loud no-image failure", err)
+	}
+}

--- a/pkg/sandbox/adapter/container_test.go
+++ b/pkg/sandbox/adapter/container_test.go
@@ -13,15 +13,22 @@ import (
 
 func prepareContainer(t *testing.T, cwd string, options map[string]any) api.Sandbox {
 	t.Helper()
+	sandbox, err := newContainer(t, options)
+	if _, err2 := sandbox.Prepare(context.Background(), specWithCwd(cwd)); err2 != nil {
+		t.Fatal(err2)
+	}
+	_ = err
+	return sandbox
+}
+
+func newContainer(t *testing.T, options map[string]any) (api.Sandbox, error) {
+	t.Helper()
 	sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxContainer, Options: options})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = sandbox.Close() })
-	if _, err := sandbox.Prepare(context.Background(), specWithCwd(cwd)); err != nil {
-		t.Fatal(err)
-	}
-	return sandbox
+	return sandbox, nil
 }
 
 func wrap(t *testing.T, sandbox api.Sandbox, command string, args []string) (string, []string) {
@@ -73,29 +80,100 @@ func TestContainerAdapter_PassesCredentialEnvByName(t *testing.T) {
 	}
 }
 
-func TestContainerAdapter_LoadsProjectConfig(t *testing.T) {
-	cwd := t.TempDir()
-	config := `
-image: claude-env:custom
-envPassthrough: [MY_TOKEN]
-volumes:
-  - source: /data
-    target: /data
-    readOnly: true
-`
-	if err := os.WriteFile(filepath.Join(cwd, ".container-sandbox.yaml"), []byte(config), 0o644); err != nil {
+// Request-declared setup variables cross by name; values ride the docker
+// client environment Wrap returns, never the argv.
+func TestContainerAdapter_SetupEnvCrossesByName(t *testing.T) {
+	sandbox := prepareContainer(t, t.TempDir(), map[string]any{"image": "img"})
+	wrapper, _ := api.SandboxAs[api.CommandWrapper](sandbox)
+
+	_, args, env, err := wrapper.Wrap(context.Background(), "claude", nil,
+		[]string{"REVIEW_SENTINEL=present-inside-container", "API_BASE=http://mock:1234"})
+	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("MY_TOKEN", "value")
-	sandbox := prepareContainer(t, cwd, nil)
 
-	_, args := wrap(t, sandbox, "claude", nil)
+	for _, name := range []string{"REVIEW_SENTINEL", "API_BASE"} {
+		if i := slices.Index(args, name); i < 1 || args[i-1] != "-e" {
+			t.Errorf("argv %v missing name-only -e %s", args, name)
+		}
+	}
+	if strings.Contains(strings.Join(args, " "), "present-inside-container") {
+		t.Fatal("setup values must never appear in the docker argv")
+	}
+	if !slices.Contains(env, "REVIEW_SENTINEL=present-inside-container") {
+		t.Fatalf("client env must carry the declared value for docker to resolve; got %d entries", len(env))
+	}
+}
+
+// The project file is repository content: settings that reach the host are
+// refused loudly, naming the trusted place to declare them.
+func TestContainerAdapter_UntrustedProjectConfigRejected(t *testing.T) {
+	t.Run("envPassthrough refused", func(t *testing.T) {
+		cwd := t.TempDir()
+		writeProjectConfig(t, cwd, "image: img\nenvPassthrough: [AWS_SECRET_ACCESS_KEY]\n")
+		sandbox, _ := newContainer(t, nil)
+		_, err := sandbox.Prepare(context.Background(), specWithCwd(cwd))
+		if err == nil || !strings.Contains(err.Error(), "~/.captain.yaml") {
+			t.Fatalf("err = %v, want refusal naming the trusted config", err)
+		}
+	})
+
+	t.Run("out-of-project volume refused", func(t *testing.T) {
+		cwd := t.TempDir()
+		writeProjectConfig(t, cwd, "image: img\nvolumes:\n  - source: /\n    target: /host\n")
+		sandbox, _ := newContainer(t, nil)
+		_, err := sandbox.Prepare(context.Background(), specWithCwd(cwd))
+		if err == nil || !strings.Contains(err.Error(), "outside the project directory") {
+			t.Fatalf("err = %v, want out-of-project mount refusal", err)
+		}
+	})
+
+	t.Run("project-contained volume allowed", func(t *testing.T) {
+		cwd := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(cwd, "data"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeProjectConfig(t, cwd, "image: img\nvolumes:\n  - source: "+filepath.Join(cwd, "data")+"\n    target: /data\n    readOnly: true\n")
+		sandbox := prepareContainer(t, cwd, nil)
+		_, args := wrap(t, sandbox, "claude", nil)
+		if !strings.Contains(strings.Join(args, " "), "-v "+filepath.Join(cwd, "data")+":/data:ro") {
+			t.Fatalf("argv %v missing the project-contained mount", args)
+		}
+	})
+}
+
+// Backend options are the user's own machine config; env, passthrough and
+// volumes declared there are honoured — env still by name only in the argv.
+func TestContainerAdapter_TrustedBackendOptions(t *testing.T) {
+	t.Setenv("MY_TOKEN", "tok")
+	sandbox := prepareContainer(t, t.TempDir(), map[string]any{
+		"image":          "img",
+		"env":            map[string]any{"API_BASE": "http://mock:1234"},
+		"envPassthrough": []any{"MY_TOKEN"},
+		"volumes":        []any{"/data:/data:ro"},
+	})
+	wrapper, _ := api.SandboxAs[api.CommandWrapper](sandbox)
+
+	_, args, env, err := wrapper.Wrap(context.Background(), "claude", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	argv := strings.Join(args, " ")
-	for _, want := range []string{"claude-env:custom", "-e MY_TOKEN", "-v /data:/data:ro"} {
-		if !strings.Contains(argv, want) {
-			t.Errorf("argv %q missing %q", argv, want)
-		}
+	if i := slices.Index(args, "API_BASE"); i < 1 || args[i-1] != "-e" {
+		t.Errorf("argv %v missing name-only -e API_BASE", args)
+	}
+	if strings.Contains(argv, "http://mock:1234") {
+		t.Error("backend env value must not appear in the argv")
+	}
+	if !slices.Contains(env, "API_BASE=http://mock:1234") {
+		t.Error("client env must carry the backend env value")
+	}
+	if i := slices.Index(args, "MY_TOKEN"); i < 1 || args[i-1] != "-e" {
+		t.Errorf("argv %v missing -e MY_TOKEN", args)
+	}
+	if !strings.Contains(argv, "-v /data:/data:ro") {
+		t.Errorf("argv %v missing the trusted volume", args)
 	}
 }
 
@@ -107,5 +185,12 @@ func TestContainerAdapter_NoImageFailsLoud(t *testing.T) {
 
 	if err == nil || !strings.Contains(err.Error(), "no image") {
 		t.Fatalf("err = %v, want a loud no-image failure", err)
+	}
+}
+
+func writeProjectConfig(t *testing.T, cwd, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(cwd, ".container-sandbox.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/sandbox/adapter/container_test.go
+++ b/pkg/sandbox/adapter/container_test.go
@@ -117,6 +117,16 @@ func TestContainerAdapter_UntrustedProjectConfigRejected(t *testing.T) {
 		}
 	})
 
+	t.Run("preset refused", func(t *testing.T) {
+		cwd := t.TempDir()
+		writeProjectConfig(t, cwd, "image: img\npresets: [aws]\n")
+		sandbox := newContainer(t, nil)
+		_, err := sandbox.Prepare(context.Background(), specWithCwd(cwd))
+		if err == nil || !strings.Contains(err.Error(), "declares presets") {
+			t.Fatalf("err = %v, want repository preset refusal", err)
+		}
+	})
+
 	t.Run("out-of-project volume refused", func(t *testing.T) {
 		cwd := t.TempDir()
 		writeProjectConfig(t, cwd, "image: img\nvolumes:\n  - source: /\n    target: /host\n")
@@ -139,17 +149,48 @@ func TestContainerAdapter_UntrustedProjectConfigRejected(t *testing.T) {
 			t.Fatalf("argv %v missing the project-contained mount", args)
 		}
 	})
+
+	t.Run("project-relative volume uses run cwd", func(t *testing.T) {
+		cwd := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(cwd, "data"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeProjectConfig(t, cwd, "image: img\nvolumes:\n  - source: ./data\n    target: /data\n")
+		sandbox := prepareContainer(t, cwd, nil)
+		_, args := wrap(t, sandbox, "claude", nil)
+		if !strings.Contains(strings.Join(args, " "), "-v "+filepath.Join(cwd, "data")+":/data") {
+			t.Fatalf("argv %v missing the project-relative mount", args)
+		}
+	})
+
+	t.Run("missing source below outward symlink refused", func(t *testing.T) {
+		cwd := t.TempDir()
+		outside := t.TempDir()
+		link := filepath.Join(cwd, "outside-link")
+		if err := os.Symlink(outside, link); err != nil {
+			t.Fatal(err)
+		}
+		source := filepath.Join(link, "created-by-docker")
+		writeProjectConfig(t, cwd, "image: img\nvolumes:\n  - source: "+source+"\n    target: /host\n")
+		sandbox := newContainer(t, nil)
+		_, err := sandbox.Prepare(context.Background(), specWithCwd(cwd))
+		if err == nil || !strings.Contains(err.Error(), "outside the project directory") {
+			t.Fatalf("err = %v, want symlink escape refusal", err)
+		}
+	})
 }
 
 // Backend options are the user's own machine config; env, passthrough and
 // volumes declared there are honoured — env still by name only in the argv.
 func TestContainerAdapter_TrustedBackendOptions(t *testing.T) {
 	t.Setenv("MY_TOKEN", "tok")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "review-secret")
 	sandbox := prepareContainer(t, t.TempDir(), map[string]any{
 		"image":          "img",
 		"env":            map[string]any{"API_BASE": "http://mock:1234"},
 		"envPassthrough": []any{"MY_TOKEN"},
 		"volumes":        []any{"/data:/data:ro"},
+		"presets":        []any{"aws"},
 	})
 	wrapper, _ := api.SandboxAs[api.CommandWrapper](sandbox)
 
@@ -173,6 +214,15 @@ func TestContainerAdapter_TrustedBackendOptions(t *testing.T) {
 	}
 	if !strings.Contains(argv, "-v /data:/data:ro") {
 		t.Errorf("argv %v missing the trusted volume", args)
+	}
+	if i := slices.Index(args, "AWS_SECRET_ACCESS_KEY"); i < 1 || args[i-1] != "-e" {
+		t.Errorf("argv %v missing name-only preset credential", args)
+	}
+	if strings.Contains(argv, "review-secret") {
+		t.Error("preset credential value must not appear in the argv")
+	}
+	if !slices.Contains(env, "AWS_SECRET_ACCESS_KEY=review-secret") {
+		t.Error("client env must carry the trusted preset credential value")
 	}
 }
 

--- a/pkg/sandbox/adapter/none.go
+++ b/pkg/sandbox/adapter/none.go
@@ -1,0 +1,30 @@
+// Package adapter holds the sandbox adapter implementations and their
+// registrations against pkg/api's sandbox registry. Importing it (blank is
+// enough) makes every adapter constructible through api.NewSandbox — the same
+// pattern as database/sql drivers and pkg/ai/provider's init().
+package adapter
+
+import (
+	"context"
+
+	"github.com/flanksource/captain/pkg/api"
+)
+
+// noneSandbox is the identity adapter: the run executes as a bare child process
+// on the host, exactly as every run did before adapters existed. It declares no
+// capabilities, so the exec seam falls through to an unwrapped command.
+type noneSandbox struct{}
+
+// None is the SandboxFactory for the identity adapter, exported so tests that
+// stub the "none" registration can restore it.
+func None(api.SandboxConfig) (api.Sandbox, error) { return noneSandbox{}, nil }
+
+func init() { api.RegisterSandbox(api.SandboxNone, None) }
+
+func (noneSandbox) Kind() api.SandboxKind { return api.SandboxNone }
+
+func (noneSandbox) Prepare(context.Context, *api.Spec) (*api.SandboxSession, error) {
+	return &api.SandboxSession{}, nil
+}
+
+func (noneSandbox) Close() error { return nil }

--- a/pkg/sandbox/adapter/none_test.go
+++ b/pkg/sandbox/adapter/none_test.go
@@ -1,0 +1,32 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/api"
+)
+
+func TestNoneAdapter(t *testing.T) {
+	sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxNone})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sandbox.Close()
+
+	if sandbox.Kind() != api.SandboxNone {
+		t.Fatalf("kind = %q", sandbox.Kind())
+	}
+	session, err := sandbox.Prepare(context.Background(), &api.Spec{})
+	if err != nil || session == nil {
+		t.Fatalf("session = %v, err = %v", session, err)
+	}
+	if session.WorkDir != "" || len(session.Env) != 0 {
+		t.Fatalf("none must change nothing, got %+v", session)
+	}
+	// No CommandWrapper: the exec seam must fall through to a bare command,
+	// matching the descriptor's empty capability list.
+	if _, ok := api.SandboxAs[api.CommandWrapper](sandbox); ok {
+		t.Fatal("none must not provide a CommandWrapper")
+	}
+}

--- a/pkg/sandbox/adapter/srt.go
+++ b/pkg/sandbox/adapter/srt.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -65,9 +66,13 @@ func (s *srtSandbox) Wrap(ctx context.Context, command string, args, env []strin
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("wrap %s with sandbox-runtime: %w", command, err)
 	}
+	// When the runtime supplies its own environment, the request-declared
+	// variables are appended so they survive; when it supplies none, nil is
+	// returned and the exec seam falls back to the full resolved environment,
+	// which already contains them.
 	wrappedEnv := cmd.Env
-	if len(wrappedEnv) == 0 {
-		wrappedEnv = env
+	if len(wrappedEnv) > 0 {
+		wrappedEnv = append(wrappedEnv, env...)
 	}
 	return cmd.Args[0], cmd.Args[1:], wrappedEnv, nil
 }
@@ -77,12 +82,15 @@ func (s *srtSandbox) Close() error {
 	runtimes := s.runtimes
 	s.runtimes = nil
 	s.mu.Unlock()
+	var errs []error
 	for _, runtime := range runtimes {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_ = runtime.Close(closeCtx)
+		if err := runtime.Close(closeCtx); err != nil {
+			errs = append(errs, err)
+		}
 		cancel()
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // srtConfigFor builds the per-CLI confinement policy: the provider's API
@@ -133,6 +141,12 @@ func srtConfigFor(command, cwd string) (sandboxruntime.Config, error) {
 				filepath.Join(home, ".azure"),
 				filepath.Join(home, ".config", "gcloud"),
 				filepath.Join(home, ".kube"),
+				filepath.Join(home, ".netrc"),
+				filepath.Join(home, ".git-credentials"),
+				filepath.Join(home, ".config", "gh"),
+				filepath.Join(home, ".docker", "config.json"),
+				filepath.Join(home, ".npmrc"),
+				filepath.Join(home, ".pypirc"),
 				filepath.Join(home, ".docker", "run", "docker.sock"),
 				"/var/run/docker.sock",
 				"/run/docker.sock",

--- a/pkg/sandbox/adapter/srt.go
+++ b/pkg/sandbox/adapter/srt.go
@@ -104,23 +104,21 @@ func srtConfigFor(command, cwd string) (sandboxruntime.Config, error) {
 		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox home directory: %w", err)
 	}
 
-	var domains, passthroughEnv, statePaths []string
+	var domains, statePaths []string
 	switch filepath.Base(command) {
 	case "claude":
 		domains = []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}
-		passthroughEnv = []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}
 		statePaths = []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}
 	case "codex":
 		domains = []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}
-		passthroughEnv = []string{"OPENAI_API_KEY"}
 		statePaths = []string{filepath.Join(home, ".codex")}
 	case "gemini":
 		domains = []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}
-		passthroughEnv = []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
 		statePaths = []string{filepath.Join(home, ".gemini")}
 	default:
 		return sandboxruntime.Config{}, fmt.Errorf("sandbox-runtime does not support CLI command %q", command)
 	}
+	passthroughEnv := cliCredentialEnv(command)
 
 	return sandboxruntime.Config{
 		Network: sandboxruntime.NetworkConfig{

--- a/pkg/sandbox/adapter/srt.go
+++ b/pkg/sandbox/adapter/srt.go
@@ -1,0 +1,148 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/flanksource/captain/pkg/api"
+	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
+)
+
+// Runtime is the slice of sandbox-runtime the adapter uses, kept as an
+// interface so tests can substitute a fake.
+type Runtime interface {
+	Command(ctx context.Context, command string, args ...string) (*exec.Cmd, error)
+	Close(context.Context) error
+}
+
+// NewSRTRuntime constructs the live sandbox-runtime confinement. A variable so
+// tests can stub the runtime without OS-level sandbox support.
+var NewSRTRuntime = func(ctx context.Context, cfg sandboxruntime.Config) (Runtime, error) {
+	return sandboxruntime.New(ctx, cfg)
+}
+
+// srtSandbox confines the agent CLI with sandbox-runtime (filesystem and
+// network policy). The confinement is constructed per wrapped command, because
+// its policy depends on which CLI is being run.
+type srtSandbox struct {
+	cwd string
+
+	mu       sync.Mutex
+	runtimes []Runtime
+}
+
+// SRT is the SandboxFactory for the sandbox-runtime adapter.
+func SRT(api.SandboxConfig) (api.Sandbox, error) { return &srtSandbox{}, nil }
+
+func init() { api.RegisterSandbox(api.SandboxSRT, SRT) }
+
+func (s *srtSandbox) Kind() api.SandboxKind { return api.SandboxSRT }
+
+func (s *srtSandbox) Prepare(_ context.Context, spec *api.Spec) (*api.SandboxSession, error) {
+	s.cwd = spec.Cwd()
+	return &api.SandboxSession{}, nil
+}
+
+func (s *srtSandbox) Wrap(ctx context.Context, command string, args, env []string) (string, []string, []string, error) {
+	cfg, err := srtConfigFor(command, s.cwd)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	runtime, err := NewSRTRuntime(ctx, cfg)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("initialize sandbox-runtime: %w", err)
+	}
+	s.mu.Lock()
+	s.runtimes = append(s.runtimes, runtime)
+	s.mu.Unlock()
+
+	cmd, err := runtime.Command(ctx, command, args...)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("wrap %s with sandbox-runtime: %w", command, err)
+	}
+	wrappedEnv := cmd.Env
+	if len(wrappedEnv) == 0 {
+		wrappedEnv = env
+	}
+	return cmd.Args[0], cmd.Args[1:], wrappedEnv, nil
+}
+
+func (s *srtSandbox) Close() error {
+	s.mu.Lock()
+	runtimes := s.runtimes
+	s.runtimes = nil
+	s.mu.Unlock()
+	for _, runtime := range runtimes {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = runtime.Close(closeCtx)
+		cancel()
+	}
+	return nil
+}
+
+// srtConfigFor builds the per-CLI confinement policy: the provider's API
+// domains, its credential env vars, and its state directory — nothing else.
+func srtConfigFor(command, cwd string) (sandboxruntime.Config, error) {
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox working directory: %w", err)
+		}
+	}
+	absoluteCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox working directory %q: %w", cwd, err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return sandboxruntime.Config{}, fmt.Errorf("resolve sandbox home directory: %w", err)
+	}
+
+	var domains, passthroughEnv, statePaths []string
+	switch filepath.Base(command) {
+	case "claude":
+		domains = []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}
+		passthroughEnv = []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}
+		statePaths = []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}
+	case "codex":
+		domains = []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}
+		passthroughEnv = []string{"OPENAI_API_KEY"}
+		statePaths = []string{filepath.Join(home, ".codex")}
+	case "gemini":
+		domains = []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}
+		passthroughEnv = []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
+		statePaths = []string{filepath.Join(home, ".gemini")}
+	default:
+		return sandboxruntime.Config{}, fmt.Errorf("sandbox-runtime does not support CLI command %q", command)
+	}
+
+	return sandboxruntime.Config{
+		Network: sandboxruntime.NetworkConfig{
+			AllowedDomains: domains,
+			DeniedDomains:  []string{},
+		},
+		Filesystem: sandboxruntime.FilesystemConfig{
+			AllowWrite: append([]string{absoluteCwd, "/tmp"}, statePaths...),
+			DenyRead: []string{
+				filepath.Join(home, ".ssh"),
+				filepath.Join(home, ".aws"),
+				filepath.Join(home, ".azure"),
+				filepath.Join(home, ".config", "gcloud"),
+				filepath.Join(home, ".kube"),
+				filepath.Join(home, ".docker", "run", "docker.sock"),
+				"/var/run/docker.sock",
+				"/run/docker.sock",
+				"/run/containerd/containerd.sock",
+				"/run/podman/podman.sock",
+			},
+			DenyWrite: []string{},
+		},
+		PassthroughEnv: passthroughEnv,
+	}, nil
+}

--- a/pkg/sandbox/adapter/srt_test.go
+++ b/pkg/sandbox/adapter/srt_test.go
@@ -1,0 +1,128 @@
+package adapter
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/flanksource/captain/pkg/api"
+	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
+)
+
+type fakeRuntime struct {
+	gotConfig sandboxruntime.Config
+	closed    bool
+}
+
+func (f *fakeRuntime) Command(ctx context.Context, command string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, "srt-wrapper", append([]string{command}, args...)...)
+	cmd.Env = []string{"SRT=1"}
+	return cmd, nil
+}
+
+func (f *fakeRuntime) Close(context.Context) error { f.closed = true; return nil }
+
+func TestSRTAdapter_WrapAndClose(t *testing.T) {
+	original := NewSRTRuntime
+	t.Cleanup(func() { NewSRTRuntime = original })
+	fake := &fakeRuntime{}
+	NewSRTRuntime = func(_ context.Context, cfg sandboxruntime.Config) (Runtime, error) {
+		fake.gotConfig = cfg
+		return fake, nil
+	}
+
+	sandbox, err := api.NewSandbox(api.SandboxConfig{Kind: api.SandboxSRT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+	if _, err := sandbox.Prepare(context.Background(), specWithCwd(cwd)); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapper, ok := api.SandboxAs[api.CommandWrapper](sandbox)
+	if !ok {
+		t.Fatal("srt must provide a CommandWrapper (its descriptor declares it)")
+	}
+	command, args, env, err := wrapper.Wrap(context.Background(), "claude", []string{"-p"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "srt-wrapper" || len(args) != 2 || args[0] != "claude" || args[1] != "-p" {
+		t.Fatalf("wrapped argv = %q %v", command, args)
+	}
+	if len(env) != 1 || env[0] != "SRT=1" {
+		t.Fatalf("wrapped env = %v", env)
+	}
+	if got := fake.gotConfig.Filesystem.AllowWrite[0]; got != cwd {
+		t.Fatalf("confinement cwd = %q, want the Prepare()d spec's %q", got, cwd)
+	}
+
+	if err := sandbox.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !fake.closed {
+		t.Fatal("Close must close the live runtime")
+	}
+}
+
+func TestSRTConfigFor(t *testing.T) {
+	cwd := t.TempDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	denyRead := []string{
+		filepath.Join(home, ".ssh"), filepath.Join(home, ".aws"), filepath.Join(home, ".azure"),
+		filepath.Join(home, ".config", "gcloud"), filepath.Join(home, ".kube"),
+		filepath.Join(home, ".docker", "run", "docker.sock"), "/var/run/docker.sock",
+		"/run/docker.sock", "/run/containerd/containerd.sock", "/run/podman/podman.sock",
+	}
+	tests := []struct {
+		command string
+		domains []string
+		env     []string
+		state   []string
+	}{
+		{"claude", []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}, []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}, []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}},
+		{"codex", []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}, []string{"OPENAI_API_KEY"}, []string{filepath.Join(home, ".codex")}},
+		{"gemini", []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}, []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, []string{filepath.Join(home, ".gemini")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			got, err := srtConfigFor(tt.command, cwd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := sandboxruntime.Config{
+				Network: sandboxruntime.NetworkConfig{AllowedDomains: tt.domains, DeniedDomains: []string{}},
+				Filesystem: sandboxruntime.FilesystemConfig{
+					AllowWrite: append([]string{cwd, "/tmp"}, tt.state...),
+					DenyRead:   denyRead,
+					DenyWrite:  []string{},
+				},
+				PassthroughEnv: tt.env,
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("srtConfigFor() = %#v, want %#v", got, want)
+			}
+		})
+	}
+
+	t.Run("unsupported command fails loud", func(t *testing.T) {
+		_, err := srtConfigFor("bash", cwd)
+		if err == nil || !strings.Contains(err.Error(), "does not support CLI command") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+func specWithCwd(cwd string) *api.Spec {
+	spec := &api.Spec{}
+	spec.SetCwd(cwd)
+	return spec
+}

--- a/pkg/sandbox/adapter/srt_test.go
+++ b/pkg/sandbox/adapter/srt_test.go
@@ -48,15 +48,16 @@ func TestSRTAdapter_WrapAndClose(t *testing.T) {
 	if !ok {
 		t.Fatal("srt must provide a CommandWrapper (its descriptor declares it)")
 	}
-	command, args, env, err := wrapper.Wrap(context.Background(), "claude", []string{"-p"}, nil)
+	command, args, env, err := wrapper.Wrap(context.Background(), "claude", []string{"-p"}, []string{"DECLARED=1"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if command != "srt-wrapper" || len(args) != 2 || args[0] != "claude" || args[1] != "-p" {
 		t.Fatalf("wrapped argv = %q %v", command, args)
 	}
-	if len(env) != 1 || env[0] != "SRT=1" {
-		t.Fatalf("wrapped env = %v", env)
+	// Runtime env survives AND the request-declared variables ride along.
+	if len(env) != 2 || env[0] != "SRT=1" || env[1] != "DECLARED=1" {
+		t.Fatalf("wrapped env = %v, want runtime env plus declared vars", env)
 	}
 	if got := fake.gotConfig.Filesystem.AllowWrite[0]; got != cwd {
 		t.Fatalf("confinement cwd = %q, want the Prepare()d spec's %q", got, cwd)
@@ -79,6 +80,9 @@ func TestSRTConfigFor(t *testing.T) {
 	denyRead := []string{
 		filepath.Join(home, ".ssh"), filepath.Join(home, ".aws"), filepath.Join(home, ".azure"),
 		filepath.Join(home, ".config", "gcloud"), filepath.Join(home, ".kube"),
+		filepath.Join(home, ".netrc"), filepath.Join(home, ".git-credentials"),
+		filepath.Join(home, ".config", "gh"), filepath.Join(home, ".docker", "config.json"),
+		filepath.Join(home, ".npmrc"), filepath.Join(home, ".pypirc"),
 		filepath.Join(home, ".docker", "run", "docker.sock"), "/var/run/docker.sock",
 		"/run/docker.sock", "/run/containerd/containerd.sock", "/run/podman/podman.sock",
 	}
@@ -88,8 +92,8 @@ func TestSRTConfigFor(t *testing.T) {
 		env     []string
 		state   []string
 	}{
-		{"claude", []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}, []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}, []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}},
-		{"codex", []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}, []string{"OPENAI_API_KEY"}, []string{filepath.Join(home, ".codex")}},
+		{"claude", []string{"anthropic.com", "*.anthropic.com", "claude.ai", "*.claude.ai"}, []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "CLAUDE_CODE_OAUTH_TOKEN"}, []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}},
+		{"codex", []string{"openai.com", "*.openai.com", "chatgpt.com", "*.chatgpt.com"}, []string{"OPENAI_API_KEY", "OPENAI_BASE_URL"}, []string{filepath.Join(home, ".codex")}},
 		{"gemini", []string{"google.com", "*.google.com", "googleapis.com", "*.googleapis.com"}, []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, []string{filepath.Join(home, ".gemini")}},
 	}
 	for _, tt := range tests {

--- a/pkg/sandbox/config.go
+++ b/pkg/sandbox/config.go
@@ -3,41 +3,28 @@ package sandbox
 import (
 	"fmt"
 	"strings"
+
+	sandboxruntime "github.com/flanksource/sandbox-runtime/sandbox"
 )
 
-type MitmProxyConfig struct {
-	SocketPath string   `json:"socketPath" yaml:"socketPath"`
-	Domains    []string `json:"domains" yaml:"domains"`
-}
+// The sub-config types are aliases for sandbox-runtime's public types — one
+// definition, upstream's, following upstream's own convention (its Config is
+// itself an alias for the internal SandboxRuntimeConfig). The previous
+// hand-copied definitions drifted silently from the module actually enforcing
+// them.
+type (
+	MitmProxyConfig  = sandboxruntime.MitmProxyConfig
+	NetworkConfig    = sandboxruntime.NetworkConfig
+	FilesystemConfig = sandboxruntime.FilesystemConfig
+	RipgrepConfig    = sandboxruntime.RipgrepConfig
+	SeccompConfig    = sandboxruntime.SeccompConfig
+)
 
-type NetworkConfig struct {
-	AllowedDomains      []string         `json:"allowedDomains" yaml:"allowedDomains"`
-	DeniedDomains       []string         `json:"deniedDomains" yaml:"deniedDomains"`
-	AllowUnixSockets    []string         `json:"allowUnixSockets,omitempty" yaml:"allowUnixSockets,omitempty"`
-	AllowAllUnixSockets bool             `json:"allowAllUnixSockets,omitempty" yaml:"allowAllUnixSockets,omitempty"`
-	AllowLocalBinding   bool             `json:"allowLocalBinding,omitempty" yaml:"allowLocalBinding,omitempty"`
-	HTTPProxyPort       *int             `json:"httpProxyPort,omitempty" yaml:"httpProxyPort,omitempty"`
-	SocksProxyPort      *int             `json:"socksProxyPort,omitempty" yaml:"socksProxyPort,omitempty"`
-	MitmProxy           *MitmProxyConfig `json:"mitmProxy,omitempty" yaml:"mitmProxy,omitempty"`
-}
-
-type FilesystemConfig struct {
-	DenyRead       []string `json:"denyRead" yaml:"denyRead"`
-	AllowWrite     []string `json:"allowWrite" yaml:"allowWrite"`
-	DenyWrite      []string `json:"denyWrite" yaml:"denyWrite"`
-	AllowGitConfig bool     `json:"allowGitConfig,omitempty" yaml:"allowGitConfig,omitempty"`
-}
-
-type RipgrepConfig struct {
-	Command string   `json:"command" yaml:"command"`
-	Args    []string `json:"args,omitempty" yaml:"args,omitempty"`
-}
-
-type SeccompConfig struct {
-	BPFPath   string `json:"bpfPath,omitempty" yaml:"bpfPath,omitempty"`
-	ApplyPath string `json:"applyPath,omitempty" yaml:"applyPath,omitempty"`
-}
-
+// SandboxRuntimeConfig cannot yet be an alias for sandboxruntime.Config: its
+// Tokens field must be captain's *TokensConfig (the token-acquisition machinery
+// lives here), and upstream keeps its token types in an internal package. Once
+// upstream exports them, this struct collapses into an alias too — that fix
+// belongs upstream, not as a fork here.
 type SandboxRuntimeConfig struct {
 	Network                      NetworkConfig       `json:"network" yaml:"network"`
 	Filesystem                   FilesystemConfig    `json:"filesystem" yaml:"filesystem"`


### PR DESCRIPTION
This PR introduces a pluggable sandbox adapter framework that allows agent CLI processes (claude-cli, codex-cli, gemini-cli) to execute under different confinement mechanisms.

resolves: https://github.com/flanksource/captain/issues/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable sandbox selections, including container, sandbox-runtime, and unsandboxed execution.
  * Added sandbox settings for projects and workflows, with defaults, named backends, and validation.
  * Added prompt-based AI verification hooks for workflow runs.
  * Added structured output fields to prompt run results.

* **Bug Fixes**
  * Verification now stops at the first failure and preserves its retry guidance.
  * Command verification now supports timeouts, cancellation, process cleanup, and bounded output.
  * Improved validation and error reporting for unsupported sandbox and workflow configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->