### PR TITLE
fix: preserve approvals submitted before prompt runs wait

### DIFF
--- a/pkg/aichat/database_threads_integration_test.go
+++ b/pkg/aichat/database_threads_integration_test.go
@@ -69,6 +69,11 @@ var _ = Describe("Database chat sessions", func() {
 			Input: map[string]any{"id": "acc-1"},
 		})
 		Expect(err).NotTo(HaveOccurred())
+		resolution := aichat.ToolApprovalResolution{
+			ThreadID: thread.ID, ApprovalID: permission.ApprovalID, Approved: false, Reason: "not now",
+		}
+		_, err = authority.ResolveToolApproval(ctx, resolution)
+		Expect(err).To(MatchError(ContainSubstring("cannot be resolved before its prompt run is waiting")))
 		assistant := aichat.UIMessage{
 			ID: execution.TurnID() + "-assistant", TurnID: execution.TurnID(), Role: "assistant",
 			Parts: []aichat.UIPart{{
@@ -78,6 +83,21 @@ var _ = Describe("Database chat sessions", func() {
 			}},
 		}
 		Expect(store.AppendMessage(ctx, thread.ID, assistant)).To(Succeed())
+		_, err = execution.Observe(ctx, api.Event{
+			Kind: api.EventResult, Success: true,
+			ToolApproval: &api.ToolApprovalState{
+				Messages: []api.Message{{Role: api.RoleAssistant, Parts: []api.Part{{
+					Type: api.PartToolRequest, ToolRequest: &api.ToolRequest{
+						ToolCallID: "call-account-1", Name: "accounts_edit", Input: json.RawMessage(`{"id":"acc-1"}`),
+					},
+				}}}},
+				Calls: []api.ToolApprovalCall{{Request: api.ToolApprovalRequest{
+					ToolCallID: "call-account-1", Tool: "accounts_edit", Input: json.RawMessage(`{"id":"acc-1"}`),
+				}}},
+				ProviderCheckpoint: &api.ProviderCheckpoint{Codec: "test-provider", Version: 1, Payload: []byte("checkpoint")},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
 
 		aggregate, err := store.GetSession(ctx, thread.ID)
 		Expect(err).NotTo(HaveOccurred())
@@ -98,11 +118,10 @@ var _ = Describe("Database chat sessions", func() {
 		Expect(aggregate.Requests[0].RequestedBy).To(Equal("provider"))
 		Expect(aggregate.Messages[1].Parts[0].Approval.ID).To(Equal(permission.ApprovalID))
 
-		continuation, err := authority.ResolveToolApproval(ctx, aichat.ToolApprovalResolution{
-			ThreadID: thread.ID, ApprovalID: permission.ApprovalID, Approved: false, Reason: "not now",
-		})
+		continuation, err := authority.ResolveToolApproval(ctx, resolution)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(continuation).To(BeNil())
+		Expect(continuation).NotTo(BeNil())
+		DeferCleanup(continuation.Execution.Close)
 		resolved, err := store.GetSession(ctx, thread.ID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resolved.Messages[1].Parts[0].State).To(Equal(session.ToolStateOutputDenied))

--- a/pkg/aichat/execution_database_authority.go
+++ b/pkg/aichat/execution_database_authority.go
@@ -3,7 +3,6 @@ package aichat
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -125,6 +124,25 @@ func (a *DatabaseExecutionAuthority) ResolveToolApproval(
 	ctx context.Context,
 	resolution ToolApprovalResolution,
 ) (*ApprovalContinuation, error) {
+	var continuation *ApprovalContinuation
+	err := a.db.Transaction(ctx, func(tx *database.DB) error {
+		var resolveErr error
+		continuation, resolveErr = (&DatabaseExecutionAuthority{db: tx}).resolveToolApproval(ctx, resolution)
+		return resolveErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	if continuation != nil {
+		continuation.Execution.(*databaseExecution).db = a.db
+	}
+	return continuation, nil
+}
+
+func (a *DatabaseExecutionAuthority) resolveToolApproval(
+	ctx context.Context,
+	resolution ToolApprovalResolution,
+) (*ApprovalContinuation, error) {
 	sessionID, err := uuid.Parse(resolution.ThreadID)
 	if err != nil {
 		return nil, fmt.Errorf("chat thread ID %q is not a UUID: %w", resolution.ThreadID, err)
@@ -199,25 +217,18 @@ func (a *DatabaseExecutionAuthority) ResolveToolApproval(
 	phase := database.PromptRunPhaseGenerate
 	var resumed *database.PromptRun
 	var modelCallID uuid.UUID
-	err = a.db.Transaction(ctx, func(tx *database.DB) error {
-		var updateErr error
-		resumed, updateErr = tx.UpdatePromptRun(ctx, database.UpdatePromptRunInput{
-			ID: run.ID, ExpectedVersion: run.Version, State: &running, Phase: &phase,
-			ClearApprovalState: true, ClearProviderCheckpoint: true,
-		})
-		if updateErr != nil {
-			return updateErr
-		}
-		modelCallID, updateErr = tx.CreateChatModelCall(ctx, database.CreateChatModelCallInput{
-			TurnID: turn.ID, PromptRunID: run.ID, Model: spec.Name,
-			Backend: string(spec.Backend), Effort: string(spec.Effort),
-		})
-		return updateErr
+	resumed, err = a.db.UpdatePromptRun(ctx, database.UpdatePromptRunInput{
+		ID: run.ID, ExpectedVersion: run.Version, State: &running, Phase: &phase,
+		ClearApprovalState: true, ClearProviderCheckpoint: true,
 	})
 	if err != nil {
-		if errors.Is(err, database.ErrPromptRunConflict) {
-			return nil, nil
-		}
+		return nil, err
+	}
+	modelCallID, err = a.db.CreateChatModelCall(ctx, database.CreateChatModelCallInput{
+		TurnID: turn.ID, PromptRunID: run.ID, Model: spec.Name,
+		Backend: string(spec.Backend), Effort: string(spec.Effort),
+	})
+	if err != nil {
 		return nil, err
 	}
 	sessionRecord, err := a.db.GetSession(ctx, sessionID)

--- a/pkg/aichat/execution_database_integration_test.go
+++ b/pkg/aichat/execution_database_integration_test.go
@@ -14,6 +14,7 @@ import (
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+	"gorm.io/gorm"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -331,7 +332,7 @@ var _ = Describe("Database execution authority", func() {
 		Expect(sessionRecord.ActivityState).To(Equal(database.SessionActivityIdle))
 	})
 
-	It("keeps an interrupted API run waiting for its durable approvals", func(ctx SpecContext) {
+	It("keeps an approval pending when its prompt run changes before the claim", func(ctx SpecContext) {
 		testDB := dbtest.ForGinkgo(dbtest.Options{Name: "captain_aichat_waiting_approval"})
 		db, err := database.Open(ctx, database.WithDSN(testDB.DSN()), database.WithMigrations())
 		Expect(err).NotTo(HaveOccurred())
@@ -381,6 +382,58 @@ var _ = Describe("Database execution authority", func() {
 		requests, err := db.ListTurnRequests(ctx, database.TurnRequestFilter{SessionID: run.SessionID, PromptRunID: &run.ID})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requests).To(HaveLen(1))
+
+		versionRead := make(chan struct{})
+		continueResolution := make(chan struct{})
+		var intercepted atomic.Bool
+		const callback = "test:pause_approval_after_prompt_run_read"
+		Expect(db.Gorm().Callback().Query().After("gorm:query").Register(callback, func(tx *gorm.DB) {
+			if tx.Statement.Table == "captain_prompt_runs" && intercepted.CompareAndSwap(false, true) {
+				close(versionRead)
+				<-continueResolution
+			}
+		})).To(Succeed())
+		DeferCleanup(func() {
+			Expect(db.Gorm().Callback().Query().Remove(callback)).To(Succeed())
+		})
+		DeferCleanup(func() {
+			select {
+			case <-continueResolution:
+			default:
+				close(continueResolution)
+			}
+		})
+		type resolutionResult struct {
+			continuation *aichat.ApprovalContinuation
+			err          error
+		}
+		result := make(chan resolutionResult, 1)
+		go func() {
+			continuation, resolveErr := authority.ResolveToolApproval(ctx, aichat.ToolApprovalResolution{
+				ThreadID: run.SessionID.String(), ApprovalID: requests[0].ID.String(), Approved: true,
+			})
+			result <- resolutionResult{continuation: continuation, err: resolveErr}
+		}()
+		Eventually(versionRead).Should(BeClosed())
+		Expect(db.Transaction(ctx, func(tx *database.DB) error {
+			if setErr := tx.Gorm().Exec("SET LOCAL captain.suppress_session_change = 'on'").Error; setErr != nil {
+				return setErr
+			}
+			return tx.Gorm().Exec(`
+				UPDATE captain_prompt_runs
+				SET current_iteration = current_iteration + 1
+				WHERE id = ?
+			`, run.ID).Error
+		})).To(Succeed())
+		close(continueResolution)
+		var conflict resolutionResult
+		Eventually(result).Should(Receive(&conflict))
+		Expect(errors.Is(conflict.err, database.ErrPromptRunConflict)).To(BeTrue())
+		Expect(conflict.continuation).To(BeNil())
+		pending, err := db.GetTurnRequest(ctx, requests[0].ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pending.State).To(Equal(database.TurnRequestStatePending))
+
 		continuation, err := authority.ResolveToolApproval(ctx, aichat.ToolApprovalResolution{
 			ThreadID: run.SessionID.String(), ApprovalID: requests[0].ID.String(), Approved: true,
 		})

--- a/pkg/database/caller_tool_store.go
+++ b/pkg/database/caller_tool_store.go
@@ -342,6 +342,10 @@ func (db *DB) ResolveToolApprovalRequest(
 	now := time.Now().UTC()
 	result := db.gorm.WithContext(ctx).Model(&turnRequestRecord{}).
 		Where("id = ? AND state = 'pending'", pending.ID).
+		Where(`credential_id IS NOT NULL OR EXISTS (
+			SELECT 1 FROM captain_prompt_runs run
+			WHERE run.id = captain_turn_requests.prompt_run_id AND run.state = 'waiting'
+		)`).
 		Where(`credential_id IS NULL OR EXISTS (
 			SELECT 1 FROM captain_session_mcp_credentials credential
 			WHERE credential.id = captain_turn_requests.credential_id
@@ -356,6 +360,9 @@ func (db *DB) ResolveToolApprovalRequest(
 		return nil, fmt.Errorf("resolve tool approval request: %w", result.Error)
 	}
 	if result.RowsAffected == 0 {
+		if pending.CredentialID == nil {
+			return nil, fmt.Errorf("%w: approval %s cannot be resolved before its prompt run is waiting", ErrTurnRequestConflict, pending.ID)
+		}
 		if pending.CredentialID != nil {
 			if err := db.ValidateCallerToolCredential(ctx, *pending.CredentialID); err != nil {
 				return nil, err


### PR DESCRIPTION
Closes #69.

Provider approval requests become visible before their prompt run finishes transitioning to `waiting`. Resolving during that window marked the request terminal but skipped continuation, leaving the turn open.

Require provider approval resolution to observe a waiting prompt run in the same conditional database update. Early attempts now return a conflict without consuming the pending decision; credential-backed approvals remain unchanged.

<img width="694" height="404" alt="image" src="https://github.com/user-attachments/assets/d2357cdf-889b-47ac-b7ed-d263be210a15" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented tool approval requests from being resolved before the associated prompt run is ready.
  - Added clearer conflict handling for premature or concurrent approval attempts.
  - Preserved validation for credential-backed approval requests.
  - Improved continuation behavior after successful approval resolution.
  - Kept approval requests pending when a prompt-run conflict prevents resolution.

- **Tests**
  - Added coverage for approval timing, provider results, checkpoints, continuation execution, and concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->