### PR TITLE
Make chat sessions authoritative and forkable

### DIFF
--- a/pkg/aichat/approval_execution.go
+++ b/pkg/aichat/approval_execution.go
@@ -45,29 +45,31 @@ func awaitSuspendedSeed(ctx context.Context, store ThreadStore, threadID, turnID
 	}
 }
 
-func (s *Service) resumeToolApproval(ctx context.Context, threadID string, continuation *ApprovalContinuation) error {
+// resumeToolApproval reports whether it consumed the caller's pending
+// reservation, even when the activated continuation later fails.
+func (s *Service) resumeToolApproval(ctx context.Context, threadID string, continuation *ApprovalContinuation) (bool, error) {
 	if continuation == nil || continuation.Execution == nil || continuation.Spec.ToolApproval == nil {
-		return fmt.Errorf("tool approval continuation is incomplete")
+		return false, fmt.Errorf("tool approval continuation is incomplete")
 	}
 	execution := continuation.Execution
 	defer closeExecution(execution)
 	profile, err := s.runtimeProfile(ctx)
 	if err != nil {
-		return fmt.Errorf("load chat runtime profile: %w", err)
+		return false, fmt.Errorf("load chat runtime profile: %w", err)
 	}
 	if err := enforceApprovalRuntimeProfile(continuation.Spec, profile.Resolved); err != nil {
 		if interruptErr := execution.Interrupt(ctx, err.Error()); interruptErr != nil {
-			return fmt.Errorf("%w (interrupt rejected approval continuation: %v)", err, interruptErr)
+			return false, fmt.Errorf("%w (interrupt rejected approval continuation: %v)", err, interruptErr)
 		}
-		return err
+		return false, err
 	}
 	set, err := s.loadTools(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	definitions, err := aitools.ResolveDefinitions(set.Definitions, continuation.Spec.ToolPreferences)
 	if err != nil {
-		return err
+		return false, err
 	}
 	config := profile.ProviderConfig
 	config.Model = continuation.Spec.Model
@@ -77,12 +79,12 @@ func (s *Service) resumeToolApproval(ctx context.Context, threadID string, conti
 	config.Tools = definitions
 	config, err = s.prepareProviderConfig(ctx, config)
 	if err != nil {
-		return err
+		return false, err
 	}
 	continuation.Spec.Model = config.Model
 	provider, err := s.resolver.Provider(ctx, config)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() {
 		if closeErr := closeProvider(provider); closeErr != nil {
@@ -92,12 +94,12 @@ func (s *Service) resumeToolApproval(ctx context.Context, threadID string, conti
 	if len(definitions) > 0 {
 		capability, ok := api.ProviderAs[api.ToolCapableProvider](provider)
 		if !ok || !capability.SupportsCallerTools() {
-			return fmt.Errorf("backend %q does not support caller tools", provider.GetBackend())
+			return false, fmt.Errorf("backend %q does not support caller tools", provider.GetBackend())
 		}
 	}
 	seed, err := s.awaitSuspendedSeed(ctx, threadID, execution.TurnID())
 	if err != nil {
-		return err
+		return false, err
 	}
 	request := ChatRequest{
 		ID: threadID, ThreadID: threadID, Trigger: "submit-message", MessageID: seed.ID,
@@ -107,26 +109,28 @@ func (s *Service) resumeToolApproval(ctx context.Context, threadID string, conti
 	defer cancel()
 	active := newActiveTurn(streamContext, provider, execution, cancel)
 	if err := s.registerActiveTurn(threadID, active); err != nil {
-		return err
+		return false, err
 	}
 	defer s.unregisterActiveTurn(threadID, active)
 	events, err := provider.ExecuteStream(streamContext, continuation.Spec)
 	if err != nil {
-		return err
+		return true, err
 	}
+	runtime := func() api.Model { return providerRuntime(provider, config.Model) }
+	events = s.bindThreadRuntime(streamContext, threadID, execution, runtime, events)
 	events = active.stream(events)
 	events = observeExecutionEvents(streamContext, execution, events)
 	// A resumed approval writes no SSE stream, so no TurnCosts sink is needed;
 	// the thread total is recomputed from the database on the next read.
 	resumed := s.persistedEvents(streamContext, persistedEventOptions{
-		Request: request, TurnID: execution.TurnID(), Model: continuation.Spec.Model,
+		Request: request, TurnID: execution.TurnID(), Model: continuation.Spec.Model, Runtime: runtime,
 	}, events)
 	for event := range resumed {
 		if event.Kind == api.EventError {
-			return fmt.Errorf("resume provider approval: %s", event.Error)
+			return true, fmt.Errorf("resume provider approval: %s", event.Error)
 		}
 	}
-	return nil
+	return true, nil
 }
 
 func enforceApprovalRuntimeProfile(spec api.Spec, resolved api.ResolvedSpec) error {

--- a/pkg/aichat/approval_execution.go
+++ b/pkg/aichat/approval_execution.go
@@ -105,15 +105,15 @@ func (s *Service) resumeToolApproval(ctx context.Context, threadID string, conti
 	}
 	streamContext, cancel := context.WithCancel(ctx)
 	defer cancel()
-	events, err := provider.ExecuteStream(streamContext, continuation.Spec)
-	if err != nil {
-		return err
-	}
 	active := newActiveTurn(streamContext, provider, execution, cancel)
 	if err := s.registerActiveTurn(threadID, active); err != nil {
 		return err
 	}
 	defer s.unregisterActiveTurn(threadID, active)
+	events, err := provider.ExecuteStream(streamContext, continuation.Spec)
+	if err != nil {
+		return err
+	}
 	events = active.stream(events)
 	events = observeExecutionEvents(streamContext, execution, events)
 	// A resumed approval writes no SSE stream, so no TurnCosts sink is needed;

--- a/pkg/aichat/approval_http.go
+++ b/pkg/aichat/approval_http.go
@@ -2,6 +2,7 @@ package aichat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -39,9 +40,16 @@ func (s *Service) handleResolveToolApproval(w http.ResponseWriter, request *http
 		http.Error(w, "denied tool approval cannot replace input", http.StatusBadRequest)
 		return
 	}
+	activeTurnID, err := s.reserveThreadForApproval(threadID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	defer s.releaseThreadReservation(threadID)
 	continuation, err := s.options.Authority.ResolveToolApproval(request.Context(), ToolApprovalResolution{
 		ThreadID: threadID, ApprovalID: request.PathValue("approvalID"),
-		Approved: *body.Approved, UpdatedInput: body.UpdatedInput, Reason: body.Reason,
+		ExpectedTurnID: activeTurnID,
+		Approved:       *body.Approved, UpdatedInput: body.UpdatedInput, Reason: body.Reason,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
@@ -49,7 +57,11 @@ func (s *Service) handleResolveToolApproval(w http.ResponseWriter, request *http
 	}
 	if continuation != nil {
 		if err := s.resumeToolApproval(request.Context(), threadID, continuation); err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			status := http.StatusBadGateway
+			if errors.Is(err, errThreadBusy) {
+				status = http.StatusConflict
+			}
+			http.Error(w, err.Error(), status)
 			return
 		}
 	}

--- a/pkg/aichat/approval_http.go
+++ b/pkg/aichat/approval_http.go
@@ -45,7 +45,12 @@ func (s *Service) handleResolveToolApproval(w http.ResponseWriter, request *http
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
-	defer s.releaseThreadReservation(threadID)
+	reserved := true
+	defer func() {
+		if reserved {
+			s.releaseThreadReservation(threadID)
+		}
+	}()
 	continuation, err := s.options.Authority.ResolveToolApproval(request.Context(), ToolApprovalResolution{
 		ThreadID: threadID, ApprovalID: request.PathValue("approvalID"),
 		ExpectedTurnID: activeTurnID,
@@ -56,7 +61,11 @@ func (s *Service) handleResolveToolApproval(w http.ResponseWriter, request *http
 		return
 	}
 	if continuation != nil {
-		if err := s.resumeToolApproval(request.Context(), threadID, continuation); err != nil {
+		activated, err := s.resumeToolApproval(request.Context(), threadID, continuation)
+		if activated {
+			reserved = false
+		}
+		if err != nil {
 			status := http.StatusBadGateway
 			if errors.Is(err, errThreadBusy) {
 				status = http.StatusConflict

--- a/pkg/aichat/database_threads.go
+++ b/pkg/aichat/database_threads.go
@@ -3,6 +3,7 @@ package aichat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,11 @@ import (
 	"github.com/flanksource/captain/pkg/database"
 	"github.com/flanksource/captain/pkg/session"
 	"github.com/google/uuid"
+)
+
+const (
+	threadRuntimeMetadataKey = "aichatRuntime"
+	forkedFromMetadataKey    = "forkedFrom"
 )
 
 type DatabaseThreadStore struct {
@@ -41,17 +47,18 @@ func (s *DatabaseThreadStore) Create(ctx context.Context, title string) (*Thread
 }
 
 func (s *DatabaseThreadStore) List(ctx context.Context) ([]*Thread, error) {
-	overviews, err := s.db.ListSessionOverviews(ctx, database.SessionOverviewFilter{Source: "aichat", RootsOnly: true})
+	overviews, err := s.db.ListSessionOverviews(ctx, database.SessionOverviewFilter{
+		Source: "aichat", RootsOnly: true, Limit: maxThreadSummaries,
+	})
 	if err != nil {
 		return nil, err
 	}
 	threads := make([]*Thread, len(overviews))
 	for i := range overviews {
-		aggregate, err := s.getSession(ctx, overviews[i])
+		threads[i], err = threadSummaryFromOverview(overviews[i])
 		if err != nil {
 			return nil, err
 		}
-		threads[i] = threadFromSession(aggregate, overviews[i])
 	}
 	return threads, nil
 }
@@ -68,7 +75,7 @@ func (s *DatabaseThreadStore) Get(ctx context.Context, id string) (*Thread, erro
 	if err != nil {
 		return nil, err
 	}
-	return threadFromSession(aggregate, *overview), nil
+	return threadFromSession(aggregate, *overview)
 }
 
 func (s *DatabaseThreadStore) GetSession(ctx context.Context, id string) (*session.Session, error) {
@@ -86,6 +93,9 @@ func (s *DatabaseThreadStore) getOverview(ctx context.Context, id string) (*data
 	}
 	overview, err := s.db.GetSessionOverviewByIdentity(ctx, parsed.String())
 	if err != nil {
+		if errors.Is(err, database.ErrSessionNotFound) {
+			return nil, fmt.Errorf("%w: %s", ErrThreadNotFound, parsed)
+		}
 		return nil, err
 	}
 	if overview.ID != parsed {
@@ -120,6 +130,12 @@ func (s *DatabaseThreadStore) getSession(ctx context.Context, overview database.
 	if err := ApplyOverviewProjection(ctx, s.db, overview, aggregate); err != nil {
 		return nil, err
 	}
+	runtime, forkedFrom, err := threadIdentityMetadata(overview.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("decode Captain chat session %s metadata: %w", overview.ID, err)
+	}
+	aggregate.Runtime = runtime
+	aggregate.ForkedFrom = forkedFrom
 	// The overview's own usage/cost is root-scoped; a thread's subagents spend
 	// against the same conversation, so roll the thread-wide figures on top.
 	applyThreadCosts(aggregate, costs)
@@ -156,9 +172,12 @@ func (s *DatabaseThreadStore) putMessage(ctx context.Context, id string, message
 	if err != nil {
 		return fmt.Errorf("captain chat session ID %q is not a UUID: %w", id, err)
 	}
-	turnID, err := uuid.Parse(message.TurnID)
-	if err != nil {
-		return fmt.Errorf("captain chat message %q turn ID %q is not a UUID: %w", message.ID, message.TurnID, err)
+	turnID := uuid.Nil
+	if strings.TrimSpace(message.TurnID) != "" {
+		turnID, err = uuid.Parse(message.TurnID)
+		if err != nil {
+			return fmt.Errorf("captain chat message %q turn ID %q is not a UUID: %w", message.ID, message.TurnID, err)
+		}
 	}
 	parts, err := json.Marshal(message.Parts)
 	if err != nil {
@@ -201,6 +220,56 @@ func (s *DatabaseThreadStore) SetProviderSession(ctx context.Context, id, provid
 		ID: parsed, ExpectedVersion: record.StateVersion, ProviderSessionID: &providerSessionID,
 	})
 	return err
+}
+
+func (s *DatabaseThreadStore) SetRuntime(ctx context.Context, id string, runtime api.Model) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return fmt.Errorf("captain chat session ID %q is not a UUID: %w", id, err)
+	}
+	identity, err := threadRuntimeIdentity(runtime)
+	if err != nil {
+		return err
+	}
+	if err := s.db.SetSessionMetadataOnce(ctx, parsed, threadRuntimeMetadataKey, identity); err != nil {
+		if errors.Is(err, database.ErrSessionConflict) {
+			return fmt.Errorf("%w: %v", ErrThreadRuntimeConflict, err)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *DatabaseThreadStore) Fork(ctx context.Context, id string) (*Thread, error) {
+	source, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	title, seed, err := forkSeedMessage(source)
+	if err != nil {
+		return nil, err
+	}
+	parts, err := json.Marshal(seed.Parts)
+	if err != nil {
+		return nil, fmt.Errorf("encode fork seed: %w", err)
+	}
+	forkID := uuid.New()
+	if _, err := s.db.ForkChatSession(ctx, database.ForkChatSessionInput{
+		SourceSessionID: sourceID(source), ExpectedSourceUpdatedAt: source.UpdatedAt,
+		SessionID: forkID, Title: title,
+		Metadata: map[string]any{
+			"aichat": true, forkedFromMetadataKey: source.ID,
+			database.SessionTitleSourceKey: string(database.SessionTitleDerived),
+		},
+		ProviderMessageID: seed.ID, Role: seed.Role, Parts: parts,
+	}); err != nil {
+		return nil, err
+	}
+	return s.Get(ctx, forkID.String())
+}
+
+func sourceID(thread *Thread) uuid.UUID {
+	return uuid.MustParse(thread.ID)
 }
 
 func (s *DatabaseThreadStore) SetTitle(ctx context.Context, id string, update TitleUpdate) error {
@@ -383,7 +452,7 @@ func applyRequestState(aggregate *session.Session) {
 	}
 }
 
-func threadFromSession(aggregate *session.Session, overview database.SessionOverview) *Thread {
+func threadFromSession(aggregate *session.Session, overview database.SessionOverview) (*Thread, error) {
 	messages := make([]UIMessage, len(aggregate.Messages))
 	for i := range aggregate.Messages {
 		parts := make([]UIPart, len(aggregate.Messages[i].Parts))
@@ -403,13 +472,66 @@ func threadFromSession(aggregate *session.Session, overview database.SessionOver
 			Parts: parts, TurnID: aggregate.Messages[i].TurnID,
 		}
 	}
-	return &Thread{
-		ID: aggregate.ID, Title: aggregate.Title, CreatedAt: overview.CreatedAt, UpdatedAt: overview.UpdatedAt,
-		Messages: messages, TotalInputTokens: aggregate.Usage.InputTokens, TotalOutputTokens: aggregate.Usage.OutputTokens,
-		TotalReasoningTokens: aggregate.Usage.ReasoningTokens, TotalCacheReadTokens: aggregate.Usage.CacheReadTokens,
-		TotalCacheWriteTokens: aggregate.Usage.CacheWriteTokens, TotalCostUSD: aggregate.Cost.Total(),
-		LastContextTokens: intPointer(overview.ContextTokens), ProviderSessionID: aggregate.ProviderSessionID,
+	thread, err := threadSummaryFromOverview(overview)
+	if err != nil {
+		return nil, err
 	}
+	thread.Messages = messages
+	thread.TotalInputTokens = aggregate.Usage.InputTokens
+	thread.TotalOutputTokens = aggregate.Usage.OutputTokens
+	thread.TotalReasoningTokens = aggregate.Usage.ReasoningTokens
+	thread.TotalCacheReadTokens = aggregate.Usage.CacheReadTokens
+	thread.TotalCacheWriteTokens = aggregate.Usage.CacheWriteTokens
+	thread.TotalCostUSD = aggregate.Cost.Total()
+	thread.ProviderSessionID = aggregate.ProviderSessionID
+	return thread, nil
+}
+
+func threadSummaryFromOverview(overview database.SessionOverview) (*Thread, error) {
+	runtime, forkedFrom, err := threadIdentityMetadata(overview.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("decode Captain chat session %s metadata: %w", overview.ID, err)
+	}
+	// Summaries intentionally carry no transcript. GET /sessions/{id} is the
+	// only hydration path, keeping the picker bounded as threads grow.
+	return &Thread{
+		ID: overview.ID.String(), Title: stringPointer(overview.Title), Revision: overview.StateVersion,
+		CreatedAt: overview.CreatedAt, UpdatedAt: overview.UpdatedAt,
+		Runtime: runtime, ForkedFrom: forkedFrom,
+		Messages: nil, TotalInputTokens: int(overview.InputTokens), TotalOutputTokens: int(overview.OutputTokens),
+		TotalReasoningTokens: int(overview.ReasoningTokens), TotalCacheReadTokens: int(overview.CacheReadTokens),
+		TotalCacheWriteTokens: int(overview.CacheWriteTokens), TotalCostUSD: overview.CostUSD,
+		LastContextTokens: intPointer(overview.ContextTokens), ProviderSessionID: stringPointer(overview.ProviderSessionID),
+	}, nil
+}
+
+func threadIdentityMetadata(raw json.RawMessage) (*api.Model, string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, "", nil
+	}
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return nil, "", err
+	}
+	var runtime *api.Model
+	if value := metadata[threadRuntimeMetadataKey]; len(value) > 0 {
+		var decoded api.Model
+		if err := json.Unmarshal(value, &decoded); err != nil {
+			return nil, "", err
+		}
+		identity, err := threadRuntimeIdentity(decoded)
+		if err != nil {
+			return nil, "", err
+		}
+		runtime = &identity
+	}
+	var forkedFrom string
+	if value := metadata[forkedFromMetadataKey]; len(value) > 0 {
+		if err := json.Unmarshal(value, &forkedFrom); err != nil {
+			return nil, "", err
+		}
+	}
+	return runtime, forkedFrom, nil
 }
 
 func stringPointer(value *string) string {

--- a/pkg/aichat/database_threads.go
+++ b/pkg/aichat/database_threads.go
@@ -59,6 +59,13 @@ func (s *DatabaseThreadStore) List(ctx context.Context) ([]*Thread, error) {
 		if err != nil {
 			return nil, err
 		}
+		if overviews[i].AgentCount > 1 {
+			costs, costErr := s.db.ListThreadCosts(ctx, overviews[i].ID)
+			if costErr != nil {
+				return nil, costErr
+			}
+			applyThreadSummaryCosts(threads[i], costs)
+		}
 	}
 	return threads, nil
 }

--- a/pkg/aichat/database_threads_integration_test.go
+++ b/pkg/aichat/database_threads_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -40,6 +41,111 @@ var _ = Describe("Database chat sessions", func() {
 		Expect(store.SetProviderSession(ctx, thread.ID, "provider-session-2")).To(MatchError(ContainSubstring(
 			`provider session ID is already bound to "provider-session-1"`,
 		)))
+	})
+
+	It("does not lock an empty thread when provider setup fails", func(ctx SpecContext) {
+		testDB := dbtest.ForGinkgo(dbtest.Options{Name: "captain_aichat_failed_provider_setup"})
+		db, err := database.Open(ctx, database.WithDSN(testDB.DSN()), database.WithMigrations())
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+		store, err := aichat.NewDatabaseThreadStore(db)
+		Expect(err).NotTo(HaveOccurred())
+		thread, err := store.Create(ctx, "Provider setup")
+		Expect(err).NotTo(HaveOccurred())
+		authority, err := aichat.NewDatabaseExecutionAuthority(db)
+		Expect(err).NotTo(HaveOccurred())
+		service := aichat.NewService(aichat.ServiceOptions{
+			Resolver: &fakeResolver{providerErr: errors.New("provider unavailable")},
+			Threads:  aichat.FixedThreadStore(store), Authority: authority,
+		})
+
+		for index, runtime := range []api.Model{
+			{Name: "first-model", Backend: api.BackendOpenAI},
+			{Name: "second-model", Backend: api.BackendAnthropic},
+		} {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message", Runtime: &runtime,
+				Messages: []aichat.UIMessage{{
+					ID: fmt.Sprintf("failed-user-%d", index), Role: "user",
+					Parts: []aichat.UIPart{{Type: "text", Text: "Retry provider setup"}},
+				}},
+			}))
+			Expect(response.Code).To(Equal(http.StatusServiceUnavailable), response.Body.String())
+			stored, getErr := store.Get(ctx, thread.ID)
+			Expect(getErr).NotTo(HaveOccurred())
+			Expect(stored.Messages).To(BeEmpty())
+			Expect(stored.Runtime).To(BeNil())
+		}
+	})
+
+	It("binds and accounts for the provider candidate selected after fallback", func(ctx SpecContext) {
+		testDB := dbtest.ForGinkgo(dbtest.Options{Name: "captain_aichat_selected_fallback"})
+		db, err := database.Open(ctx, database.WithDSN(testDB.DSN()), database.WithMigrations())
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+		store, err := aichat.NewDatabaseThreadStore(db)
+		Expect(err).NotTo(HaveOccurred())
+		thread, err := store.Create(ctx, "Fallback")
+		Expect(err).NotTo(HaveOccurred())
+		authority, err := aichat.NewDatabaseExecutionAuthority(db)
+		Expect(err).NotTo(HaveOccurred())
+		provider := &fakeStreamingProvider{
+			model: "fallback-model", backend: api.BackendGemini,
+			events: []api.Event{
+				{Kind: api.EventSystem, SessionID: "fallback-session", Model: "fallback-model"},
+				{Kind: api.EventText, Text: "Fallback answer", Model: "fallback-model"},
+				{Kind: api.EventResult, Success: true, Model: "fallback-model", CostUSD: 0.25,
+					Usage: &api.Usage{InputTokens: 12, OutputTokens: 4}},
+			},
+		}
+		resolver := &fakeResolver{provider: provider}
+		service := aichat.NewService(aichat.ServiceOptions{
+			Resolver: resolver, Threads: aichat.FixedThreadStore(store), Authority: authority,
+		})
+		submit := func(id string, runtime api.Model) *httptest.ResponseRecorder {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message", Runtime: &runtime,
+				Messages: []aichat.UIMessage{{
+					ID: id, Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Use the selected runtime"}},
+				}},
+			}))
+			return response
+		}
+
+		primary := api.Model{
+			Name: "primary-model", Backend: api.BackendOpenAI,
+			Fallbacks: []api.Model{{Name: "fallback-model", Backend: api.BackendGemini, Effort: api.EffortHigh}},
+		}
+		first := submit("fallback-user-1", primary)
+		Expect(first.Code).To(Equal(http.StatusOK), first.Body.String())
+		stored, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stored.Runtime).To(Equal(&api.Model{Name: "fallback-model", Backend: api.BackendGemini}))
+		Expect(stored.ProviderSessionID).To(Equal("fallback-session"))
+
+		aggregate, err := store.GetSession(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(aggregate.Model).To(Equal("fallback-model"))
+		Expect(aggregate.Backend).To(Equal(string(api.BackendGemini)))
+		Expect(aggregate.Usage.InputTokens).To(Equal(12))
+		Expect(aggregate.Cost.Total()).To(BeNumerically("~", 0.25, 0.000001))
+		sessionID := uuid.MustParse(thread.ID)
+		runs, err := db.ListPromptRuns(ctx, database.PromptRunFilter{SessionID: &sessionID})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(runs).To(HaveLen(1))
+		Expect(runs[0].Runtime.Requested.Model).To(Equal(primary.Name))
+		Expect(runs[0].Runtime.Resolved.Model).To(Equal("fallback-model"))
+		Expect(runs[0].Runtime.Resolved.Effort).To(Equal(string(api.EffortHigh)))
+
+		conflict := submit("fallback-user-conflict", primary)
+		Expect(conflict.Code).To(Equal(http.StatusConflict), conflict.Body.String())
+		selected := api.Model{Name: "fallback-model", Backend: api.BackendGemini}
+		second := submit("fallback-user-2", selected)
+		Expect(second.Code).To(Equal(http.StatusOK), second.Body.String())
+		Expect(resolver.configs).To(HaveLen(2))
+		Expect(resolver.configs[1].SessionID).To(Equal("fallback-session"))
 	})
 
 	It("rejects stale database history snapshots before turn admission or fork creation", func(ctx SpecContext) {
@@ -101,6 +207,10 @@ var _ = Describe("Database chat sessions", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(execution.Close(ctx)).To(Succeed())
+		unbound, err := store.Get(ctx, source.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unbound.Runtime).To(BeNil(), "admission alone must not lock a provider runtime")
+		Expect(store.SetRuntime(ctx, source.ID, runtime)).To(Succeed())
 		bound, err := store.Get(ctx, source.ID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bound.Runtime).To(Equal(&runtime))

--- a/pkg/aichat/database_threads_integration_test.go
+++ b/pkg/aichat/database_threads_integration_test.go
@@ -3,6 +3,7 @@ package aichat_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -39,6 +40,110 @@ var _ = Describe("Database chat sessions", func() {
 		Expect(store.SetProviderSession(ctx, thread.ID, "provider-session-2")).To(MatchError(ContainSubstring(
 			`provider session ID is already bound to "provider-session-1"`,
 		)))
+	})
+
+	It("rejects stale database history snapshots before turn admission or fork creation", func(ctx SpecContext) {
+		testDB := dbtest.ForGinkgo(dbtest.Options{Name: "captain_aichat_stale_history"})
+		db, err := database.Open(ctx, database.WithDSN(testDB.DSN()), database.WithMigrations())
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+		store, err := aichat.NewDatabaseThreadStore(db)
+		Expect(err).NotTo(HaveOccurred())
+		thread, err := store.Create(ctx, "History snapshot")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "first-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "First"}},
+		})).To(Succeed())
+		stale, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "intervening-assistant", Role: "assistant", Parts: []aichat.UIPart{{Type: "text", Text: "Intervening"}},
+		})).To(Succeed())
+
+		authority, err := aichat.NewDatabaseExecutionAuthority(db)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = authority.Begin(ctx, aichat.ExecutionRequest{
+			ThreadID: thread.ID, RequestID: "stale-turn", Title: stale.Title,
+			ExpectedThreadUpdatedAt: stale.UpdatedAt,
+			Spec:                    api.Spec{Model: api.Model{Name: "test-model", Backend: api.BackendOpenAI}},
+		})
+		Expect(errors.Is(err, database.ErrSessionConflict)).To(BeTrue())
+
+		_, err = db.ForkChatSession(ctx, database.ForkChatSessionInput{
+			SourceSessionID: uuid.MustParse(thread.ID), ExpectedSourceUpdatedAt: stale.UpdatedAt,
+			SessionID: uuid.New(), Title: "Stale fork", ProviderMessageID: "stale-seed",
+			Role: "user", Parts: json.RawMessage(`[{"type":"text","text":"stale"}]`),
+		})
+		Expect(errors.Is(err, database.ErrSessionConflict)).To(BeTrue())
+	})
+
+	It("persists write-once runtime identity and an independent turnless fork seed", func(ctx SpecContext) {
+		testDB := dbtest.ForGinkgo(dbtest.Options{Name: "captain_aichat_runtime_fork"})
+		db, err := database.Open(ctx, database.WithDSN(testDB.DSN()), database.WithMigrations())
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+		store, err := aichat.NewDatabaseThreadStore(db)
+		Expect(err).NotTo(HaveOccurred())
+		source, err := store.Create(ctx, "Runtime source")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, source.ID, aichat.UIMessage{
+			ID: "source-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Question"}},
+		})).To(Succeed())
+		Expect(store.AppendMessage(ctx, source.ID, aichat.UIMessage{
+			ID: "source-assistant", Role: "assistant", Parts: []aichat.UIPart{{Type: "text", Text: "Answer"}},
+		})).To(Succeed())
+		runtime := api.Model{Name: "test-model", Backend: api.BackendOpenAI}
+		authority, err := aichat.NewDatabaseExecutionAuthority(db)
+		Expect(err).NotTo(HaveOccurred())
+		execution, err := authority.Begin(ctx, aichat.ExecutionRequest{
+			ThreadID: source.ID, RequestID: "runtime-binding-turn", Title: source.Title,
+			Spec: api.Spec{Model: runtime},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(execution.Close(ctx)).To(Succeed())
+		bound, err := store.Get(ctx, source.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bound.Runtime).To(Equal(&runtime))
+		Expect(store.SetRuntime(ctx, source.ID, api.Model{
+			Name: "test-model", Backend: api.BackendOpenAI, Effort: api.EffortHigh,
+		})).To(Succeed())
+		err = store.SetRuntime(ctx, source.ID, api.Model{Name: "other-model", Backend: api.BackendOpenAI})
+		Expect(errors.Is(err, aichat.ErrThreadRuntimeConflict)).To(BeTrue())
+		Expect(store.SetProviderSession(ctx, source.ID, "provider-source")).To(Succeed())
+		_, err = store.AddUsage(ctx, source.ID, aichat.TurnUsage{InputTokens: 11, OutputTokens: 5, CostUSD: 0.3})
+		Expect(err).NotTo(HaveOccurred())
+
+		fork, err := store.Fork(ctx, source.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fork.ForkedFrom).To(Equal(source.ID))
+		Expect(fork.ProviderSessionID).To(BeEmpty())
+		Expect(fork.Runtime).To(BeNil())
+		Expect(fork.TotalInputTokens).To(BeZero())
+		Expect(fork.TotalCostUSD).To(BeZero())
+		Expect(fork.Messages).To(HaveLen(1))
+		Expect(fork.Messages[0].TurnID).To(BeEmpty())
+		Expect(fork.Messages[0].Parts).To(ContainElement(HaveField("Type", "data-fork-seed")))
+
+		var parentID *uuid.UUID
+		var providerSessionID *string
+		var metadata string
+		Expect(db.Gorm().WithContext(ctx).Raw(`
+			SELECT parent_session_id, provider_session_id, metadata::text
+			FROM captain_sessions WHERE id = ?
+		`, fork.ID).Row().Scan(&parentID, &providerSessionID, &metadata)).To(Succeed())
+		Expect(parentID).To(BeNil(), "forks remain independent root sessions")
+		Expect(providerSessionID).To(BeNil())
+		Expect(metadata).To(ContainSubstring(`"forkedFrom"`))
+		Expect(metadata).NotTo(ContainSubstring(`"aichatRuntime"`))
+
+		var seedTurnID *uuid.UUID
+		Expect(db.Gorm().WithContext(ctx).Raw(`
+			SELECT turn_id FROM captain_messages WHERE session_id = ?
+		`, fork.ID).Row().Scan(&seedTurnID)).To(Succeed())
+		Expect(seedTurnID).To(BeNil())
+		roots, err := store.List(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(roots).To(HaveLen(2))
 	})
 
 	It("projects messages, turns, usage, and durable approvals from one Captain session", func(ctx SpecContext) {

--- a/pkg/aichat/execution.go
+++ b/pkg/aichat/execution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/flanksource/captain/pkg/api"
 )
@@ -11,22 +12,24 @@ import (
 // ExecutionRequest is the authoritative identity and resolved policy for one
 // chat provider turn.
 type ExecutionRequest struct {
-	ThreadID    string
-	RequestID   string
-	Title       string
-	Spec        api.Spec
-	Profile     api.ResolvedSpec
-	Definitions []api.ToolDefinition
+	ThreadID                string
+	RequestID               string
+	Title                   string
+	ExpectedThreadUpdatedAt time.Time
+	Spec                    api.Spec
+	Profile                 api.ResolvedSpec
+	Definitions             []api.ToolDefinition
 }
 
 // ToolApprovalResolution is the authenticated user's answer to one live
 // caller-tool approval.
 type ToolApprovalResolution struct {
-	ThreadID     string
-	ApprovalID   string
-	Approved     bool
-	UpdatedInput map[string]any
-	Reason       string
+	ThreadID       string
+	ApprovalID     string
+	ExpectedTurnID string
+	Approved       bool
+	UpdatedInput   map[string]any
+	Reason         string
 }
 
 type ApprovalContinuation struct {

--- a/pkg/aichat/execution.go
+++ b/pkg/aichat/execution.go
@@ -57,6 +57,12 @@ type Execution interface {
 	Close(context.Context) error
 }
 
+// executionRuntimeBinder commits the provider runtime selected after fallback
+// resolution, before any provider session identity from that runtime is stored.
+type executionRuntimeBinder interface {
+	BindRuntime(context.Context, api.Model) error
+}
+
 func mergeExecutionEvents(
 	ctx context.Context,
 	provider <-chan api.Event,

--- a/pkg/aichat/execution_authority_ginkgo_test.go
+++ b/pkg/aichat/execution_authority_ginkgo_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Authoritative aichat execution", func() {
 		Expect(persisted.Messages[3].ID).To(Equal("turn-user-message-2-assistant"))
 	})
 
-	It("regenerates the named assistant message without duplicating persisted history", func() {
+	It("repeatedly regenerates the named assistant message without reusing durable turns", func() {
 		store := aichat.NewMemoryThreadStore()
 		thread, err := store.Create(context.Background(), "Accounts")
 		Expect(err).NotTo(HaveOccurred())
@@ -326,15 +326,23 @@ var _ = Describe("Authoritative aichat execution", func() {
 			Resolver: &fakeResolver{provider: provider}, Threads: aichat.FixedThreadStore(store), Authority: authority,
 		})
 
-		response := httptest.NewRecorder()
-		service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
-			ID: thread.ID, ThreadID: thread.ID, Trigger: "regenerate-message", MessageID: assistant.ID,
-			Runtime: &api.Model{Name: "gemini", Backend: api.BackendGemini}, Messages: []aichat.UIMessage{user},
-		}))
+		regenerate := func() *httptest.ResponseRecorder {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: thread.ID, ThreadID: thread.ID, Trigger: "regenerate-message", MessageID: assistant.ID,
+				Runtime: &api.Model{Name: "gemini", Backend: api.BackendGemini}, Messages: []aichat.UIMessage{user},
+			}))
+			return response
+		}
 
-		Expect(response.Code).To(Equal(http.StatusOK), response.Body.String())
-		Expect(authority.begins).To(HaveLen(1))
-		Expect(authority.begins[0].RequestID).To(Equal(assistant.ID))
+		first := regenerate()
+		second := regenerate()
+		Expect(first.Code).To(Equal(http.StatusOK), first.Body.String())
+		Expect(second.Code).To(Equal(http.StatusOK), second.Body.String())
+		Expect(authority.begins).To(HaveLen(2))
+		Expect(authority.begins[0].RequestID).To(HavePrefix(assistant.ID + ":"))
+		Expect(authority.begins[1].RequestID).To(HavePrefix(assistant.ID + ":"))
+		Expect(authority.begins[1].RequestID).NotTo(Equal(authority.begins[0].RequestID))
 		persisted, err := store.Get(context.Background(), thread.ID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(persisted.Messages).To(HaveLen(2))

--- a/pkg/aichat/execution_database.go
+++ b/pkg/aichat/execution_database.go
@@ -84,8 +84,8 @@ func (e *databaseExecution) BindRuntime(ctx context.Context, runtime api.Model) 
 		return err
 	}
 	e.mu.Lock()
+	defer e.mu.Unlock()
 	runID, runVersion, runRuntime := e.run.ID, e.run.Version, e.run.Runtime
-	e.mu.Unlock()
 	runRuntime.Resolved = runtimeSelection(api.Model{
 		Name: identity.Name, Backend: identity.Backend, Effort: runtime.Effort,
 	})
@@ -110,11 +110,9 @@ func (e *databaseExecution) BindRuntime(ctx context.Context, runtime api.Model) 
 	if err != nil {
 		return err
 	}
-	e.mu.Lock()
 	e.model = identity.Name
 	e.backend = identity.Backend
 	e.run = updatedRun
-	e.mu.Unlock()
 	return nil
 }
 

--- a/pkg/aichat/execution_database.go
+++ b/pkg/aichat/execution_database.go
@@ -57,12 +57,15 @@ func (e *databaseExecution) finishModelCall(
 	stopReason string,
 	event api.Event,
 ) error {
+	e.mu.Lock()
+	model, backend := e.model, e.backend
+	e.mu.Unlock()
 	input := database.FinishChatModelCallInput{
 		ID: e.modelCallID, Status: status, StopReason: stopReason, Event: event,
-		ContextWindowTokens: ai.ContextWindowFor(e.backend, e.model),
+		ContextWindowTokens: ai.ContextWindowFor(backend, model),
 	}
 	if event.Usage != nil {
-		cost := ai.PriceUsage(e.backend, e.model, *event.Usage, event.CostUSD)
+		cost := ai.PriceUsage(backend, model, *event.Usage, event.CostUSD)
 		input.Cost = &cost
 	}
 	return e.db.FinishChatModelCall(ctx, input)
@@ -72,6 +75,48 @@ func (e *databaseExecution) CaptainSessionID() string { return e.session.ID.Stri
 func (e *databaseExecution) TurnID() string           { return e.turn.ID.String() }
 func (e *databaseExecution) PromptRunID() string      { return e.run.ID.String() }
 func (e *databaseExecution) Events() <-chan api.Event { return e.events }
+
+// BindRuntime atomically records the selected provider candidate on the thread,
+// prompt run, and model call before provider-specific events are observed.
+func (e *databaseExecution) BindRuntime(ctx context.Context, runtime api.Model) error {
+	identity, err := threadRuntimeIdentity(runtime)
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	runID, runVersion, runRuntime := e.run.ID, e.run.Version, e.run.Runtime
+	e.mu.Unlock()
+	runRuntime.Resolved = runtimeSelection(api.Model{
+		Name: identity.Name, Backend: identity.Backend, Effort: runtime.Effort,
+	})
+	var updatedRun *database.PromptRun
+	err = e.db.Transaction(ctx, func(tx *database.DB) error {
+		if bindErr := tx.SetSessionMetadataOnce(ctx, e.session.ID, threadRuntimeMetadataKey, identity); bindErr != nil {
+			if errors.Is(bindErr, database.ErrSessionConflict) {
+				return fmt.Errorf("%w: %v", ErrThreadRuntimeConflict, bindErr)
+			}
+			return bindErr
+		}
+		if updateErr := tx.UpdateChatModelCallRuntime(ctx, database.UpdateChatModelCallRuntimeInput{
+			ID: e.modelCallID, Model: identity.Name, Backend: string(identity.Backend), Effort: string(runtime.Effort),
+		}); updateErr != nil {
+			return updateErr
+		}
+		updatedRun, err = tx.UpdatePromptRun(ctx, database.UpdatePromptRunInput{
+			ID: runID, ExpectedVersion: runVersion, Runtime: &runRuntime,
+		})
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.model = identity.Name
+	e.backend = identity.Backend
+	e.run = updatedRun
+	e.mu.Unlock()
+	return nil
+}
 
 func (e *databaseExecution) CallerTools() *api.CallerToolEndpoint {
 	e.mu.Lock()

--- a/pkg/aichat/execution_database_authority.go
+++ b/pkg/aichat/execution_database_authority.go
@@ -34,26 +34,46 @@ func (a *DatabaseExecutionAuthority) Begin(
 	if request.Spec.Backend == "" {
 		return nil, fmt.Errorf("authoritative chat execution requires a resolved backend")
 	}
-	session, err := a.db.CreateOrGetSession(ctx, database.CreateSessionInput{
-		ID: sessionID, Source: "aichat", Provider: ai.BackendToProvider(request.Spec.Backend),
-		HostID: "local", Title: request.Title, InitialPrompt: initialUserPrompt(request.Spec),
-		Metadata: map[string]any{"aichat": true},
-	})
+	runtime, err := threadRuntimeIdentity(request.Spec.Model)
 	if err != nil {
 		return nil, err
-	}
-	if session.Source != "aichat" {
-		return nil, fmt.Errorf("chat thread %s has incompatible source %q", request.ThreadID, session.Source)
 	}
 	renderedSpec, err := renderedSpecMap(request.Spec, request.Profile)
 	if err != nil {
 		return nil, err
 	}
+	var session *database.Session
 	var execution *databaseExecution
 	var recovered *database.ChatTurn
 	resumed := false
 	err = a.db.Transaction(ctx, func(tx *database.DB) error {
+		if !request.ExpectedThreadUpdatedAt.IsZero() {
+			locked, lockErr := tx.LockSessionForUpdate(ctx, sessionID)
+			if lockErr != nil {
+				return lockErr
+			}
+			if !locked.UpdatedAt.Equal(request.ExpectedThreadUpdatedAt) {
+				return fmt.Errorf("%w: chat thread %s changed after its history was read", database.ErrSessionConflict, sessionID)
+			}
+		}
 		var createErr error
+		session, createErr = tx.CreateOrGetSession(ctx, database.CreateSessionInput{
+			ID: sessionID, Source: "aichat", Provider: ai.BackendToProvider(request.Spec.Backend),
+			HostID: "local", Title: request.Title, InitialPrompt: initialUserPrompt(request.Spec),
+			Metadata: map[string]any{"aichat": true},
+		})
+		if createErr != nil {
+			return createErr
+		}
+		if session.Source != "aichat" {
+			return fmt.Errorf("chat thread %s has incompatible source %q", request.ThreadID, session.Source)
+		}
+		if bindErr := tx.SetSessionMetadataOnce(ctx, session.ID, threadRuntimeMetadataKey, runtime); bindErr != nil {
+			if errors.Is(bindErr, database.ErrSessionConflict) {
+				return fmt.Errorf("%w: %v", ErrThreadRuntimeConflict, bindErr)
+			}
+			return bindErr
+		}
 		recovered, createErr = tx.RecoverIncompleteChatAdmission(ctx, database.RecoverIncompleteChatAdmissionInput{
 			SessionID: session.ID, ProviderTurnID: request.RequestID,
 		})
@@ -151,8 +171,16 @@ func (a *DatabaseExecutionAuthority) resolveToolApproval(
 	if err != nil {
 		return nil, fmt.Errorf("tool approval ID %q is not a UUID: %w", resolution.ApprovalID, err)
 	}
+	var expectedTurnID *uuid.UUID
+	if strings.TrimSpace(resolution.ExpectedTurnID) != "" {
+		parsed, parseErr := uuid.Parse(resolution.ExpectedTurnID)
+		if parseErr != nil {
+			return nil, fmt.Errorf("active chat turn ID %q is not a UUID: %w", resolution.ExpectedTurnID, parseErr)
+		}
+		expectedTurnID = &parsed
+	}
 	request, err := a.db.ResolveToolApprovalRequest(ctx, database.ResolveToolApprovalRequestInput{
-		SessionID: sessionID, RequestID: approvalID,
+		SessionID: sessionID, RequestID: approvalID, ExpectedTurnID: expectedTurnID,
 		Approved: resolution.Approved, UpdatedInput: resolution.UpdatedInput,
 		ResolvedBy: "chat", Reason: resolution.Reason,
 	})

--- a/pkg/aichat/execution_database_authority.go
+++ b/pkg/aichat/execution_database_authority.go
@@ -34,10 +34,6 @@ func (a *DatabaseExecutionAuthority) Begin(
 	if request.Spec.Backend == "" {
 		return nil, fmt.Errorf("authoritative chat execution requires a resolved backend")
 	}
-	runtime, err := threadRuntimeIdentity(request.Spec.Model)
-	if err != nil {
-		return nil, err
-	}
 	renderedSpec, err := renderedSpecMap(request.Spec, request.Profile)
 	if err != nil {
 		return nil, err
@@ -67,12 +63,6 @@ func (a *DatabaseExecutionAuthority) Begin(
 		}
 		if session.Source != "aichat" {
 			return fmt.Errorf("chat thread %s has incompatible source %q", request.ThreadID, session.Source)
-		}
-		if bindErr := tx.SetSessionMetadataOnce(ctx, session.ID, threadRuntimeMetadataKey, runtime); bindErr != nil {
-			if errors.Is(bindErr, database.ErrSessionConflict) {
-				return fmt.Errorf("%w: %v", ErrThreadRuntimeConflict, bindErr)
-			}
-			return bindErr
 		}
 		recovered, createErr = tx.RecoverIncompleteChatAdmission(ctx, database.RecoverIncompleteChatAdmissionInput{
 			SessionID: session.ID, ProviderTurnID: request.RequestID,

--- a/pkg/aichat/fork.go
+++ b/pkg/aichat/fork.go
@@ -1,0 +1,109 @@
+package aichat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/flanksource/captain/pkg/api"
+	"github.com/google/uuid"
+)
+
+const forkSeedPartType = "data-fork-seed"
+
+type forkSeedMetadata struct {
+	ForkedFrom string `json:"forkedFrom"`
+	Title      string `json:"title,omitempty"`
+}
+
+func forkSeedMessage(source *Thread) (string, UIMessage, error) {
+	hasConversation := false
+	for _, message := range source.Messages {
+		if !isForkSeedMessage(message) {
+			hasConversation = true
+			break
+		}
+	}
+	if !hasConversation {
+		return "", UIMessage{}, ErrForkSourceEmpty
+	}
+	metadata, err := json.Marshal(forkSeedMetadata{ForkedFrom: source.ID, Title: source.Title})
+	if err != nil {
+		return "", UIMessage{}, fmt.Errorf("encode fork provenance: %w", err)
+	}
+	label := strings.TrimSpace(source.Title)
+	if label == "" {
+		label = "Untitled"
+	}
+	return "Fork of " + label, UIMessage{
+		ID: uuid.NewString() + "-fork-seed", Role: string(api.RoleUser),
+		Parts: []UIPart{
+			{Type: forkSeedPartType, Data: metadata},
+			// Keep an earlier fork's flattened text when this is a fork-of-a-fork;
+			// writeForkPart ignores its UI-only provenance marker.
+			{Type: "text", Text: flattenForkTranscript(source.ID, source.Messages)},
+		},
+	}, nil
+}
+
+func isForkSeedMessage(message UIMessage) bool {
+	for _, part := range message.Parts {
+		if part.Type == forkSeedPartType {
+			return true
+		}
+	}
+	return false
+}
+
+func flattenForkTranscript(sourceID string, messages []UIMessage) string {
+	var transcript strings.Builder
+	fmt.Fprintf(&transcript, "<captain-fork source-session=%q>\n", sourceID)
+	transcript.WriteString("The following is the conversation before it was forked. Continue from this context.\n\n")
+	for _, message := range messages {
+		role := strings.ToUpper(strings.TrimSpace(message.Role))
+		if role == "" {
+			role = "MESSAGE"
+		}
+		transcript.WriteString(role)
+		transcript.WriteString(":\n")
+		for _, part := range message.Parts {
+			writeForkPart(&transcript, part)
+		}
+		transcript.WriteString("\n")
+	}
+	transcript.WriteString("</captain-fork>")
+	return transcript.String()
+}
+
+func writeForkPart(transcript *strings.Builder, part UIPart) {
+	switch {
+	case part.Type == "text":
+		transcript.WriteString(part.Text)
+		transcript.WriteByte('\n')
+	case part.Type == "file":
+		fmt.Fprintf(transcript, "[Attachment: %s]\n", firstNonempty(part.Filename, part.MediaType, "file"))
+	case part.IsTool():
+		fmt.Fprintf(transcript, "[Tool %s", firstNonempty(part.EffectiveToolName(), "unknown"))
+		if part.ToolCallID != "" {
+			fmt.Fprintf(transcript, " (%s)", part.ToolCallID)
+		}
+		if len(part.Input) > 0 {
+			fmt.Fprintf(transcript, " input=%s", part.Input)
+		}
+		if part.ErrorText != "" {
+			fmt.Fprintf(transcript, " error=%s", part.ErrorText)
+		} else if len(part.Output) > 0 {
+			fmt.Fprintf(transcript, " output=%s", part.Output)
+		}
+		transcript.WriteString("]\n")
+	}
+}
+
+func firstNonempty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/pkg/aichat/interrupt.go
+++ b/pkg/aichat/interrupt.go
@@ -11,6 +11,7 @@ import (
 )
 
 var errNoActiveTurn = errors.New("chat session has no active turn")
+var errThreadBusy = errors.New("chat session is busy")
 
 type activeTurn struct {
 	provider  api.StreamingProvider
@@ -137,11 +138,64 @@ func (t *activeTurn) finish() {
 func (s *Service) registerActiveTurn(threadID string, turn *activeTurn) error {
 	s.activeMu.Lock()
 	defer s.activeMu.Unlock()
-	if _, exists := s.active[threadID]; exists {
-		return fmt.Errorf("chat session %s already has an active turn", threadID)
+	if active, exists := s.active[threadID]; exists {
+		if sameExecutionTurn(active.execution, turn.execution) {
+			delete(s.pending, threadID)
+			s.active[threadID] = turn
+			return nil
+		}
+		return fmt.Errorf("%w: chat session %s already has an active turn", errThreadBusy, threadID)
 	}
+	if _, reserved := s.pending[threadID]; !reserved {
+		return fmt.Errorf("%w: chat session %s has no reserved turn to activate", errThreadBusy, threadID)
+	}
+	delete(s.pending, threadID)
 	s.active[threadID] = turn
 	return nil
+}
+
+func sameExecutionTurn(left, right Execution) bool {
+	return left != nil && right != nil && left.TurnID() != "" && left.TurnID() == right.TurnID()
+}
+
+func (s *Service) reserveThread(threadID string) error {
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if _, exists := s.active[threadID]; exists {
+		return fmt.Errorf("%w: chat session %s already has an active turn", errThreadBusy, threadID)
+	}
+	if _, exists := s.pending[threadID]; exists {
+		return fmt.Errorf("%w: chat session %s already has a turn being admitted", errThreadBusy, threadID)
+	}
+	s.pending[threadID] = struct{}{}
+	return nil
+}
+
+// reserveThreadForApproval claims the admission slot before a durable approval
+// is consumed. If the suspending turn is still active, the reservation keeps
+// the slot claimed while ownership is handed to its continuation.
+func (s *Service) reserveThreadForApproval(threadID string) (string, error) {
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if _, exists := s.pending[threadID]; exists {
+		return "", fmt.Errorf("%w: chat session %s already has a turn being admitted", errThreadBusy, threadID)
+	}
+	if active, exists := s.active[threadID]; exists {
+		turnID := ""
+		if active.execution != nil {
+			turnID = active.execution.TurnID()
+		}
+		s.pending[threadID] = struct{}{}
+		return turnID, nil
+	}
+	s.pending[threadID] = struct{}{}
+	return "", nil
+}
+
+func (s *Service) releaseThreadReservation(threadID string) {
+	s.activeMu.Lock()
+	delete(s.pending, threadID)
+	s.activeMu.Unlock()
 }
 
 func (s *Service) unregisterActiveTurn(threadID string, turn *activeTurn) {

--- a/pkg/aichat/persistence.go
+++ b/pkg/aichat/persistence.go
@@ -82,7 +82,15 @@ type persistedEventOptions struct {
 	Request ChatRequest
 	TurnID  string
 	Model   api.Model
+	Runtime func() api.Model
 	Costs   *TurnCosts
+}
+
+func (o persistedEventOptions) runtime() api.Model {
+	if o.Runtime != nil {
+		return o.Runtime()
+	}
+	return o.Model
 }
 
 func (s *Service) persistedEvents(ctx context.Context, options persistedEventOptions, source <-chan api.Event) <-chan api.Event {
@@ -114,7 +122,7 @@ func (s *Service) persistedEvents(ctx context.Context, options persistedEventOpt
 				return
 			}
 			if !persisted && event.Kind != api.EventResult && event.Kind != api.EventError && event.SessionID != "" {
-				if err := s.persistEvent(ctx, request.ThreadID, event, options.Model, options.Costs); err != nil {
+				if err := s.persistEvent(ctx, request.ThreadID, event, options.runtime(), options.Costs); err != nil {
 					sendEvent(ctx, out, api.Event{Kind: api.EventError, Error: err.Error(), Model: event.Model})
 					return
 				}
@@ -180,7 +188,7 @@ func (s *Service) persistCompletedTurn(
 	event api.Event,
 	options persistedEventOptions,
 ) error {
-	if err := s.persistEvent(ctx, threadID, event, options.Model, options.Costs); err != nil {
+	if err := s.persistEvent(ctx, threadID, event, options.runtime(), options.Costs); err != nil {
 		return err
 	}
 	if len(builder.message.Parts) == 0 {

--- a/pkg/aichat/runtime_settings.go
+++ b/pkg/aichat/runtime_settings.go
@@ -2,6 +2,7 @@ package aichat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -16,8 +17,15 @@ type requestError struct {
 func (e requestError) Error() string { return e.text }
 
 func requestErrorStatus(err error) int {
-	if typed, ok := err.(requestError); ok {
+	var typed requestError
+	if errors.As(err, &typed) {
 		return typed.status
+	}
+	if errors.Is(err, ErrThreadRuntimeConflict) {
+		return http.StatusConflict
+	}
+	if errors.Is(err, ErrThreadNotFound) {
+		return http.StatusNotFound
 	}
 	return http.StatusBadRequest
 }

--- a/pkg/aichat/service.go
+++ b/pkg/aichat/service.go
@@ -3,6 +3,7 @@ package aichat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/flanksource/captain/pkg/ai"
 	aitools "github.com/flanksource/captain/pkg/ai/tools"
 	"github.com/flanksource/captain/pkg/api"
+	"github.com/flanksource/captain/pkg/database"
 	"github.com/flanksource/commons/logger"
 )
 
@@ -74,6 +76,7 @@ type Service struct {
 	resolver Resolver
 	activeMu sync.Mutex
 	active   map[string]*activeTurn
+	pending  map[string]struct{}
 }
 
 func NewService(options ServiceOptions) *Service {
@@ -81,7 +84,10 @@ func NewService(options ServiceOptions) *Service {
 	if resolver == nil {
 		resolver = captainResolver{}
 	}
-	return &Service{options: options, resolver: resolver, active: map[string]*activeTurn{}}
+	return &Service{
+		options: options, resolver: resolver,
+		active: map[string]*activeTurn{}, pending: map[string]struct{}{},
+	}
 }
 
 func (s *Service) Handler() http.Handler {
@@ -167,17 +173,34 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 		http.Error(w, fmt.Sprintf("load chat runtime profile: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if err := enforceRuntimeProfile(chat, profile.Resolved); err != nil {
-		http.Error(w, err.Error(), requestErrorStatus(err))
-		return
+	reserved := false
+	if chat.ThreadID != "" {
+		if err := s.reserveThread(chat.ThreadID); err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		reserved = true
+		defer func() {
+			if reserved {
+				s.releaseThreadReservation(chat.ThreadID)
+			}
+		}()
 	}
 	thread, err := s.resolveThreadSession(request.Context(), &chat)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), requestErrorStatus(err))
 		return
 	}
 	if err := validateThreadTurn(chat, thread); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := bindAuthoritativeHistory(&chat, thread); err != nil {
+		http.Error(w, err.Error(), requestErrorStatus(err))
+		return
+	}
+	if err := enforceRuntimeProfile(chat, profile.Resolved); err != nil {
+		http.Error(w, err.Error(), requestErrorStatus(err))
 		return
 	}
 	var attachments map[partLocation]api.AttachmentRef
@@ -224,6 +247,10 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 	}
 	spec.Model = config.Model
 	resolved.Spec = spec
+	if err := enforceThreadRuntime(thread, config.Model); err != nil {
+		http.Error(w, err.Error(), requestErrorStatus(err))
+		return
+	}
 	var execution Execution
 	var callerToolEvents <-chan api.Event
 	if s.options.Authority != nil && chat.ThreadID != "" {
@@ -233,10 +260,16 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 		}
 		execution, err = s.options.Authority.Begin(request.Context(), ExecutionRequest{
 			ThreadID: chat.ThreadID, RequestID: turnID, Title: title,
-			Spec: spec, Profile: resolved, Definitions: definitions,
+			ExpectedThreadUpdatedAt: thread.UpdatedAt,
+			Spec:                    spec, Profile: resolved, Definitions: definitions,
 		})
 		if err != nil {
-			http.Error(w, fmt.Sprintf("admit chat execution: %v", err), http.StatusInternalServerError)
+			status := http.StatusInternalServerError
+			if errors.Is(err, database.ErrOpenChatTurn) || errors.Is(err, database.ErrSessionConflict) ||
+				errors.Is(err, ErrThreadRuntimeConflict) {
+				status = http.StatusConflict
+			}
+			http.Error(w, fmt.Sprintf("admit chat execution: %v", err), status)
 			return
 		}
 		defer closeExecution(execution)
@@ -272,25 +305,29 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 			return
 		}
 	}
-	if err := s.persistIncoming(request.Context(), chat); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
 	streamContext, cancel := context.WithCancel(request.Context())
 	defer cancel()
+	var active *activeTurn
+	if chat.ThreadID != "" {
+		active = newActiveTurn(streamContext, provider, execution, cancel)
+		if err := s.registerActiveTurn(chat.ThreadID, active); err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		reserved = false
+		defer s.unregisterActiveTurn(chat.ThreadID, active)
+	}
+	if err := s.persistIncoming(request.Context(), chat, config.Model); err != nil {
+		http.Error(w, err.Error(), requestErrorStatus(err))
+		return
+	}
 	events, err := provider.ExecuteStream(streamContext, spec)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	events = mergeExecutionEvents(streamContext, events, callerToolEvents, definitions)
-	if chat.ThreadID != "" {
-		active := newActiveTurn(streamContext, provider, execution, cancel)
-		if err := s.registerActiveTurn(chat.ThreadID, active); err != nil {
-			http.Error(w, err.Error(), http.StatusConflict)
-			return
-		}
-		defer s.unregisterActiveTurn(chat.ThreadID, active)
+	if active != nil {
 		events = active.stream(events)
 	}
 	events = observeExecutionEvents(streamContext, execution, events)
@@ -408,10 +445,52 @@ func (s *Service) resolveThreadSession(ctx context.Context, request *ChatRequest
 	if err != nil {
 		return nil, err
 	}
-	if request.ProviderSessionID == "" {
-		request.ProviderSessionID = thread.ProviderSessionID
+	provided := strings.TrimSpace(request.ProviderSessionID)
+	if provided != "" && provided != thread.ProviderSessionID {
+		return nil, requestError{status: http.StatusConflict, text: fmt.Sprintf(
+			"provider session ID %q does not match thread %q binding", provided, thread.ProviderSessionID,
+		)}
 	}
+	request.ProviderSessionID = thread.ProviderSessionID
 	return thread, nil
+}
+
+func bindAuthoritativeHistory(request *ChatRequest, thread *Thread) error {
+	if thread == nil {
+		return nil
+	}
+	switch request.Trigger {
+	case "submit-message":
+		incoming := request.Messages[len(request.Messages)-1]
+		for _, persisted := range thread.Messages {
+			if persisted.ID != "" && persisted.ID == incoming.ID {
+				return requestError{status: http.StatusConflict, text: fmt.Sprintf(
+					"chat message %q is already persisted in thread %s", incoming.ID, thread.ID,
+				)}
+			}
+		}
+		request.Messages = append(append([]UIMessage(nil), thread.Messages...), incoming)
+	case "regenerate-message":
+		request.Messages = append([]UIMessage(nil), thread.Messages[:len(thread.Messages)-1]...)
+	}
+	return nil
+}
+
+func enforceThreadRuntime(thread *Thread, requested api.Model) error {
+	if thread == nil || thread.Runtime == nil {
+		return nil
+	}
+	identity, err := threadRuntimeIdentity(requested)
+	if err != nil {
+		return err
+	}
+	if sameThreadRuntime(*thread.Runtime, identity) {
+		return nil
+	}
+	return requestError{status: http.StatusConflict, text: fmt.Sprintf(
+		"chat session runtime is locked to %s/%s, not %s/%s; fork the session to use a different model or backend",
+		thread.Runtime.Backend, thread.Runtime.Name, identity.Backend, identity.Name,
+	)}
 }
 
 func closeExecution(execution Execution) {
@@ -425,7 +504,7 @@ func closeExecution(execution Execution) {
 	}
 }
 
-func (s *Service) persistIncoming(ctx context.Context, request ChatRequest) error {
+func (s *Service) persistIncoming(ctx context.Context, request ChatRequest, runtime api.Model) error {
 	if request.ThreadID == "" || request.Trigger != "submit-message" || request.MessageID != "" || len(request.Messages) == 0 {
 		return nil
 	}
@@ -435,6 +514,9 @@ func (s *Service) persistIncoming(ctx context.Context, request ChatRequest) erro
 	}
 	store, err := s.threads(ctx)
 	if err != nil {
+		return err
+	}
+	if err := store.SetRuntime(ctx, request.ThreadID, runtime); err != nil {
 		return err
 	}
 	if err := store.AppendMessage(ctx, request.ThreadID, last); err != nil {

--- a/pkg/aichat/service.go
+++ b/pkg/aichat/service.go
@@ -483,17 +483,19 @@ func enforceThreadRuntime(thread *Thread, requested api.Model) error {
 	if thread == nil || thread.Runtime == nil {
 		return nil
 	}
-	identity, err := threadRuntimeIdentity(requested)
-	if err != nil {
-		return err
+	for _, candidate := range requested.Candidates() {
+		identity, err := threadRuntimeIdentity(candidate)
+		if err != nil {
+			return err
+		}
+		if !sameThreadRuntime(*thread.Runtime, identity) {
+			return requestError{status: http.StatusConflict, text: fmt.Sprintf(
+				"chat session runtime is locked to %s/%s, not %s/%s; fork the session to use a different model or backend",
+				thread.Runtime.Backend, thread.Runtime.Name, identity.Backend, identity.Name,
+			)}
+		}
 	}
-	if sameThreadRuntime(*thread.Runtime, identity) {
-		return nil
-	}
-	return requestError{status: http.StatusConflict, text: fmt.Sprintf(
-		"chat session runtime is locked to %s/%s, not %s/%s; fork the session to use a different model or backend",
-		thread.Runtime.Backend, thread.Runtime.Name, identity.Backend, identity.Name,
-	)}
+	return nil
 }
 
 func providerRuntime(provider api.Provider, configured api.Model) api.Model {

--- a/pkg/aichat/service.go
+++ b/pkg/aichat/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/database"
 	"github.com/flanksource/commons/logger"
+	"github.com/google/uuid"
 )
 
 var serviceLog = logger.GetLogger("aichat")
@@ -326,6 +327,8 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
+	runtime := func() api.Model { return providerRuntime(provider, config.Model) }
+	events = s.bindThreadRuntime(streamContext, chat.ThreadID, execution, runtime, events)
 	events = mergeExecutionEvents(streamContext, events, callerToolEvents, definitions)
 	if active != nil {
 		events = active.stream(events)
@@ -338,7 +341,7 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 	}
 	costs := &TurnCosts{}
 	persisted := s.persistedEvents(streamContext, persistedEventOptions{
-		Request: chat, TurnID: turnID, Model: config.Model, Costs: costs,
+		Request: chat, TurnID: turnID, Model: config.Model, Runtime: runtime, Costs: costs,
 	}, events)
 	if err := WriteEventStream(writer, persisted, EventStreamOptions{
 		ToolApproval: chat.ToolApproval,
@@ -389,7 +392,7 @@ func chatTurnID(request ChatRequest) (string, error) {
 		if request.MessageID == "" {
 			return "", fmt.Errorf("regenerate-message requires messageId")
 		}
-		return request.MessageID, nil
+		return request.MessageID + ":" + uuid.NewString(), nil
 	default:
 		return "", fmt.Errorf("unsupported chat trigger %q", request.Trigger)
 	}
@@ -493,6 +496,66 @@ func enforceThreadRuntime(thread *Thread, requested api.Model) error {
 	)}
 }
 
+func providerRuntime(provider api.Provider, configured api.Model) api.Model {
+	selected := api.Model{Name: strings.TrimSpace(provider.GetModel()), Backend: provider.GetBackend()}
+	for _, candidate := range configured.Candidates() {
+		identity, err := threadRuntimeIdentity(candidate)
+		if err == nil && sameThreadRuntime(identity, selected) {
+			candidate.Name = identity.Name
+			candidate.Backend = identity.Backend
+			return candidate
+		}
+	}
+	return selected
+}
+
+// bindThreadRuntime stores the provider actually selected by fallback before
+// later stages can bind its provider-session ID or account for its usage.
+func (s *Service) bindThreadRuntime(
+	ctx context.Context,
+	threadID string,
+	execution Execution,
+	runtime func() api.Model,
+	source <-chan api.Event,
+) <-chan api.Event {
+	if threadID == "" {
+		return source
+	}
+	out := make(chan api.Event)
+	go func() {
+		defer close(out)
+		bound := false
+		var selected api.Model
+		for event := range source {
+			if !bound && event.Kind != api.EventError {
+				selected = runtime()
+				var err error
+				if binder, ok := execution.(executionRuntimeBinder); ok {
+					err = binder.BindRuntime(ctx, selected)
+				} else {
+					var store ThreadStore
+					store, err = s.threads(ctx)
+					if err == nil {
+						err = store.SetRuntime(ctx, threadID, selected)
+					}
+				}
+				if err != nil {
+					sendEvent(ctx, out, api.Event{Kind: api.EventError, Error: err.Error(), Model: selected.Name})
+					return
+				}
+				bound = true
+			}
+			if bound && event.Model == "" {
+				event.Model = selected.Name
+			}
+			if !sendEvent(ctx, out, event) {
+				return
+			}
+		}
+	}()
+	return out
+}
+
 func closeExecution(execution Execution) {
 	if execution == nil {
 		return
@@ -516,8 +579,10 @@ func (s *Service) persistIncoming(ctx context.Context, request ChatRequest, runt
 	if err != nil {
 		return err
 	}
-	if err := store.SetRuntime(ctx, request.ThreadID, runtime); err != nil {
-		return err
+	if candidates := runtime.Candidates(); len(candidates) == 1 {
+		if err := store.SetRuntime(ctx, request.ThreadID, candidates[0]); err != nil {
+			return err
+		}
 	}
 	if err := store.AppendMessage(ctx, request.ThreadID, last); err != nil {
 		return err

--- a/pkg/aichat/service_ginkgo_test.go
+++ b/pkg/aichat/service_ginkgo_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type fakeResolver struct {
-	models   aichat.ModelCatalogResponse
-	runtimes []api.RuntimeFamily
-	provider *fakeStreamingProvider
-	configs  []api.Config
+	models      aichat.ModelCatalogResponse
+	runtimes    []api.RuntimeFamily
+	provider    api.StreamingProvider
+	providerErr error
+	configs     []api.Config
 }
 
 type fakeProviderConfigSource struct {
@@ -53,6 +54,9 @@ func (f *fakeResolver) Runtimes(context.Context) ([]api.RuntimeFamily, error) {
 
 func (f *fakeResolver) Provider(_ context.Context, config api.Config) (api.StreamingProvider, error) {
 	f.configs = append(f.configs, config)
+	if f.providerErr != nil {
+		return nil, f.providerErr
+	}
 	return f.provider, nil
 }
 
@@ -60,7 +64,10 @@ type fakeStreamingProvider struct {
 	events              []api.Event
 	specs               []api.Spec
 	execute             func(context.Context, api.Spec) (<-chan api.Event, error)
+	model               string
 	backend             api.Backend
+	activeModel         string
+	activeBackend       api.Backend
 	supportsCallerTools *bool
 	interrupt           func(context.Context) error
 }
@@ -71,6 +78,8 @@ func (f *fakeStreamingProvider) Execute(context.Context, api.Spec) (*api.Respons
 
 func (f *fakeStreamingProvider) ExecuteStream(ctx context.Context, spec api.Spec) (<-chan api.Event, error) {
 	f.specs = append(f.specs, spec)
+	f.activeModel = spec.Name
+	f.activeBackend = spec.Backend
 	if f.execute != nil {
 		return f.execute(ctx, spec)
 	}
@@ -82,10 +91,21 @@ func (f *fakeStreamingProvider) ExecuteStream(ctx context.Context, spec api.Spec
 	return events, nil
 }
 
-func (f *fakeStreamingProvider) GetModel() string { return "test-model" }
+func (f *fakeStreamingProvider) GetModel() string {
+	if f.model != "" {
+		return f.model
+	}
+	if f.activeModel != "" {
+		return f.activeModel
+	}
+	return "test-model"
+}
 func (f *fakeStreamingProvider) GetBackend() api.Backend {
 	if f.backend != "" {
 		return f.backend
+	}
+	if f.activeBackend != "" {
+		return f.activeBackend
 	}
 	return api.BackendOpenAI
 }

--- a/pkg/aichat/service_ginkgo_test.go
+++ b/pkg/aichat/service_ginkgo_test.go
@@ -341,6 +341,7 @@ var _ = Describe("Captain aichat service", func() {
 		store := aichat.NewMemoryThreadStore()
 		thread, err := store.Create(context.Background(), "Agent chat")
 		Expect(err).NotTo(HaveOccurred())
+		Expect(store.SetProviderSession(context.Background(), thread.ID, "provider-session-1")).To(Succeed())
 		provider := &fakeStreamingProvider{
 			backend: api.BackendClaudeAgent,
 			events:  []api.Event{{Kind: api.EventResult, Success: true}},

--- a/pkg/aichat/thread_costs.go
+++ b/pkg/aichat/thread_costs.go
@@ -112,3 +112,14 @@ func applyThreadCosts(aggregate *session.Session, rows []database.SessionCost) {
 		return aggregate.ToolCosts[i].Model < aggregate.ToolCosts[j].Model
 	})
 }
+
+func applyThreadSummaryCosts(thread *Thread, rows []database.SessionCost) {
+	aggregate := &session.Session{}
+	applyThreadCosts(aggregate, rows)
+	thread.TotalInputTokens = aggregate.Usage.InputTokens
+	thread.TotalOutputTokens = aggregate.Usage.OutputTokens
+	thread.TotalReasoningTokens = aggregate.Usage.ReasoningTokens
+	thread.TotalCacheReadTokens = aggregate.Usage.CacheReadTokens
+	thread.TotalCacheWriteTokens = aggregate.Usage.CacheWriteTokens
+	thread.TotalCostUSD = aggregate.Cost.Total()
+}

--- a/pkg/aichat/thread_identity_ginkgo_test.go
+++ b/pkg/aichat/thread_identity_ginkgo_test.go
@@ -1,0 +1,498 @@
+package aichat_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+
+	"github.com/flanksource/captain/pkg/aichat"
+	"github.com/flanksource/captain/pkg/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type staleRuntimeThreadStore struct {
+	aichat.ThreadStore
+}
+
+type blockingForkThreadStore struct {
+	aichat.ThreadStore
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (s blockingForkThreadStore) Fork(ctx context.Context, id string) (*aichat.Thread, error) {
+	s.started <- struct{}{}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.release:
+		return s.ThreadStore.Fork(ctx, id)
+	}
+}
+
+func (s staleRuntimeThreadStore) Get(ctx context.Context, id string) (*aichat.Thread, error) {
+	thread, err := s.ThreadStore.Get(ctx, id)
+	if thread != nil {
+		thread.Runtime = nil
+	}
+	return thread, err
+}
+
+var _ = Describe("Authoritative chat thread identity", func() {
+	It("uses stored history and locks only model identity after the first admitted turn", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		thread, err := store.Create(ctx, "Identity")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "persisted-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Persisted question"}},
+		})).To(Succeed())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "persisted-assistant", Role: "assistant", Parts: []aichat.UIPart{{Type: "text", Text: "Persisted answer"}},
+		})).To(Succeed())
+		provider := &fakeStreamingProvider{events: []api.Event{
+			{Kind: api.EventText, Text: "New answer"},
+			{Kind: api.EventResult, Success: true, SessionID: "provider-session-1"},
+		}}
+		resolver := &fakeResolver{provider: provider}
+		service := aichat.NewService(aichat.ServiceOptions{
+			Resolver: resolver, Threads: aichat.FixedThreadStore(store),
+		})
+
+		submit := func(id string, runtime api.Model, clientHistory ...aichat.UIMessage) *httptest.ResponseRecorder {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message", Runtime: &runtime,
+				Messages: append(clientHistory, aichat.UIMessage{
+					ID: id, Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: id}},
+				}),
+			}))
+			return response
+		}
+
+		first := submit("new-user-1", api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+			aichat.UIMessage{ID: "stale", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Stale client history"}}})
+		Expect(first.Code).To(Equal(http.StatusOK), first.Body.String())
+		Expect(provider.specs).To(HaveLen(1))
+		encoded, err := json.Marshal(provider.specs[0].Messages)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(encoded)).To(ContainSubstring("Persisted question"))
+		Expect(string(encoded)).To(ContainSubstring("Persisted answer"))
+		Expect(string(encoded)).NotTo(ContainSubstring("Stale client history"))
+
+		bound, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bound.Runtime).To(Equal(&api.Model{Name: "test-model", Backend: api.BackendOpenAI}))
+		Expect(bound.ProviderSessionID).To(Equal("provider-session-1"))
+
+		sameModel := submit("new-user-2", api.Model{
+			Name: "test-model", Backend: api.BackendOpenAI, Effort: api.EffortHigh,
+		})
+		Expect(sameModel.Code).To(Equal(http.StatusOK), sameModel.Body.String())
+		Expect(provider.specs).To(HaveLen(2))
+		Expect(provider.specs[1].Model.Effort).To(Equal(api.EffortHigh))
+		Expect(resolver.configs[1].SessionID).To(Equal("provider-session-1"))
+
+		beforeConflict, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		mismatch := submit("new-user-3", api.Model{Name: "claude-sonnet-4-6", Backend: api.BackendAnthropic})
+		Expect(mismatch.Code).To(Equal(http.StatusConflict))
+		Expect(mismatch.Body.String()).To(ContainSubstring("openai/test-model"))
+		Expect(mismatch.Body.String()).To(ContainSubstring("anthropic/claude-sonnet-4-6"))
+		Expect(strings.ToLower(mismatch.Body.String())).To(ContainSubstring("fork"))
+		Expect(provider.specs).To(HaveLen(2), "a rejected resume must not launch the provider")
+		afterConflict, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(afterConflict.Messages).To(Equal(beforeConflict.Messages), "a rejected resume must not persist")
+	})
+
+	It("does not persist a message when a concurrent runtime binding wins admission", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		thread, err := store.Create(ctx, "Runtime race")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.SetRuntime(ctx, thread.ID, api.Model{
+			Name: "bound-model", Backend: api.BackendOpenAI,
+		})).To(Succeed())
+		provider := &fakeStreamingProvider{}
+		service := aichat.NewService(aichat.ServiceOptions{
+			Resolver: &fakeResolver{provider: provider},
+			Threads:  aichat.FixedThreadStore(staleRuntimeThreadStore{ThreadStore: store}),
+		})
+
+		response := httptest.NewRecorder()
+		service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+			ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message",
+			Runtime: &api.Model{Name: "other-model", Backend: api.BackendOpenAI},
+			Messages: []aichat.UIMessage{{
+				ID: "losing-message", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Do not persist"}},
+			}},
+		}))
+
+		Expect(response.Code).To(Equal(http.StatusConflict), response.Body.String())
+		Expect(provider.specs).To(BeEmpty(), "a rejected runtime must not launch the provider")
+		stored, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stored.Messages).To(BeEmpty())
+	})
+
+	It("rejects a second admission and a fork while the first turn is active", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		thread, err := store.Create(ctx, "Concurrent")
+		Expect(err).NotTo(HaveOccurred())
+		started := make(chan struct{})
+		release := make(chan struct{})
+		provider := &fakeStreamingProvider{execute: func(context.Context, api.Spec) (<-chan api.Event, error) {
+			events := make(chan api.Event)
+			close(started)
+			go func() {
+				<-release
+				close(events)
+			}()
+			return events, nil
+		}}
+		service := aichat.NewService(aichat.ServiceOptions{
+			Resolver: &fakeResolver{provider: provider}, Threads: aichat.FixedThreadStore(store),
+		})
+		submit := func(messageID string) *httptest.ResponseRecorder {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message",
+				Runtime: &api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+				Messages: []aichat.UIMessage{{
+					ID: messageID, Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: messageID}},
+				}},
+			}))
+			return response
+		}
+
+		firstDone := make(chan *httptest.ResponseRecorder, 1)
+		go func() { firstDone <- submit("first-user") }()
+		Eventually(started).Should(BeClosed())
+
+		second := submit("second-user")
+		Expect(second.Code).To(Equal(http.StatusConflict))
+		Expect(second.Body.String()).To(ContainSubstring("active turn"))
+		fork := httptest.NewRecorder()
+		service.Handler().ServeHTTP(fork, httptest.NewRequest(http.MethodPost,
+			"/api/chat/sessions/"+thread.ID+"/fork", nil))
+		Expect(fork.Code).To(Equal(http.StatusConflict))
+
+		close(release)
+		Eventually(firstDone).Should(Receive())
+		Expect(provider.specs).To(HaveLen(1))
+		stored, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stored.Messages).NotTo(ContainElement(HaveField("ID", "second-user")))
+	})
+
+	It("reserves a suspended approval before relaunching its provider", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		thread, err := store.Create(ctx, "Approval resume")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.SetRuntime(ctx, thread.ID, api.Model{Name: "test-model", Backend: api.BackendOpenAI})).To(Succeed())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "approval-user", Role: "user", TurnID: "turn-1",
+			Parts: []aichat.UIPart{{Type: "text", Text: "Update the account"}},
+		})).To(Succeed())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "turn-1-assistant", Role: "assistant", TurnID: "turn-1",
+			Parts: []aichat.UIPart{{
+				Type: "dynamic-tool", ToolName: "accounts_edit", ToolCallID: "call-1", State: "approval-requested",
+			}},
+		})).To(Succeed())
+
+		providerStarted := make(chan struct{})
+		releaseProvider := make(chan struct{})
+		var launches atomic.Int32
+		provider := &fakeStreamingProvider{execute: func(context.Context, api.Spec) (<-chan api.Event, error) {
+			if launches.Add(1) == 1 {
+				close(providerStarted)
+				<-releaseProvider
+			}
+			events := make(chan api.Event, 2)
+			events <- api.Event{Kind: api.EventToolResult, ToolCallID: "call-1", Tool: "accounts_edit", Success: true}
+			events <- api.Event{Kind: api.EventResult, Success: true}
+			close(events)
+			return events, nil
+		}}
+		execution := &fakeExecution{}
+		authority := &fakeExecutionAuthority{continuation: &aichat.ApprovalContinuation{
+			Execution: execution,
+			Spec: api.Spec{
+				Model:        api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+				ToolApproval: &api.ToolApprovalResume{},
+			},
+		}}
+		service := aichat.NewService(aichat.ServiceOptions{
+			Threads: aichat.FixedThreadStore(store), Authority: authority,
+			Resolver: &fakeResolver{provider: provider},
+		})
+
+		approvalDone := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(
+				http.MethodPost,
+				"/api/chat/sessions/"+thread.ID+"/approvals/approval-1",
+				map[string]any{"approved": true},
+			))
+			approvalDone <- response
+		}()
+		Eventually(providerStarted).Should(BeClosed())
+
+		concurrent := httptest.NewRecorder()
+		service.Handler().ServeHTTP(concurrent, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+			ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message",
+			Runtime: &api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+			Messages: []aichat.UIMessage{{
+				ID: "concurrent-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Race the approval"}},
+			}},
+		}))
+		Expect(concurrent.Code).To(Equal(http.StatusConflict), concurrent.Body.String())
+		fork := httptest.NewRecorder()
+		service.Handler().ServeHTTP(fork, httptest.NewRequest(http.MethodPost,
+			"/api/chat/sessions/"+thread.ID+"/fork", nil))
+		Expect(fork.Code).To(Equal(http.StatusConflict), fork.Body.String())
+		Expect(launches.Load()).To(Equal(int32(1)), "no second provider may launch while approval continuation is active")
+
+		close(releaseProvider)
+		var approval *httptest.ResponseRecorder
+		Eventually(approvalDone).Should(Receive(&approval))
+		Expect(approval.Code).To(Equal(http.StatusOK), approval.Body.String())
+		stored, err := store.Get(ctx, thread.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stored.Messages).NotTo(ContainElement(HaveField("ID", "concurrent-user")))
+	})
+
+	It("reserves a fork source against concurrent turn admission", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		thread, err := store.Create(ctx, "Fork race")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+			ID: "source-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Source"}},
+		})).To(Succeed())
+		forkStarted := make(chan struct{}, 1)
+		releaseFork := make(chan struct{})
+		provider := &fakeStreamingProvider{}
+		service := aichat.NewService(aichat.ServiceOptions{
+			Threads: aichat.FixedThreadStore(blockingForkThreadStore{
+				ThreadStore: store, started: forkStarted, release: releaseFork,
+			}),
+			Resolver: &fakeResolver{provider: provider},
+		})
+
+		forkDone := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodPost,
+				"/api/chat/sessions/"+thread.ID+"/fork", nil))
+			forkDone <- response
+		}()
+		Eventually(forkStarted).Should(Receive())
+
+		concurrent := httptest.NewRecorder()
+		service.Handler().ServeHTTP(concurrent, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+			ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message",
+			Runtime: &api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+			Messages: []aichat.UIMessage{{
+				ID: "concurrent-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Race the fork"}},
+			}},
+		}))
+		Expect(concurrent.Code).To(Equal(http.StatusConflict), concurrent.Body.String())
+		Expect(provider.specs).To(BeEmpty())
+
+		close(releaseFork)
+		var response *httptest.ResponseRecorder
+		Eventually(forkDone).Should(Receive(&response))
+		Expect(response.Code).To(Equal(http.StatusCreated), response.Body.String())
+	})
+
+	It("creates an independent root fork with one turnless transcript seed", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		source, err := store.Create(ctx, "Source chat")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, source.ID, aichat.UIMessage{
+			ID: "source-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Question"}},
+		})).To(Succeed())
+		Expect(store.AppendMessage(ctx, source.ID, aichat.UIMessage{
+			ID: "source-assistant", Role: "assistant", Parts: []aichat.UIPart{{Type: "text", Text: "Answer"}},
+		})).To(Succeed())
+		Expect(store.SetProviderSession(ctx, source.ID, "provider-source")).To(Succeed())
+		Expect(store.SetRuntime(ctx, source.ID, api.Model{Name: "test-model", Backend: api.BackendOpenAI})).To(Succeed())
+		_, err = store.AddUsage(ctx, source.ID, aichat.TurnUsage{InputTokens: 10, OutputTokens: 4, CostUSD: 0.2})
+		Expect(err).NotTo(HaveOccurred())
+		service := aichat.NewService(aichat.ServiceOptions{Threads: aichat.FixedThreadStore(store)})
+
+		response := httptest.NewRecorder()
+		service.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodPost,
+			"/api/chat/sessions/"+source.ID+"/fork", nil))
+		Expect(response.Code).To(Equal(http.StatusCreated), response.Body.String())
+		var fork aichat.Thread
+		Expect(json.Unmarshal(response.Body.Bytes(), &fork)).To(Succeed())
+		Expect(fork.ID).NotTo(Equal(source.ID))
+		Expect(fork.Title).To(Equal("Fork of Source chat"))
+		Expect(fork.ForkedFrom).To(Equal(source.ID))
+		Expect(fork.ProviderSessionID).To(BeEmpty())
+		Expect(fork.Runtime).To(BeNil())
+		Expect(fork.TotalInputTokens).To(BeZero())
+		Expect(fork.TotalCostUSD).To(BeZero())
+		Expect(fork.Messages).To(HaveLen(1))
+		Expect(fork.Messages[0].TurnID).To(BeEmpty())
+		Expect(fork.Messages[0].Parts).To(ContainElement(HaveField("Type", "data-fork-seed")))
+		Expect(fork.Messages[0].Parts[1].Text).To(ContainSubstring("<captain-fork"))
+		Expect(fork.Messages[0].Parts[1].Text).To(ContainSubstring("Question"))
+		Expect(fork.Messages[0].Parts[1].Text).To(ContainSubstring("Answer"))
+		Expect(fork.Messages[0].Parts[1].Text).To(ContainSubstring("</captain-fork>"))
+
+		list := httptest.NewRecorder()
+		service.Handler().ServeHTTP(list, httptest.NewRequest(http.MethodGet, "/api/chat/sessions", nil))
+		var summaries []aichat.Thread
+		Expect(json.Unmarshal(list.Body.Bytes(), &summaries)).To(Succeed())
+		Expect(summaries).To(HaveLen(2))
+		for _, summary := range summaries {
+			Expect(summary.Messages).To(BeNil())
+		}
+
+		seedOnly := httptest.NewRecorder()
+		service.Handler().ServeHTTP(seedOnly, httptest.NewRequest(http.MethodPost,
+			"/api/chat/sessions/"+fork.ID+"/fork", nil))
+		Expect(seedOnly.Code).To(Equal(http.StatusBadRequest))
+
+		Expect(store.AppendMessage(ctx, fork.ID, aichat.UIMessage{
+			ID: "fork-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Follow-up question"}},
+		})).To(Succeed())
+		Expect(store.AppendMessage(ctx, fork.ID, aichat.UIMessage{
+			ID: "fork-assistant", Role: "assistant", Parts: []aichat.UIPart{{Type: "text", Text: "Follow-up answer"}},
+		})).To(Succeed())
+		nestedResponse := httptest.NewRecorder()
+		service.Handler().ServeHTTP(nestedResponse, httptest.NewRequest(http.MethodPost,
+			"/api/chat/sessions/"+fork.ID+"/fork", nil))
+		Expect(nestedResponse.Code).To(Equal(http.StatusCreated), nestedResponse.Body.String())
+		var nested aichat.Thread
+		Expect(json.Unmarshal(nestedResponse.Body.Bytes(), &nested)).To(Succeed())
+		Expect(nested.Messages).To(HaveLen(1))
+		Expect(nested.Messages[0].TurnID).To(BeEmpty())
+		Expect(nested.Messages[0].Parts).To(ContainElement(HaveField("Type", "data-fork-seed")))
+		Expect(nested.Messages[0].Parts[1].Text).To(ContainSubstring("Question"))
+		Expect(nested.Messages[0].Parts[1].Text).To(ContainSubstring("Answer"))
+		Expect(nested.Messages[0].Parts[1].Text).To(ContainSubstring("Follow-up question"))
+		Expect(nested.Messages[0].Parts[1].Text).To(ContainSubstring("Follow-up answer"))
+
+		missing := httptest.NewRecorder()
+		service.Handler().ServeHTTP(missing, httptest.NewRequest(http.MethodPost,
+			"/api/chat/sessions/missing/fork", nil))
+		Expect(missing.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("sends the fork seed once to agent runtimes and skips its marker for API runtimes", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		source, err := store.Create(ctx, "Seed source")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.AppendMessage(ctx, source.ID, aichat.UIMessage{
+			ID: "source-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Original question"}},
+		})).To(Succeed())
+
+		agentFork, err := store.Fork(ctx, source.ID)
+		Expect(err).NotTo(HaveOccurred())
+		agentProvider := &fakeStreamingProvider{
+			backend: api.BackendClaudeAgent,
+			events:  []api.Event{{Kind: api.EventResult, Success: true, SessionID: "provider-fork"}},
+		}
+		agentResolver := &fakeResolver{provider: agentProvider}
+		agentService := aichat.NewService(aichat.ServiceOptions{
+			Resolver: agentResolver, Threads: aichat.FixedThreadStore(store),
+		})
+		submitAgent := func(id, text string) *httptest.ResponseRecorder {
+			response := httptest.NewRecorder()
+			agentService.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: agentFork.ID, ThreadID: agentFork.ID, Trigger: "submit-message",
+				Runtime: &api.Model{Name: "sonnet", Backend: api.BackendClaudeAgent},
+				Messages: []aichat.UIMessage{{
+					ID: id, Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: text}},
+				}},
+			}))
+			return response
+		}
+
+		first := submitAgent("agent-user-1", "Continue on agent")
+		Expect(first.Code).To(Equal(http.StatusOK), first.Body.String())
+		Expect(agentProvider.specs).To(HaveLen(1))
+		Expect(agentProvider.specs[0].Messages).To(BeNil())
+		Expect(agentProvider.specs[0].Prompt.User).To(ContainSubstring("<captain-fork"))
+		Expect(agentProvider.specs[0].Prompt.User).To(ContainSubstring("Original question"))
+		Expect(agentProvider.specs[0].Prompt.User).To(ContainSubstring("Continue on agent"))
+
+		second := submitAgent("agent-user-2", "Second agent turn")
+		Expect(second.Code).To(Equal(http.StatusOK), second.Body.String())
+		Expect(agentProvider.specs).To(HaveLen(2))
+		Expect(agentProvider.specs[1].Prompt.User).To(Equal("Second agent turn"))
+		Expect(agentProvider.specs[1].Prompt.User).NotTo(ContainSubstring("<captain-fork"))
+		Expect(agentResolver.configs[1].SessionID).To(Equal("provider-fork"))
+
+		apiFork, err := store.Fork(ctx, source.ID)
+		Expect(err).NotTo(HaveOccurred())
+		apiProvider := &fakeStreamingProvider{events: []api.Event{{Kind: api.EventResult, Success: true}}}
+		apiService := aichat.NewService(aichat.ServiceOptions{
+			Resolver: &fakeResolver{provider: apiProvider}, Threads: aichat.FixedThreadStore(store),
+		})
+		apiResponse := httptest.NewRecorder()
+		apiService.Handler().ServeHTTP(apiResponse, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+			ID: apiFork.ID, ThreadID: apiFork.ID, Trigger: "submit-message",
+			Runtime: &api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+			Messages: []aichat.UIMessage{{
+				ID: "api-user-1", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Continue on API"}},
+			}},
+		}))
+
+		Expect(apiResponse.Code).To(Equal(http.StatusOK), apiResponse.Body.String())
+		Expect(apiProvider.specs).To(HaveLen(1))
+		Expect(apiProvider.specs[0].Messages).To(HaveLen(2))
+		Expect(apiProvider.specs[0].Messages[0].Parts).To(HaveLen(1), "the data-fork-seed marker is UI-only")
+		Expect(apiProvider.specs[0].Messages[0].Parts[0].Text).To(ContainSubstring("<captain-fork"))
+		Expect(apiProvider.specs[0].Messages[1].Parts[0].Text).To(Equal("Continue on API"))
+	})
+
+	It("bounds thread summaries and hydrates full detail separately", func() {
+		ctx := context.Background()
+		store := aichat.NewMemoryThreadStore()
+		var detailID string
+		for i := 0; i < 101; i++ {
+			thread, err := store.Create(ctx, "Summary")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.AppendMessage(ctx, thread.ID, aichat.UIMessage{
+				ID: "message-" + thread.ID, Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "content"}},
+			})).To(Succeed())
+			detailID = thread.ID
+		}
+		Expect(store.SetRuntime(ctx, detailID, api.Model{Name: "test-model", Backend: api.BackendOpenAI})).To(Succeed())
+		service := aichat.NewService(aichat.ServiceOptions{Threads: aichat.FixedThreadStore(store)})
+
+		list := httptest.NewRecorder()
+		service.Handler().ServeHTTP(list, httptest.NewRequest(http.MethodGet, "/api/chat/sessions", nil))
+		var summaries []aichat.Thread
+		Expect(json.Unmarshal(list.Body.Bytes(), &summaries)).To(Succeed())
+		Expect(summaries).To(HaveLen(100))
+		for _, summary := range summaries {
+			Expect(summary.Messages).To(BeNil())
+		}
+
+		detail := httptest.NewRecorder()
+		service.Handler().ServeHTTP(detail, httptest.NewRequest(http.MethodGet,
+			"/api/chat/sessions/"+detailID, nil))
+		var hydrated aichat.Thread
+		Expect(json.Unmarshal(detail.Body.Bytes(), &hydrated)).To(Succeed())
+		Expect(hydrated.Messages).To(HaveLen(1))
+		Expect(hydrated.Runtime).To(Equal(&api.Model{Name: "test-model", Backend: api.BackendOpenAI}))
+	})
+})

