### PR TITLE
fix(codex): emit complete correlated tool results

### DIFF
--- a/pkg/ai/history/codex_normalize.go
+++ b/pkg/ai/history/codex_normalize.go
@@ -325,7 +325,7 @@ func buildToolUses(callEvent, outputEvent CodexEvent, cwd, sessionID string) []T
 		SessionID:  sessionID,
 		TurnID:     firstNonEmpty(codexEventTurnID(callEvent), codexEventTurnID(outputEvent)),
 		ID:         callEvent.Payload.CallID,
-		Response:   extractCommandOutput(CodexOutputText(outputEvent.Payload.Output)),
+		Response:   CodexCommandOutputText(CodexOutputText(outputEvent.Payload.Output)),
 		RecordType: "response_item." + callEvent.Payload.Type,
 	})
 }
@@ -449,7 +449,9 @@ func CodexOutputText(raw json.RawMessage) string {
 	return text
 }
 
-func extractCommandOutput(raw string) string {
+// CodexCommandOutputText removes Codex's execution metadata prefix from a raw
+// function_call_output while preserving the complete command stdout/stderr.
+func CodexCommandOutputText(raw string) string {
 	if _, after, ok := strings.Cut(raw, "Output:\n"); ok {
 		return after
 	}

--- a/pkg/ai/provider/codex_appserver.go
+++ b/pkg/ai/provider/codex_appserver.go
@@ -141,15 +141,14 @@ func (c *CodexAppServer) ExecuteStream(ctx context.Context, req ai.Request) (<-c
 	c.mu.Unlock()
 
 	ts := &turnState{
-		ch:                 make(chan ai.Event, 16),
-		usage:              &ai.Usage{},
-		model:              c.model,
-		streamed:           map[string]string{},
-		toolOutput:         map[string]string{},
-		completeToolOutput: map[string]string{},
-		terminal:           make(chan struct{}),
-		started:            make(chan struct{}),
-		outputSchema:       schema,
+		ch:           make(chan ai.Event, 16),
+		usage:        &ai.Usage{},
+		model:        c.model,
+		streamed:     map[string]string{},
+		toolOutput:   map[string]string{},
+		terminal:     make(chan struct{}),
+		started:      make(chan struct{}),
+		outputSchema: schema,
 	}
 	c.setActive(ts)
 
@@ -287,10 +286,8 @@ func (c *CodexAppServer) ensureStarted(ctx context.Context) error {
 // before it errors "Not initialized" server-side).
 func (c *CodexAppServer) handshake(ctx context.Context, rpc *jsonrpc.Client) error {
 	params := map[string]any{
-		"clientInfo": map[string]string{"name": "captain", "version": "dev"},
-		"capabilities": map[string]any{
-			"experimentalApi": true, "requestAttestation": false,
-		},
+		"clientInfo":   map[string]string{"name": "captain", "version": "dev"},
+		"capabilities": map[string]bool{"experimentalApi": true},
 	}
 	if _, err := rpc.Call(ctx, "initialize", params); err != nil {
 		return fmt.Errorf("codex app-server initialize: %w", err)
@@ -453,6 +450,85 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+// handleNotification routes one notification to the active turn. It runs on the
+// rpc Run goroutine (notifications dispatch sequentially). Pending tool results
+// also synchronize with driveTurn's cancellation and process-exit paths.
+func (c *CodexAppServer) handleNotification(method string, params json.RawMessage) {
+	ts := c.currentTurn()
+	if ts == nil {
+		return
+	}
+	ctx := appServerEventContext{Model: ts.model, Usage: ts.usage}
+	switch method {
+	case "item/agentMessage/delta":
+		notification := parseAppServerNotif(params)
+		if notification.ItemID != "" {
+			ts.streamed[notification.ItemID] += notification.Delta
+		}
+		if len(ts.outputSchema) > 0 {
+			return
+		}
+	case "rawResponseItem/completed":
+		// Codex emits raw command output after item/completed and before turn/completed.
+		if toolCallID, output, ok := appServerRawCommandOutput(params); ok {
+			ts.receiveCompleteToolOutput(toolCallID, output)
+		}
+		return
+	case "item/commandExecution/outputDelta":
+		n := parseAppServerNotif(params)
+		if n.ItemID != "" && n.Delta != "" {
+			ts.toolOutput[n.ItemID] += n.Delta
+		}
+		return
+	case "item/completed":
+		// The completed agent message carries the full text (structured runs use it
+		// as the validated JSON result). Capture it, then drop the duplicate so
+		// CoalesceStream / renderers don't double-count already-streamed deltas.
+		if it := parseAppServerNotif(params).Item; it != nil && it.Type == "agentMessage" {
+			ts.lastAgentMessage = it.Text
+			if len(ts.outputSchema) > 0 {
+				return
+			}
+		}
+		remainder, streamed, err := appServerAgentMessageRemainder(params, ts.streamed)
+		if err != nil {
+			ts.send(ai.Event{Kind: ai.EventError, Error: err.Error(), Model: ts.model})
+			return
+		}
+		if streamed {
+			if remainder != "" {
+				ts.send(ai.Event{Kind: ai.EventText, Text: remainder, Model: ts.model})
+			}
+			return
+		}
+		if it := parseAppServerNotif(params).Item; it != nil {
+			ctx.ToolOutput = ts.toolOutput[it.ID]
+			delete(ts.toolOutput, it.ID)
+		}
+	}
+	terminal := method == "turn/completed" || appServerErrorIsFatal(method, params)
+	if terminal {
+		ts.flushToolResults()
+	}
+	if ev, ok := mapAppServerNotification(method, params, ctx); ok {
+		if ev.Kind == ai.EventResult && len(ts.outputSchema) > 0 {
+			ev.StructuredData = json.RawMessage(ts.lastAgentMessage)
+		}
+		if method == "item/completed" && ev.Kind == ai.EventToolResult {
+			it := parseAppServerNotif(params).Item
+			if it != nil && it.Type == "commandExecution" {
+				ts.queueToolResult(ev)
+				return
+			}
+		}
+		ts.send(ev)
+	}
+	if terminal {
+		c.clearActive(ts)
+		ts.signalTerminal()
+	}
 }
 
 // --- turn state ------------------------------------------------------------

--- a/pkg/ai/provider/codex_appserver.go
+++ b/pkg/ai/provider/codex_appserver.go
@@ -141,14 +141,15 @@ func (c *CodexAppServer) ExecuteStream(ctx context.Context, req ai.Request) (<-c
 	c.mu.Unlock()
 
 	ts := &turnState{
-		ch:           make(chan ai.Event, 16),
-		usage:        &ai.Usage{},
-		model:        c.model,
-		streamed:     map[string]string{},
-		toolOutput:   map[string]string{},
-		terminal:     make(chan struct{}),
-		started:      make(chan struct{}),
-		outputSchema: schema,
+		ch:                 make(chan ai.Event, 16),
+		usage:              &ai.Usage{},
+		model:              c.model,
+		streamed:           map[string]string{},
+		toolOutput:         map[string]string{},
+		completeToolOutput: map[string]string{},
+		terminal:           make(chan struct{}),
+		started:            make(chan struct{}),
+		outputSchema:       schema,
 	}
 	c.setActive(ts)
 
@@ -178,9 +179,11 @@ func (c *CodexAppServer) driveTurn(ctx context.Context, req ai.Request, ts *turn
 	case <-ctx.Done():
 		c.interrupt(threadID, turnID)
 		c.teardown(true) // ctx cancel tears the server down (best-effort)
+		ts.flushToolResults()
 		ts.send(ai.Event{Kind: ai.EventError, Error: "codex app-server: turn cancelled", Model: c.model})
 	case <-rpcDone:
 		c.teardown(false) // child crashed; surface, never silently retry
+		ts.flushToolResults()
 		ts.send(ai.Event{Kind: ai.EventError, Error: "codex app-server exited unexpectedly", Model: c.model})
 	}
 	c.clearActive(ts)
@@ -283,7 +286,12 @@ func (c *CodexAppServer) ensureStarted(ctx context.Context) error {
 // handshake performs the required initialize → initialized exchange (any request
 // before it errors "Not initialized" server-side).
 func (c *CodexAppServer) handshake(ctx context.Context, rpc *jsonrpc.Client) error {
-	params := map[string]any{"clientInfo": map[string]string{"name": "captain", "version": "dev"}}
+	params := map[string]any{
+		"clientInfo": map[string]string{"name": "captain", "version": "dev"},
+		"capabilities": map[string]any{
+			"experimentalApi": true, "requestAttestation": false,
+		},
+	}
 	if _, err := rpc.Call(ctx, "initialize", params); err != nil {
 		return fmt.Errorf("codex app-server initialize: %w", err)
 	}
@@ -445,68 +453,6 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
-}
-
-// handleNotification routes one notification to the active turn. It runs on the
-// rpc Run goroutine (notifications dispatch sequentially), so the per-turn
-// dedup/usage state needs no extra locking.
-func (c *CodexAppServer) handleNotification(method string, params json.RawMessage) {
-	ts := c.currentTurn()
-	if ts == nil {
-		return
-	}
-	ctx := appServerEventContext{Model: ts.model, Usage: ts.usage}
-	switch method {
-	case "item/agentMessage/delta":
-		notification := parseAppServerNotif(params)
-		if notification.ItemID != "" {
-			ts.streamed[notification.ItemID] += notification.Delta
-		}
-		if len(ts.outputSchema) > 0 {
-			return
-		}
-	case "item/commandExecution/outputDelta":
-		n := parseAppServerNotif(params)
-		if n.ItemID != "" && n.Delta != "" {
-			ts.toolOutput[n.ItemID] += n.Delta
-		}
-		return
-	case "item/completed":
-		// The completed agent message carries the full text (structured runs use it
-		// as the validated JSON result). Capture it, then drop the duplicate so
-		// CoalesceStream / renderers don't double-count already-streamed deltas.
-		if it := parseAppServerNotif(params).Item; it != nil && it.Type == "agentMessage" {
-			ts.lastAgentMessage = it.Text
-			if len(ts.outputSchema) > 0 {
-				return
-			}
-		}
-		remainder, streamed, err := appServerAgentMessageRemainder(params, ts.streamed)
-		if err != nil {
-			ts.send(ai.Event{Kind: ai.EventError, Error: err.Error(), Model: ts.model})
-			return
-		}
-		if streamed {
-			if remainder != "" {
-				ts.send(ai.Event{Kind: ai.EventText, Text: remainder, Model: ts.model})
-			}
-			return
-		}
-		if it := parseAppServerNotif(params).Item; it != nil {
-			ctx.ToolOutput = ts.toolOutput[it.ID]
-			delete(ts.toolOutput, it.ID)
-		}
-	}
-	if ev, ok := mapAppServerNotification(method, params, ctx); ok {
-		if ev.Kind == ai.EventResult && len(ts.outputSchema) > 0 {
-			ev.StructuredData = json.RawMessage(ts.lastAgentMessage)
-		}
-		ts.send(ev)
-	}
-	if method == "turn/completed" || appServerErrorIsFatal(method, params) {
-		c.clearActive(ts)
-		ts.signalTerminal()
-	}
 }
 
 // --- turn state ------------------------------------------------------------

--- a/pkg/ai/provider/codex_appserver_lifecycle_ginkgo_test.go
+++ b/pkg/ai/provider/codex_appserver_lifecycle_ginkgo_test.go
@@ -20,32 +20,39 @@ func TestCodexAppServerLifecycle(t *testing.T) {
 }
 
 var _ = Describe("Codex app-server tool lifecycle", func() {
-	It("emits one command use and one correlated result", func() {
+	It("emits one command use and one complete correlated result", func() {
 		client, turn := activeGinkgoTurn()
 		client.handleNotification("item/started", json.RawMessage(`{
 			"threadId":"thread-1",
-			"item":{"id":"cmd-1","type":"commandExecution","command":"pwd","cwd":"/work","status":"inProgress"}
+			"item":{"id":"cmd-1","type":"commandExecution","command":"printf lines","cwd":"/work","status":"inProgress"}
 		}`))
 		client.handleNotification("item/commandExecution/outputDelta", json.RawMessage(`{
-			"threadId":"thread-1","itemId":"cmd-1","delta":"/work\n"
+			"threadId":"thread-1","itemId":"cmd-1","delta":"line 2\nline 3\n"
 		}`))
 		client.handleNotification("item/completed", json.RawMessage(`{
 			"threadId":"thread-1",
-			"item":{"id":"cmd-1","type":"commandExecution","command":"pwd","cwd":"/work","status":"completed","exitCode":0,"aggregatedOutput":""}
+			"item":{"id":"cmd-1","type":"commandExecution","command":"printf lines","cwd":"/work","status":"completed","exitCode":0,"aggregatedOutput":"line 2\nline 3\n"}
 		}`))
 
-		events := drainEvents(turn)
-		Expect(events).To(HaveLen(2))
-		Expect(events[0]).To(MatchFields(IgnoreExtras, Fields{
+		started := drainEvents(turn)
+		Expect(started).To(HaveLen(1), "the partial item result waits for the raw function output")
+		Expect(started[0]).To(MatchFields(IgnoreExtras, Fields{
 			"Kind":       Equal(ai.EventToolUse),
 			"Tool":       Equal("Bash"),
-			"Input":      Equal(map[string]any{"command": "pwd"}),
+			"Input":      Equal(map[string]any{"command": "printf lines"}),
 			"ToolCallID": Equal("cmd-1"),
 			"SessionID":  Equal("thread-1"),
 		}))
-		Expect(events[1]).To(MatchFields(IgnoreExtras, Fields{
+		client.handleNotification("rawResponseItem/completed", json.RawMessage(`{
+			"threadId":"thread-1",
+			"item":{"type":"function_call_output","call_id":"cmd-1","output":"Chunk ID: abc123\nWall time: 1 second\nProcess exited with code 0\nOutput:\nline 1\nline 2\nline 3\n"}
+		}`))
+
+		events := drainEvents(turn)
+		Expect(events).To(HaveLen(1))
+		Expect(events[0]).To(MatchFields(IgnoreExtras, Fields{
 			"Kind":       Equal(ai.EventToolResult),
-			"Text":       Equal("/work\n"),
+			"Text":       Equal("line 1\nline 2\nline 3\n"),
 			"ToolCallID": Equal("cmd-1"),
 			"SessionID":  Equal("thread-1"),
 			"Success":    BeTrue(),
@@ -55,6 +62,58 @@ var _ = Describe("Codex app-server tool lifecycle", func() {
 		Expect(ok).To(BeTrue())
 		Expect(tool.ToolUseID).To(Equal("cmd-1"))
 		Expect(tool.SessionID).To(Equal("thread-1"))
+		Expect(tool.Response).To(Equal("line 1\nline 2\nline 3\n"))
+	})
+
+	It("falls back to the completed item when raw events are unavailable", func() {
+		client, turn := activeGinkgoTurn()
+		client.handleNotification("item/started", json.RawMessage(`{
+			"threadId":"thread-1",
+			"item":{"id":"cmd-fallback","type":"commandExecution","command":"pwd","status":"inProgress"}
+		}`))
+		client.handleNotification("item/commandExecution/outputDelta", json.RawMessage(`{
+			"threadId":"thread-1","itemId":"cmd-fallback","delta":"/wo"
+		}`))
+		client.handleNotification("item/commandExecution/outputDelta", json.RawMessage(`{
+			"threadId":"thread-1","itemId":"cmd-fallback","delta":"rk\n"
+		}`))
+		client.handleNotification("item/completed", json.RawMessage(`{
+			"threadId":"thread-1",
+			"item":{"id":"cmd-fallback","type":"commandExecution","command":"pwd","status":"completed","exitCode":0}
+		}`))
+		client.handleNotification("turn/completed", json.RawMessage(`{
+			"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}
+		}`))
+
+		events := drainEvents(turn)
+		Expect(events).To(HaveLen(3))
+		Expect(events[0].Kind).To(Equal(ai.EventToolUse))
+		Expect(events[1]).To(MatchFields(IgnoreExtras, Fields{
+			"Kind": Equal(ai.EventToolResult), "Text": Equal("/work\n"),
+			"ToolCallID": Equal("cmd-fallback"), "Success": BeTrue(),
+		}))
+		Expect(events[2].Kind).To(Equal(ai.EventResult))
+	})
+
+	It("flushes a completed command before a transport terminal error", func() {
+		client, turn := activeGinkgoTurn()
+		client.handleNotification("item/started", json.RawMessage(`{
+			"threadId":"thread-1",
+			"item":{"id":"cmd-exit","type":"commandExecution","command":"pwd","status":"inProgress"}
+		}`))
+		client.handleNotification("item/completed", json.RawMessage(`{
+			"threadId":"thread-1",
+			"item":{"id":"cmd-exit","type":"commandExecution","command":"pwd","status":"completed","exitCode":0,"aggregatedOutput":"/work\n"}
+		}`))
+
+		turn.flushToolResults()
+		turn.send(ai.Event{Kind: ai.EventError, Error: "codex app-server exited unexpectedly"})
+
+		events := drainEvents(turn)
+		Expect(events).To(HaveLen(3))
+		Expect(events[1].Kind).To(Equal(ai.EventToolResult))
+		Expect(events[1].ToolCallID).To(Equal("cmd-exit"))
+		Expect(events[2].Kind).To(Equal(ai.EventError))
 	})
 
 	It("marks nonzero command completion as failed", func() {
@@ -67,9 +126,12 @@ var _ = Describe("Codex app-server tool lifecycle", func() {
 			"threadId":"thread-1",
 			"item":{"id":"cmd-2","type":"commandExecution","command":"false","status":"failed","exitCode":1,"aggregatedOutput":"failed\n"}
 		}`))
+		client.handleNotification("turn/completed", json.RawMessage(`{
+			"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}
+		}`))
 
 		events := drainEvents(turn)
-		Expect(events).To(HaveLen(2))
+		Expect(events).To(HaveLen(3))
 		Expect(events[1].Kind).To(Equal(ai.EventToolResult))
 		Expect(events[1].Success).To(BeFalse())
 		Expect(events[1].Text).To(Equal("failed\n"))

--- a/pkg/ai/provider/codex_appserver_params_test.go
+++ b/pkg/ai/provider/codex_appserver_params_test.go
@@ -63,6 +63,7 @@ func TestBuildThreadStartParams_Safety(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := buildThreadStartParams("gpt-5", tc.req, nil)
+			assert.Equal(t, true, p["experimentalRawEvents"])
 			assert.Equal(t, tc.wantSandbox, p["sandbox"])
 			assert.Equal(t, tc.wantApproval, p["approvalPolicy"])
 			_, hasEphem := p["ephemeral"]

--- a/pkg/ai/provider/codex_appserver_protocol.go
+++ b/pkg/ai/provider/codex_appserver_protocol.go
@@ -51,6 +51,8 @@ type appServerItemBody struct {
 	Status           string              `json:"status"`
 	Arguments        json.RawMessage     `json:"arguments"`
 	AggregatedOutput *string             `json:"aggregatedOutput"`
+	CallID           string              `json:"call_id"`
+	Output           json.RawMessage     `json:"output"`
 	ExitCode         *int                `json:"exitCode"`
 	Success          *bool               `json:"success"`
 	Result           json.RawMessage     `json:"result"`
@@ -281,6 +283,15 @@ func appServerToolSucceeded(it *appServerItemBody) bool {
 	return it.Status == "completed"
 }
 
+func appServerRawCommandOutput(params json.RawMessage) (string, string, bool) {
+	it := parseAppServerNotif(params).Item
+	if it == nil || it.Type != "function_call_output" || it.CallID == "" || len(it.Output) == 0 {
+		return "", "", false
+	}
+	text := history.CodexCommandOutputText(history.CodexOutputText(it.Output))
+	return it.CallID, text, true
+}
+
 // appServerErrorIsFatal reports whether an error/turn-failure notification ends
 // the turn. A retryable error (willRetry=true) is surfaced but not terminal.
 func appServerErrorIsFatal(method string, params json.RawMessage) bool {
@@ -324,10 +335,10 @@ func composePrompt(req ai.Request) string {
 // buildThreadStartParams translates the provider-agnostic safety knobs into
 // thread/start params. The CLI-only ignore-user-config / ignore-rules flags
 // (req.Memory.SkipUser/SkipProject/SkipHooks) have no first-class equivalent in
-// the versioned thread/start schema, so only ephemeral + an empty mcp_servers
-// override (the knobs the protocol exposes) are emitted.
+// the versioned thread/start schema. Raw response items provide the authoritative
+// command output when Codex's normal command item misses an early output chunk.
 func buildThreadStartParams(model string, req ai.Request, callerTools *api.CallerToolEndpoint) map[string]any {
-	p := map[string]any{}
+	p := map[string]any{"experimentalRawEvents": true}
 	if cwd := req.Cwd(); cwd != "" {
 		p["cwd"] = cwd
 	}
@@ -394,6 +405,9 @@ func buildTurnStartParams(model string, req ai.Request, threadID string, outputS
 }
 
 func buildResumeParams(req ai.Request, callerTools *api.CallerToolEndpoint) map[string]any {
+	// Unlike thread/start, Codex's versioned thread/resume schema does not expose
+	// experimentalRawEvents. A cold-resumed thread therefore uses the ordinary
+	// command-output fallback until Codex adds that protocol capability.
 	p := map[string]any{"threadId": req.SessionID}
 	if cwd := req.Cwd(); cwd != "" {
 		p["cwd"] = cwd

--- a/pkg/ai/provider/codex_appserver_turn.go
+++ b/pkg/ai/provider/codex_appserver_turn.go
@@ -16,7 +16,6 @@ type turnState struct {
 	model              string
 	streamed           map[string]string
 	toolOutput         map[string]string
-	completeToolOutput map[string]string
 	pendingToolResults []ai.Event
 	toolResultsMu      sync.Mutex
 	toolResultsClosed  bool
@@ -99,11 +98,6 @@ func (ts *turnState) queueToolResult(event ai.Event) {
 	if ts.toolResultsClosed {
 		return
 	}
-	if output, ok := ts.completeToolOutput[event.ToolCallID]; ok {
-		delete(ts.completeToolOutput, event.ToolCallID)
-		ts.send(withToolResultText(event, output))
-		return
-	}
 	ts.pendingToolResults = append(ts.pendingToolResults, event)
 }
 
@@ -118,13 +112,14 @@ func (ts *turnState) receiveCompleteToolOutput(toolCallID, output string) {
 			continue
 		}
 		ts.pendingToolResults = append(ts.pendingToolResults[:i], ts.pendingToolResults[i+1:]...)
-		ts.send(withToolResultText(event, output))
+		event.Text = output
+		if raw, ok := event.Raw.(claude.ToolUse); ok {
+			raw.Response = output
+			event.Raw = raw
+		}
+		ts.send(event)
 		return
 	}
-	if ts.completeToolOutput == nil {
-		ts.completeToolOutput = map[string]string{}
-	}
-	ts.completeToolOutput[toolCallID] = output
 }
 
 func (ts *turnState) flushToolResults() {
@@ -138,92 +133,4 @@ func (ts *turnState) flushToolResults() {
 		ts.send(event)
 	}
 	ts.pendingToolResults = nil
-	ts.completeToolOutput = nil
-}
-
-func withToolResultText(event ai.Event, text string) ai.Event {
-	event.Text = text
-	if raw, ok := event.Raw.(claude.ToolUse); ok {
-		raw.Response = text
-		event.Raw = raw
-	}
-	return event
-}
-
-// handleNotification routes one notification to the active turn. It runs on the
-// rpc Run goroutine (notifications dispatch sequentially). Pending tool results
-// also synchronize with driveTurn's cancellation and process-exit paths.
-func (c *CodexAppServer) handleNotification(method string, params json.RawMessage) {
-	ts := c.currentTurn()
-	if ts == nil {
-		return
-	}
-	ctx := appServerEventContext{Model: ts.model, Usage: ts.usage}
-	switch method {
-	case "item/agentMessage/delta":
-		notification := parseAppServerNotif(params)
-		if notification.ItemID != "" {
-			ts.streamed[notification.ItemID] += notification.Delta
-		}
-		if len(ts.outputSchema) > 0 {
-			return
-		}
-	case "rawResponseItem/completed":
-		if toolCallID, output, ok := appServerRawCommandOutput(params); ok {
-			ts.receiveCompleteToolOutput(toolCallID, output)
-		}
-		return
-	case "item/commandExecution/outputDelta":
-		n := parseAppServerNotif(params)
-		if n.ItemID != "" && n.Delta != "" {
-			ts.toolOutput[n.ItemID] += n.Delta
-		}
-		return
-	case "item/completed":
-		// The completed agent message carries the full text (structured runs use it
-		// as the validated JSON result). Capture it, then drop the duplicate so
-		// CoalesceStream / renderers don't double-count already-streamed deltas.
-		if it := parseAppServerNotif(params).Item; it != nil && it.Type == "agentMessage" {
-			ts.lastAgentMessage = it.Text
-			if len(ts.outputSchema) > 0 {
-				return
-			}
-		}
-		remainder, streamed, err := appServerAgentMessageRemainder(params, ts.streamed)
-		if err != nil {
-			ts.send(ai.Event{Kind: ai.EventError, Error: err.Error(), Model: ts.model})
-			return
-		}
-		if streamed {
-			if remainder != "" {
-				ts.send(ai.Event{Kind: ai.EventText, Text: remainder, Model: ts.model})
-			}
-			return
-		}
-		if it := parseAppServerNotif(params).Item; it != nil {
-			ctx.ToolOutput = ts.toolOutput[it.ID]
-			delete(ts.toolOutput, it.ID)
-		}
-	}
-	terminal := method == "turn/completed" || appServerErrorIsFatal(method, params)
-	if terminal {
-		ts.flushToolResults()
-	}
-	if ev, ok := mapAppServerNotification(method, params, ctx); ok {
-		if ev.Kind == ai.EventResult && len(ts.outputSchema) > 0 {
-			ev.StructuredData = json.RawMessage(ts.lastAgentMessage)
-		}
-		if method == "item/completed" && ev.Kind == ai.EventToolResult {
-			it := parseAppServerNotif(params).Item
-			if it != nil && it.Type == "commandExecution" {
-				ts.queueToolResult(ev)
-				return
-			}
-		}
-		ts.send(ev)
-	}
-	if terminal {
-		c.clearActive(ts)
-		ts.signalTerminal()
-	}
 }

--- a/pkg/ai/provider/codex_appserver_turn.go
+++ b/pkg/ai/provider/codex_appserver_turn.go
@@ -7,14 +7,19 @@ import (
 	"sync"
 
 	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/claude"
 )
 
 type turnState struct {
-	ch         chan ai.Event
-	usage      *ai.Usage
-	model      string
-	streamed   map[string]string
-	toolOutput map[string]string
+	ch                 chan ai.Event
+	usage              *ai.Usage
+	model              string
+	streamed           map[string]string
+	toolOutput         map[string]string
+	completeToolOutput map[string]string
+	pendingToolResults []ai.Event
+	toolResultsMu      sync.Mutex
+	toolResultsClosed  bool
 
 	outputSchema     json.RawMessage
 	lastAgentMessage string
@@ -86,4 +91,139 @@ func (ts *turnState) finish() {
 	}
 	ts.closed = true
 	close(ts.ch)
+}
+
+func (ts *turnState) queueToolResult(event ai.Event) {
+	ts.toolResultsMu.Lock()
+	defer ts.toolResultsMu.Unlock()
+	if ts.toolResultsClosed {
+		return
+	}
+	if output, ok := ts.completeToolOutput[event.ToolCallID]; ok {
+		delete(ts.completeToolOutput, event.ToolCallID)
+		ts.send(withToolResultText(event, output))
+		return
+	}
+	ts.pendingToolResults = append(ts.pendingToolResults, event)
+}
+
+func (ts *turnState) receiveCompleteToolOutput(toolCallID, output string) {
+	ts.toolResultsMu.Lock()
+	defer ts.toolResultsMu.Unlock()
+	if ts.toolResultsClosed {
+		return
+	}
+	for i, event := range ts.pendingToolResults {
+		if event.ToolCallID != toolCallID {
+			continue
+		}
+		ts.pendingToolResults = append(ts.pendingToolResults[:i], ts.pendingToolResults[i+1:]...)
+		ts.send(withToolResultText(event, output))
+		return
+	}
+	if ts.completeToolOutput == nil {
+		ts.completeToolOutput = map[string]string{}
+	}
+	ts.completeToolOutput[toolCallID] = output
+}
+
+func (ts *turnState) flushToolResults() {
+	ts.toolResultsMu.Lock()
+	defer ts.toolResultsMu.Unlock()
+	if ts.toolResultsClosed {
+		return
+	}
+	ts.toolResultsClosed = true
+	for _, event := range ts.pendingToolResults {
+		ts.send(event)
+	}
+	ts.pendingToolResults = nil
+	ts.completeToolOutput = nil
+}
+
+func withToolResultText(event ai.Event, text string) ai.Event {
+	event.Text = text
+	if raw, ok := event.Raw.(claude.ToolUse); ok {
+		raw.Response = text
+		event.Raw = raw
+	}
+	return event
+}
+
+// handleNotification routes one notification to the active turn. It runs on the
+// rpc Run goroutine (notifications dispatch sequentially). Pending tool results
+// also synchronize with driveTurn's cancellation and process-exit paths.
+func (c *CodexAppServer) handleNotification(method string, params json.RawMessage) {
+	ts := c.currentTurn()
+	if ts == nil {
+		return
+	}
+	ctx := appServerEventContext{Model: ts.model, Usage: ts.usage}
+	switch method {
+	case "item/agentMessage/delta":
+		notification := parseAppServerNotif(params)
+		if notification.ItemID != "" {
+			ts.streamed[notification.ItemID] += notification.Delta
+		}
+		if len(ts.outputSchema) > 0 {
+			return
+		}
+	case "rawResponseItem/completed":
+		if toolCallID, output, ok := appServerRawCommandOutput(params); ok {
+			ts.receiveCompleteToolOutput(toolCallID, output)
+		}
+		return
+	case "item/commandExecution/outputDelta":
+		n := parseAppServerNotif(params)
+		if n.ItemID != "" && n.Delta != "" {
+			ts.toolOutput[n.ItemID] += n.Delta
+		}
+		return
+	case "item/completed":
+		// The completed agent message carries the full text (structured runs use it
+		// as the validated JSON result). Capture it, then drop the duplicate so
+		// CoalesceStream / renderers don't double-count already-streamed deltas.
+		if it := parseAppServerNotif(params).Item; it != nil && it.Type == "agentMessage" {
+			ts.lastAgentMessage = it.Text
+			if len(ts.outputSchema) > 0 {
+				return
+			}
+		}
+		remainder, streamed, err := appServerAgentMessageRemainder(params, ts.streamed)
+		if err != nil {
+			ts.send(ai.Event{Kind: ai.EventError, Error: err.Error(), Model: ts.model})
+			return
+		}
+		if streamed {
+			if remainder != "" {
+				ts.send(ai.Event{Kind: ai.EventText, Text: remainder, Model: ts.model})
+			}
+			return
+		}
+		if it := parseAppServerNotif(params).Item; it != nil {
+			ctx.ToolOutput = ts.toolOutput[it.ID]
+			delete(ts.toolOutput, it.ID)
+		}
+	}
+	terminal := method == "turn/completed" || appServerErrorIsFatal(method, params)
+	if terminal {
+		ts.flushToolResults()
+	}
+	if ev, ok := mapAppServerNotification(method, params, ctx); ok {
+		if ev.Kind == ai.EventResult && len(ts.outputSchema) > 0 {
+			ev.StructuredData = json.RawMessage(ts.lastAgentMessage)
+		}
+		if method == "item/completed" && ev.Kind == ai.EventToolResult {
+			it := parseAppServerNotif(params).Item
+			if it != nil && it.Type == "commandExecution" {
+				ts.queueToolResult(ev)
+				return
+			}
+		}
+		ts.send(ev)
+	}
+	if terminal {
+		c.clearActive(ts)
+		ts.signalTerminal()
+	}
 }


### PR DESCRIPTION
Closes #12

Main already maps Codex command starts to `EventToolUse`, buffers output deltas, and emits a correlated `EventToolResult` on completion.

However, Codex 0.147 can omit the first output chunk from both its deltas and `aggregatedOutput`. This PR finishes the implementation by correlating the complete raw `function_call_output` with the command, while retaining the existing accumulated output as a fallback.

Tested with the provider test suite, race detector, and a live authenticated Codex run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex command output handling for more accurate tool results.
  * Ensured pending tool results are delivered before cancellations, crashes, connection failures, and other terminal errors.
  * Improved completion reporting so final turn results are emitted reliably.
  * Added support for processing raw command execution events and correlating them with the correct tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->