### PR TITLE
fix(database): reconcile chat session activity and state version

### DIFF
--- a/pkg/database/session_chat_store.go
+++ b/pkg/database/session_chat_store.go
@@ -354,8 +354,7 @@ func (db *DB) DeleteChatSession(ctx context.Context, id uuid.UUID) error {
 func (db *DB) touchChatSession(ctx context.Context, id uuid.UUID) error {
 	result := db.gorm.WithContext(ctx).Model(&sessionRecord{}).Where("id = ?", id).
 		Updates(map[string]any{
-			"state_version":    gorm.Expr("state_version + 1"),
-			"last_activity_at": time.Now().UTC(),
+			"last_activity_at": gorm.Expr("GREATEST(last_activity_at, ?)", time.Now().UTC()),
 		})
 	if result.Error != nil {
 		return fmt.Errorf("touch Captain chat session: %w", result.Error)

--- a/pkg/database/session_last_activity_integration_test.go
+++ b/pkg/database/session_last_activity_integration_test.go
@@ -195,6 +195,26 @@ func TestLastActivityAt_ChatMessageIsMonotonic(t *testing.T) {
 	assert.True(t, got.Equal(newer), "chat message moved last_activity_at backwards: got %v, want %v", got, newer)
 }
 
+func TestTouchChatSessionDoesNotAdvanceStateVersion(t *testing.T) {
+	db := openLastActivityTestDB(t)
+	session, err := db.CreateOrGetSession(t.Context(), CreateSessionInput{
+		ID: uuid.New(), Source: "aichat", Provider: "captain", HostID: "local",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.touchChatSession(t.Context(), session.ID))
+	touched, err := db.GetSession(t.Context(), session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, session.StateVersion, touched.StateVersion)
+
+	running := SessionLifecycleRunning
+	updated, err := db.UpdateSessionState(t.Context(), UpdateSessionStateInput{
+		ID: session.ID, ExpectedVersion: session.StateVersion, LifecycleStatus: &running,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, session.StateVersion+1, updated.StateVersion)
+}
+
 func TestLastActivityAt_ChildActivityOnlyRewritesSessionWhenAdvancing(t *testing.T) {
 	db := openLastActivityTestDB(t)
 	now := time.Now().UTC().Truncate(time.Second)

--- a/pkg/database/session_last_activity_integration_test.go
+++ b/pkg/database/session_last_activity_integration_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -168,6 +169,30 @@ func TestLastActivityAt_IngestIsMonotonic(t *testing.T) {
 		require.NotNil(t, got)
 		assert.True(t, got.Equal(advanced), "last_activity_at = %v, want advanced %v", got, advanced)
 	})
+}
+
+func TestLastActivityAt_ChatMessageIsMonotonic(t *testing.T) {
+	db := openLastActivityTestDB(t)
+	session, err := db.CreateOrGetSession(t.Context(), CreateSessionInput{
+		ID: uuid.New(), Source: "aichat", Provider: "captain", HostID: "local",
+	})
+	require.NoError(t, err)
+	turn, created, err := db.CreateChatTurn(t.Context(), CreateChatTurnInput{
+		SessionID: session.ID, ProviderTurnID: "turn-1",
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	newer := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
+	pinLastActivity(t, db, session.ID, newer)
+	require.NoError(t, db.PutChatMessage(t.Context(), PutChatMessageInput{
+		SessionID: session.ID, TurnID: turn.ID, ProviderMessageID: "message-1",
+		Role: "user", Parts: json.RawMessage(`[{"type":"text","text":"hello"}]`),
+	}))
+
+	got := lastActivityAt(t, db, session.ID)
+	require.NotNil(t, got)
+	assert.True(t, got.Equal(newer), "chat message moved last_activity_at backwards: got %v, want %v", got, newer)
 }
 
 func TestLastActivityAt_ChildActivityOnlyRewritesSessionWhenAdvancing(t *testing.T) {


### PR DESCRIPTION
`last_activity_at` is a high-water mark. The activity trigger and transcript ingest preserve that invariant, but `touchChatSession` assigned the current time directly and could move it backwards.

This changes the chat writer to use the same monotonic semantics as the other writers.

`touchChatSession` also attempted to increment `state_version`, but the session state trigger always discarded that increment because no state fields changed. The ineffective write is removed, preserving the existing optimistic-concurrency behavior.

Tests cover both contracts: chat activity cannot move backwards, and a chat touch does not advance `state_version`.

Closes #57