--- a/pkg/aichat/thread_identity_ginkgo_test.go
+++ b/pkg/aichat/thread_identity_ginkgo_test.go
@@ -25,6 +25,38 @@ type blockingForkThreadStore struct {
 	release <-chan struct{}
 }
 
+type blockingGetThreadStore struct {
+	aichat.ThreadStore
+	enabled         atomic.Bool
+	blocked         atomic.Int32
+	approvalStarted chan<- struct{}
+	approvalRelease <-chan struct{}
+	chatStarted     chan<- struct{}
+	chatRelease     <-chan struct{}
+}
+
+func (s *blockingGetThreadStore) Get(ctx context.Context, id string) (*aichat.Thread, error) {
+	if s.enabled.Load() {
+		switch s.blocked.Add(1) {
+		case 1:
+			s.approvalStarted <- struct{}{}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-s.approvalRelease:
+			}
+		case 2:
+			s.chatStarted <- struct{}{}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-s.chatRelease:
+			}
+		}
+	}
+	return s.ThreadStore.Get(ctx, id)
+}
+
 func (s blockingForkThreadStore) Fork(ctx context.Context, id string) (*aichat.Thread, error) {
 	s.started <- struct{}{}
 	select {
@@ -211,14 +243,28 @@ var _ = Describe("Authoritative chat thread identity", func() {
 
 		providerStarted := make(chan struct{})
 		releaseProvider := make(chan struct{})
+		approvalGetStarted := make(chan struct{})
+		releaseApprovalGet := make(chan struct{})
+		chatGetStarted := make(chan struct{})
+		releaseChatGet := make(chan struct{})
+		blockingStore := &blockingGetThreadStore{
+			ThreadStore: store, approvalStarted: approvalGetStarted, approvalRelease: releaseApprovalGet,
+			chatStarted: chatGetStarted, chatRelease: releaseChatGet,
+		}
 		var launches atomic.Int32
 		provider := &fakeStreamingProvider{execute: func(context.Context, api.Spec) (<-chan api.Event, error) {
-			if launches.Add(1) == 1 {
+			launch := launches.Add(1)
+			if launch == 1 {
 				close(providerStarted)
 				<-releaseProvider
+				blockingStore.enabled.Store(true)
 			}
 			events := make(chan api.Event, 2)
-			events <- api.Event{Kind: api.EventToolResult, ToolCallID: "call-1", Tool: "accounts_edit", Success: true}
+			if launch == 1 {
+				events <- api.Event{Kind: api.EventToolResult, ToolCallID: "call-1", Tool: "accounts_edit", Success: true}
+			} else {
+				events <- api.Event{Kind: api.EventText, Text: "Next answer"}
+			}
 			events <- api.Event{Kind: api.EventResult, Success: true}
 			close(events)
 			return events, nil
@@ -230,9 +276,9 @@ var _ = Describe("Authoritative chat thread identity", func() {
 				Model:        api.Model{Name: "test-model", Backend: api.BackendOpenAI},
 				ToolApproval: &api.ToolApprovalResume{},
 			},
-		}}
+		}, execution: &fakeExecution{}}
 		service := aichat.NewService(aichat.ServiceOptions{
-			Threads: aichat.FixedThreadStore(store), Authority: authority,
+			Threads: aichat.FixedThreadStore(blockingStore), Authority: authority,
 			Resolver: &fakeResolver{provider: provider},
 		})
 
@@ -264,12 +310,32 @@ var _ = Describe("Authoritative chat thread identity", func() {
 		Expect(launches.Load()).To(Equal(int32(1)), "no second provider may launch while approval continuation is active")
 
 		close(releaseProvider)
+		Eventually(approvalGetStarted).Should(Receive())
+		nextDone := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, requestJSON(http.MethodPost, "/api/chat", aichat.ChatRequest{
+				ID: thread.ID, ThreadID: thread.ID, Trigger: "submit-message",
+				Runtime: &api.Model{Name: "test-model", Backend: api.BackendOpenAI},
+				Messages: []aichat.UIMessage{{
+					ID: "next-user", Role: "user", Parts: []aichat.UIPart{{Type: "text", Text: "Continue after approval"}},
+				}},
+			}))
+			nextDone <- response
+		}()
+		Eventually(chatGetStarted).Should(Receive())
+		close(releaseApprovalGet)
 		var approval *httptest.ResponseRecorder
 		Eventually(approvalDone).Should(Receive(&approval))
 		Expect(approval.Code).To(Equal(http.StatusOK), approval.Body.String())
+		close(releaseChatGet)
+		var next *httptest.ResponseRecorder
+		Eventually(nextDone).Should(Receive(&next))
+		Expect(next.Code).To(Equal(http.StatusOK), next.Body.String())
 		stored, err := store.Get(ctx, thread.ID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stored.Messages).NotTo(ContainElement(HaveField("ID", "concurrent-user")))
+		Expect(stored.Messages).To(ContainElement(HaveField("ID", "next-user")))
 	})
 
 	It("reserves a fork source against concurrent turn admission", func() {

--- a/pkg/aichat/threads.go
+++ b/pkg/aichat/threads.go
@@ -2,22 +2,37 @@ package aichat
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/flanksource/captain/pkg/ai"
+	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/session"
 	"github.com/google/uuid"
 )
 
+const maxThreadSummaries = 100
+
+var (
+	ErrThreadNotFound        = errors.New("chat thread not found")
+	ErrThreadRuntimeConflict = errors.New("chat thread runtime conflict")
+	ErrForkSourceEmpty       = errors.New("chat thread has no conversation to fork")
+)
+
 type Thread struct {
-	ID        string      `json:"id"`
-	Title     string      `json:"title"`
-	CreatedAt time.Time   `json:"createdAt"`
-	UpdatedAt time.Time   `json:"updatedAt"`
-	Messages  []UIMessage `json:"messages"`
+	ID         string      `json:"id"`
+	Title      string      `json:"title"`
+	Revision   int64       `json:"revision"`
+	CreatedAt  time.Time   `json:"createdAt"`
+	UpdatedAt  time.Time   `json:"updatedAt"`
+	Messages   []UIMessage `json:"messages,omitempty"`
+	Runtime    *api.Model  `json:"runtime,omitempty"`
+	ForkedFrom string      `json:"forkedFrom,omitempty"`
 
 	TotalInputTokens      int     `json:"totalInputTokens"`
 	TotalOutputTokens     int     `json:"totalOutputTokens"`
@@ -64,6 +79,8 @@ type ThreadStore interface {
 	ReplaceLastMessage(context.Context, string, UIMessage) error
 	Delete(context.Context, string) error
 	SetProviderSession(context.Context, string, string) error
+	SetRuntime(context.Context, string, api.Model) error
+	Fork(context.Context, string) (*Thread, error)
 	SetTitle(context.Context, string, TitleUpdate) error
 	AddUsage(context.Context, string, TurnUsage) (*Thread, error)
 }
@@ -99,9 +116,14 @@ func (s *memoryThreadStore) List(context.Context) ([]*Thread, error) {
 	defer s.mu.Unlock()
 	threads := make([]*Thread, 0, len(s.threads))
 	for _, thread := range s.threads {
-		threads = append(threads, cloneThread(thread))
+		summary := cloneThread(thread)
+		summary.Messages = nil
+		threads = append(threads, summary)
 	}
 	sort.Slice(threads, func(i, j int) bool { return threads[i].UpdatedAt.After(threads[j].UpdatedAt) })
+	if len(threads) > maxThreadSummaries {
+		threads = threads[:maxThreadSummaries]
+	}
 	return threads, nil
 }
 
@@ -110,7 +132,7 @@ func (s *memoryThreadStore) Get(_ context.Context, id string) (*Thread, error) {
 	defer s.mu.Unlock()
 	thread, ok := s.threads[id]
 	if !ok {
-		return nil, fmt.Errorf("thread %q not found", id)
+		return nil, fmt.Errorf("%w: %q", ErrThreadNotFound, id)
 	}
 	return cloneThread(thread), nil
 }
@@ -122,8 +144,16 @@ func (s *memoryThreadStore) AppendMessage(_ context.Context, id string, message 
 	if err != nil {
 		return err
 	}
+	for _, existing := range thread.Messages {
+		if existing.ID != "" && existing.ID == message.ID {
+			if reflect.DeepEqual(existing, message) {
+				return nil
+			}
+			return fmt.Errorf("thread %q message %q was replayed with different content", id, message.ID)
+		}
+	}
 	thread.Messages = append(thread.Messages, message)
-	thread.UpdatedAt = time.Now()
+	touchMemoryThread(thread)
 	return nil
 }
 
@@ -138,7 +168,7 @@ func (s *memoryThreadStore) ReplaceLastMessage(_ context.Context, id string, mes
 		return fmt.Errorf("thread %q: %w", id, err)
 	}
 	thread.Messages[len(thread.Messages)-1] = message
-	thread.UpdatedAt = time.Now()
+	touchMemoryThread(thread)
 	return nil
 }
 
@@ -146,7 +176,7 @@ func (s *memoryThreadStore) Delete(_ context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.threads[id]; !ok {
-		return fmt.Errorf("thread %q not found", id)
+		return fmt.Errorf("%w: %q", ErrThreadNotFound, id)
 	}
 	delete(s.threads, id)
 	return nil
@@ -174,8 +204,52 @@ func (s *memoryThreadStore) SetProviderSession(_ context.Context, id, sessionID 
 		return nil
 	}
 	thread.ProviderSessionID = sessionID
-	thread.UpdatedAt = time.Now()
+	touchMemoryThread(thread)
 	return nil
+}
+
+func (s *memoryThreadStore) SetRuntime(_ context.Context, id string, runtime api.Model) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	thread, err := s.thread(id)
+	if err != nil {
+		return err
+	}
+	identity, err := threadRuntimeIdentity(runtime)
+	if err != nil {
+		return err
+	}
+	if thread.Runtime != nil {
+		if sameThreadRuntime(*thread.Runtime, identity) {
+			return nil
+		}
+		return fmt.Errorf("%w: runtime is already bound to %s/%s", ErrThreadRuntimeConflict,
+			thread.Runtime.Backend, thread.Runtime.Name)
+	}
+	thread.Runtime = &identity
+	touchMemoryThread(thread)
+	return nil
+}
+
+func (s *memoryThreadStore) Fork(_ context.Context, id string) (*Thread, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	source, err := s.thread(id)
+	if err != nil {
+		return nil, err
+	}
+	title, seed, err := forkSeedMessage(source)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	fork := &Thread{
+		ID: uuid.NewString(), Title: title, CreatedAt: now, UpdatedAt: now,
+		Messages: []UIMessage{seed}, ForkedFrom: source.ID,
+	}
+	s.threads[fork.ID] = fork
+	s.titleSources[fork.ID] = TitleSourceDerived
+	return cloneThread(fork), nil
 }
 
 func (s *memoryThreadStore) SetTitle(_ context.Context, id string, update TitleUpdate) error {
@@ -194,7 +268,7 @@ func (s *memoryThreadStore) SetTitle(_ context.Context, id string, update TitleU
 	}
 	thread.Title = title
 	s.titleSources[id] = update.Source
-	thread.UpdatedAt = time.Now()
+	touchMemoryThread(thread)
 	return nil
 }
 
@@ -212,14 +286,14 @@ func (s *memoryThreadStore) AddUsage(_ context.Context, id string, usage TurnUsa
 	thread.TotalCacheWriteTokens += usage.CacheWriteTokens
 	thread.TotalCostUSD += usage.CostUSD
 	thread.LastContextTokens = usage.InputTokens
-	thread.UpdatedAt = time.Now()
+	touchMemoryThread(thread)
 	return cloneThread(thread), nil
 }
 
 func (s *memoryThreadStore) thread(id string) (*Thread, error) {
 	thread, ok := s.threads[id]
 	if !ok {
-		return nil, fmt.Errorf("thread %q not found", id)
+		return nil, fmt.Errorf("%w: %q", ErrThreadNotFound, id)
 	}
 	return thread, nil
 }
@@ -227,7 +301,32 @@ func (s *memoryThreadStore) thread(id string) (*Thread, error) {
 func cloneThread(thread *Thread) *Thread {
 	copy := *thread
 	copy.Messages = append([]UIMessage(nil), thread.Messages...)
+	if thread.Runtime != nil {
+		runtime := *thread.Runtime
+		copy.Runtime = &runtime
+	}
 	return &copy
+}
+
+func touchMemoryThread(thread *Thread) {
+	thread.Revision++
+	thread.UpdatedAt = time.Now()
+}
+
+func threadRuntimeIdentity(runtime api.Model) (api.Model, error) {
+	resolved, err := ai.ResolveModelSelectors(runtime)
+	if err != nil {
+		return api.Model{}, fmt.Errorf("resolve thread runtime: %w", err)
+	}
+	identity := api.Model{Name: strings.TrimSpace(resolved.Name), Backend: resolved.Backend}
+	if identity.Name == "" || !identity.Backend.Valid() {
+		return api.Model{}, fmt.Errorf("thread runtime requires a model name and valid backend")
+	}
+	return identity, nil
+}
+
+func sameThreadRuntime(left, right api.Model) bool {
+	return left.Name == right.Name && left.Backend == right.Backend
 }
 
 func validateLastMessageReplacement(messages []UIMessage, replacement UIMessage) error {

--- a/pkg/aichat/threads_http.go
+++ b/pkg/aichat/threads_http.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/flanksource/captain/pkg/database"
 )
 
 func (s *Service) registerThreadRoutes(mux *http.ServeMux) {
@@ -15,6 +17,7 @@ func (s *Service) registerThreadRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/chat/sessions", s.handleListThreads)
 	mux.HandleFunc("GET /api/chat/sessions/{id}", s.handleGetThread)
 	mux.HandleFunc("PATCH /api/chat/sessions/{id}", s.handleRenameThread)
+	mux.HandleFunc("POST /api/chat/sessions/{id}/fork", s.handleForkThread)
 	mux.HandleFunc("GET /api/chat/sessions/{id}/costs", s.handleThreadCosts)
 	mux.HandleFunc("DELETE /api/chat/sessions/{id}", s.handleDeleteThread)
 	mux.HandleFunc("POST /api/chat/sessions/{id}/approvals/{approvalID}", s.handleResolveToolApproval)
@@ -118,6 +121,36 @@ func (s *Service) handleGetThread(w http.ResponseWriter, request *http.Request) 
 	}
 	if err := writeJSON(w, http.StatusOK, thread); err != nil {
 		serviceLog.Errorf("write chat thread %q: %v", request.PathValue("id"), err)
+	}
+}
+
+func (s *Service) handleForkThread(w http.ResponseWriter, request *http.Request) {
+	store := s.threadStore(w, request)
+	if store == nil {
+		return
+	}
+	id := request.PathValue("id")
+	if err := s.reserveThread(id); err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	defer s.releaseThreadReservation(id)
+	fork, err := store.Fork(request.Context(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, ErrForkSourceEmpty):
+			status = http.StatusBadRequest
+		case errors.Is(err, ErrThreadNotFound), errors.Is(err, database.ErrSessionNotFound):
+			status = http.StatusNotFound
+		case errors.Is(err, database.ErrOpenChatTurn), errors.Is(err, database.ErrSessionConflict):
+			status = http.StatusConflict
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	if err := writeJSON(w, http.StatusCreated, fork); err != nil {
+		serviceLog.Errorf("write forked chat thread %q from %q: %v", fork.ID, id, err)
 	}
 }
 

--- a/pkg/database/caller_tool_store.go
+++ b/pkg/database/caller_tool_store.go
@@ -299,12 +299,13 @@ func (db *DB) CreateToolApprovalRequest(
 }
 
 type ResolveToolApprovalRequestInput struct {
-	SessionID    uuid.UUID
-	RequestID    uuid.UUID
-	Approved     bool
-	UpdatedInput map[string]any
-	ResolvedBy   string
-	Reason       string
+	SessionID      uuid.UUID
+	RequestID      uuid.UUID
+	ExpectedTurnID *uuid.UUID
+	Approved       bool
+	UpdatedInput   map[string]any
+	ResolvedBy     string
+	Reason         string
 }
 
 func (db *DB) ResolveToolApprovalRequest(
@@ -338,6 +339,9 @@ func (db *DB) ResolveToolApprovalRequest(
 			return &out, nil
 		}
 		return nil, fmt.Errorf("%w: approval %s already has a different %s decision", ErrTurnRequestConflict, pending.ID, pending.State)
+	}
+	if input.ExpectedTurnID != nil && (pending.TurnID == nil || *pending.TurnID != *input.ExpectedTurnID) {
+		return nil, fmt.Errorf("%w: approval %s does not belong to active turn %s", ErrTurnRequestConflict, pending.ID, *input.ExpectedTurnID)
 	}
 	now := time.Now().UTC()
 	result := db.gorm.WithContext(ctx).Model(&turnRequestRecord{}).

--- a/pkg/database/caller_tool_store_integration_test.go
+++ b/pkg/database/caller_tool_store_integration_test.go
@@ -37,9 +37,17 @@ func TestCallerToolCredentialAndApprovalLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, TurnRequestStatePending, request.State)
+	wrongTurnID := uuid.New()
+	_, err = db.ResolveToolApprovalRequest(t.Context(), ResolveToolApprovalRequestInput{
+		SessionID: session.ID, RequestID: request.ID, ExpectedTurnID: &wrongTurnID, Approved: true,
+	})
+	assert.ErrorIs(t, err, ErrTurnRequestConflict)
+	stillPending, err := db.GetTurnRequest(t.Context(), request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, TurnRequestStatePending, stillPending.State)
 
 	resolved, err := db.ResolveToolApprovalRequest(t.Context(), ResolveToolApprovalRequestInput{
-		SessionID: session.ID, RequestID: request.ID, Approved: true,
+		SessionID: session.ID, RequestID: request.ID, ExpectedTurnID: &turn.ID, Approved: true,
 		UpdatedInput: map[string]any{"id": "acc-1", "name": "Receivables"}, ResolvedBy: "chat",
 	})
 	require.NoError(t, err)

--- a/pkg/database/session_chat_store.go
+++ b/pkg/database/session_chat_store.go
@@ -160,6 +160,13 @@ type CreateChatModelCallInput struct {
 	Effort      string
 }
 
+type UpdateChatModelCallRuntimeInput struct {
+	ID      uuid.UUID
+	Model   string
+	Backend string
+	Effort  string
+}
+
 type ModelCallStatus string
 
 const (
@@ -209,6 +216,28 @@ func (db *DB) CreateChatModelCall(ctx context.Context, input CreateChatModelCall
 		return uuid.Nil, fmt.Errorf("create Captain chat model call: %w", err)
 	}
 	return record.ID, nil
+}
+
+// UpdateChatModelCallRuntime records the candidate a fallback provider actually
+// selected while the model call is still running.
+func (db *DB) UpdateChatModelCallRuntime(ctx context.Context, input UpdateChatModelCallRuntimeInput) error {
+	input.Model = strings.TrimSpace(input.Model)
+	input.Backend = strings.TrimSpace(input.Backend)
+	if input.ID == uuid.Nil || input.Model == "" || input.Backend == "" {
+		return fmt.Errorf("%w: model call ID, model, and backend are required", ErrInvalidIngest)
+	}
+	result := db.gorm.WithContext(ctx).Model(&modelCallRecord{}).
+		Where("id = ? AND status = 'running'", input.ID).
+		Updates(map[string]any{
+			"model": input.Model, "backend": input.Backend, "effort": nullableTrimmed(input.Effort),
+		})
+	if result.Error != nil {
+		return fmt.Errorf("update Captain chat model call runtime: %w", result.Error)
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("update Captain chat model call runtime %s: expected one running call, updated %d", input.ID, result.RowsAffected)
+	}
+	return nil
 }
 
 func (db *DB) FinishChatModelCall(ctx context.Context, input FinishChatModelCallInput) error {

--- a/pkg/database/session_chat_store.go
+++ b/pkg/database/session_chat_store.go
@@ -283,7 +283,9 @@ func (db *DB) FinishChatTurn(ctx context.Context, id uuid.UUID, status TurnStatu
 }
 
 type PutChatMessageInput struct {
-	SessionID         uuid.UUID
+	SessionID uuid.UUID
+	// TurnID is zero for a persisted conversation seed and nonzero for real
+	// user/assistant turn messages.
 	TurnID            uuid.UUID
 	ProviderMessageID string
 	Role              string
@@ -294,8 +296,12 @@ type PutChatMessageInput struct {
 func (db *DB) PutChatMessage(ctx context.Context, input PutChatMessageInput) error {
 	input.ProviderMessageID = strings.TrimSpace(input.ProviderMessageID)
 	input.Role = strings.TrimSpace(input.Role)
-	if input.SessionID == uuid.Nil || input.TurnID == uuid.Nil || input.ProviderMessageID == "" || input.Role == "" || !json.Valid(input.Parts) {
-		return fmt.Errorf("%w: session, turn, message ID, role, and valid parts are required", ErrInvalidIngest)
+	if input.SessionID == uuid.Nil || input.ProviderMessageID == "" || input.Role == "" || !json.Valid(input.Parts) {
+		return fmt.Errorf("%w: session, message ID, role, and valid parts are required", ErrInvalidIngest)
+	}
+	var turnID *uuid.UUID
+	if input.TurnID != uuid.Nil {
+		turnID = &input.TurnID
 	}
 	var existing messageRecord
 	err := db.gorm.WithContext(ctx).
@@ -309,7 +315,7 @@ func (db *DB) PutChatMessage(ctx context.Context, input PutChatMessageInput) err
 			return nil
 		}
 		if err := db.gorm.WithContext(ctx).Model(&messageRecord{}).Where("id = ?", existing.ID).
-			Updates(map[string]any{"role": input.Role, "parts": append(json.RawMessage(nil), input.Parts...), "turn_id": input.TurnID}).Error; err != nil {
+			Updates(map[string]any{"role": input.Role, "parts": append(json.RawMessage(nil), input.Parts...), "turn_id": turnID}).Error; err != nil {
 			return fmt.Errorf("replace Captain chat message %q: %w", input.ProviderMessageID, err)
 		}
 		return db.touchChatSession(ctx, input.SessionID)
@@ -327,7 +333,7 @@ func (db *DB) PutChatMessage(ctx context.Context, input PutChatMessageInput) err
 	}
 	now := time.Now().UTC()
 	record := messageRecord{
-		ID: uuid.New(), SessionID: input.SessionID, TurnID: &input.TurnID,
+		ID: uuid.New(), SessionID: input.SessionID, TurnID: turnID,
 		ProviderMessageID: &input.ProviderMessageID, Sequence: sequence, Role: input.Role,
 		Parts: append([]byte(nil), input.Parts...), OccurredAt: &now,
 	}
@@ -335,6 +341,61 @@ func (db *DB) PutChatMessage(ctx context.Context, input PutChatMessageInput) err
 		return fmt.Errorf("create Captain chat message: %w", err)
 	}
 	return db.touchChatSession(ctx, input.SessionID)
+}
+
+type ForkChatSessionInput struct {
+	SourceSessionID         uuid.UUID
+	ExpectedSourceUpdatedAt time.Time
+	SessionID               uuid.UUID
+	Title                   string
+	Metadata                map[string]any
+	ProviderMessageID       string
+	Role                    string
+	Parts                   json.RawMessage
+}
+
+// ForkChatSession atomically verifies that the source is idle, creates a new
+// independent aichat root, and persists its turnless transcript seed.
+func (db *DB) ForkChatSession(ctx context.Context, input ForkChatSessionInput) (*Session, error) {
+	if input.SourceSessionID == uuid.Nil || input.SessionID == uuid.Nil || input.SourceSessionID == input.SessionID {
+		return nil, fmt.Errorf("%w: distinct source and fork session IDs are required", ErrInvalidSession)
+	}
+	var fork *Session
+	err := db.Transaction(ctx, func(tx *DB) error {
+		source, err := tx.LockSessionForUpdate(ctx, input.SourceSessionID)
+		if err != nil {
+			return err
+		}
+		if source.Source != "aichat" {
+			return fmt.Errorf("%w: fork source %s has source %q", ErrSessionConflict, source.ID, source.Source)
+		}
+		if !input.ExpectedSourceUpdatedAt.IsZero() && !source.UpdatedAt.Equal(input.ExpectedSourceUpdatedAt) {
+			return fmt.Errorf("%w: fork source %s changed after its transcript was read", ErrSessionConflict, source.ID)
+		}
+		var open turnRecord
+		err = tx.gorm.WithContext(ctx).
+			Where("session_id = ? AND status = ?", source.ID, TurnStatusOpen).
+			First(&open).Error
+		if err == nil {
+			return fmt.Errorf("%w: session %s has active turn %s", ErrOpenChatTurn, source.ID, open.ID)
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("read fork source turn: %w", err)
+		}
+		var createErr error
+		fork, createErr = tx.CreateOrGetSession(ctx, CreateSessionInput{
+			ID: input.SessionID, Source: "aichat", Provider: "captain", HostID: "local",
+			Title: strings.TrimSpace(input.Title), Metadata: input.Metadata,
+		})
+		if createErr != nil {
+			return createErr
+		}
+		return tx.PutChatMessage(ctx, PutChatMessageInput{
+			SessionID: fork.ID, ProviderMessageID: input.ProviderMessageID,
+			Role: input.Role, Parts: input.Parts,
+		})
+	})
+	return fork, err
 }
 
 func (db *DB) DeleteChatSession(ctx context.Context, id uuid.UUID) error {

--- a/pkg/database/session_metadata_store.go
+++ b/pkg/database/session_metadata_store.go
@@ -1,0 +1,64 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// SetSessionMetadataOnce binds one metadata key to its first value. Replaying
+// the same value is idempotent; replacing it is an identity conflict.
+func (db *DB) SetSessionMetadataOnce(ctx context.Context, id uuid.UUID, key string, value any) error {
+	key = strings.TrimSpace(key)
+	if id == uuid.Nil || key == "" {
+		return fmt.Errorf("%w: session ID and metadata key are required", ErrInvalidSession)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode Captain session metadata %q: %w", key, err)
+	}
+	var normalized any
+	if err := json.Unmarshal(encoded, &normalized); err != nil {
+		return fmt.Errorf("normalize Captain session metadata %q: %w", key, err)
+	}
+	return db.Transaction(ctx, func(tx *DB) error {
+		var record sessionRecord
+		if err := tx.gorm.WithContext(ctx).Clauses(clause.Locking{Strength: "UPDATE"}).
+			First(&record, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("%w: %s", ErrSessionNotFound, id)
+			}
+			return fmt.Errorf("lock Captain session metadata: %w", err)
+		}
+		if current, exists := record.Metadata[key]; exists {
+			currentJSON, marshalErr := json.Marshal(current)
+			if marshalErr != nil {
+				return fmt.Errorf("encode existing Captain session metadata %q: %w", key, marshalErr)
+			}
+			var currentNormalized any
+			if err := json.Unmarshal(currentJSON, &currentNormalized); err != nil {
+				return fmt.Errorf("normalize existing Captain session metadata %q: %w", key, err)
+			}
+			if reflect.DeepEqual(currentNormalized, normalized) {
+				return nil
+			}
+			return fmt.Errorf("%w: session metadata %q is already bound", ErrSessionConflict, key)
+		}
+		if record.Metadata == nil {
+			record.Metadata = map[string]any{}
+		}
+		record.Metadata[key] = normalized
+		if err := tx.gorm.WithContext(ctx).Model(&sessionRecord{}).Where("id = ?", id).
+			Update("metadata", record.Metadata).Error; err != nil {
+			return fmt.Errorf("set Captain session metadata %q: %w", key, err)
+		}
+		return nil
+	})
+}

--- a/pkg/database/session_metadata_store_integration_test.go
+++ b/pkg/database/session_metadata_store_integration_test.go
@@ -1,0 +1,46 @@
+package database
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/flanksource/commons-db/dbtest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionMetadataWriteOnceAndTurnlessMessage(t *testing.T) {
+	testDB := dbtest.ForT(t, dbtest.Options{Name: "captain_session_metadata_once"})
+	db, err := Open(t.Context(), WithDSN(testDB.DSN()), WithMigrations())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	session, err := db.CreateOrGetSession(t.Context(), CreateSessionInput{
+		ID: uuid.New(), Source: "aichat", Provider: "captain", HostID: "local",
+	})
+	require.NoError(t, err)
+	runtime := map[string]any{"model": "test-model", "backend": "openai"}
+	require.NoError(t, db.SetSessionMetadataOnce(t.Context(), session.ID, "aichatRuntime", runtime))
+	require.NoError(t, db.SetSessionMetadataOnce(t.Context(), session.ID, "aichatRuntime", map[string]any{
+		"backend": "openai", "model": "test-model",
+	}))
+	err = db.SetSessionMetadataOnce(t.Context(), session.ID, "aichatRuntime", map[string]any{
+		"model": "other-model", "backend": "openai",
+	})
+	assert.True(t, errors.Is(err, ErrSessionConflict))
+
+	require.NoError(t, db.PutChatMessage(t.Context(), PutChatMessageInput{
+		SessionID: session.ID, ProviderMessageID: "fork-seed", Role: "user",
+		Parts: json.RawMessage(`[{
+			"type":"data-fork-seed","data":{"forkedFrom":"source"}
+		},{"type":"text","text":"seed"}]`),
+	}))
+	var turnID *uuid.UUID
+	require.NoError(t, db.Gorm().WithContext(t.Context()).Raw(`
+		SELECT turn_id FROM captain_messages
+		WHERE session_id = ? AND provider_message_id = 'fork-seed'
+	`, session.ID).Row().Scan(&turnID))
+	assert.Nil(t, turnID)
+}

--- a/pkg/database/session_prompt_store.go
+++ b/pkg/database/session_prompt_store.go
@@ -402,6 +402,27 @@ func (db *DB) GetSession(ctx context.Context, id uuid.UUID) (*Session, error) {
 	return &out, nil
 }
 
+// LockSessionForUpdate reads and locks one session row for the lifetime of the
+// caller's transaction.
+func (db *DB) LockSessionForUpdate(ctx context.Context, id uuid.UUID) (*Session, error) {
+	if err := db.requireGorm(); err != nil {
+		return nil, err
+	}
+	if id == uuid.Nil {
+		return nil, fmt.Errorf("%w: session ID is required", ErrInvalidSession)
+	}
+	var record sessionRecord
+	if err := db.gorm.WithContext(ctx).Clauses(clause.Locking{Strength: "UPDATE"}).
+		First(&record, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%w: %s", ErrSessionNotFound, id)
+		}
+		return nil, fmt.Errorf("lock Captain session: %w", err)
+	}
+	out := sessionFromRecord(record)
+	return &out, nil
+}
+
 // GetSessionByIdentity resolves either an authoritative UUID or a provider
 // session ID. Provider IDs are required to be unambiguous across the supplied
 // optional source/provider/host filters.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -30,6 +30,8 @@ type Session struct {
 	Backend           string          `json:"backend,omitempty"`
 	ExecutionMode     api.RuntimeMode `json:"executionMode,omitempty"`
 	Model             string          `json:"model,omitempty"` // primary model
+	Runtime           *api.Model      `json:"runtime,omitempty"`
+	ForkedFrom        string          `json:"forkedFrom,omitempty"`
 	ReasoningEffort   string          `json:"reasoningEffort,omitempty"`
 	HistoryFile       string          `json:"historyFile,omitempty"`
 


### PR DESCRIPTION
Closes #54 and #59.

Makes Captain authoritative for chat/thread/runtime identity, serializes turn admission, and adds session forking with model locking. Includes DB/API/concurrency coverage; UI counterpart: flanksource/clicky-ui#65.

Validated with package tests, focused concurrency tests, `go vet`, and a Captain build. Unrelated existing failures: #69 and flanksource/clicky-ui#66.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fork chat threads while preserving conversation context, including nested fork history.
  * View thread runtime details, revisions, fork origins, summaries, and usage costs.
  * Thread lists now provide concise summaries, with full messages available in thread details.
* **Bug Fixes**
  * Improved approval continuation and concurrent chat handling to prevent conflicting actions.
  * Preserved selected model and backend information throughout streaming responses.
  * Added clearer error responses for busy, missing, and runtime-conflict threads.
* **Reliability**
  * Prevented duplicate or conflicting message updates and improved session consistency during interruptions and forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->