### PR TITLE
fix(api): remove dead routes and prevent SPA fallthrough

### DIFF
--- a/pkg/ai/tools/catalog.go
+++ b/pkg/ai/tools/catalog.go
@@ -2,7 +2,7 @@ package tools
 
 import "strings"
 
-// ToolCatalog is the GET /api/chat/tools payload.
+// ToolCatalog groups the frontend-facing metadata for available tools.
 type ToolCatalog struct {
 	Tools []ToolCatalogEntry `json:"tools"`
 }

--- a/pkg/aichat/service.go
+++ b/pkg/aichat/service.go
@@ -96,7 +96,6 @@ func (s *Service) Handler() http.Handler {
 	mux.HandleFunc("POST /api/chat", s.handleChat)
 	mux.HandleFunc("GET /api/chat/models", s.handleModels)
 	mux.HandleFunc("GET /api/chat/runtimes", s.handleRuntimes)
-	mux.HandleFunc("GET /api/chat/tools", s.handleTools)
 	s.registerThreadRoutes(mux)
 	return mux
 }
@@ -140,21 +139,6 @@ func (s *Service) handleModels(w http.ResponseWriter, request *http.Request) {
 	annotateProfileModels(profile.Resolved, models)
 	if err := writeJSON(w, http.StatusOK, models); err != nil {
 		serviceLog.Errorf("write chat models response: %v", err)
-	}
-}
-
-func (s *Service) handleTools(w http.ResponseWriter, request *http.Request) {
-	if _, err := s.runtimeProfile(request.Context()); err != nil {
-		http.Error(w, fmt.Sprintf("load chat runtime profile: %v", err), http.StatusInternalServerError)
-		return
-	}
-	set, err := s.loadTools(request.Context())
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := writeJSON(w, http.StatusOK, aitools.ToolCatalog{Tools: set.Catalog}); err != nil {
-		serviceLog.Errorf("write chat tools response: %v", err)
 	}
 }
 

--- a/pkg/aichat/service_ginkgo_test.go
+++ b/pkg/aichat/service_ginkgo_test.go
@@ -263,44 +263,18 @@ var _ = Describe("Captain aichat service", func() {
 		Expect(resolver.configs).To(BeEmpty())
 	})
 
-	It("serves models and tools from injected Captain seams", func() {
+	It("serves models from the injected Captain seam", func() {
 		resolver := &fakeResolver{models: aichat.ModelCatalogResponse{{
 			ID: "openai/test-model", Provider: "openai", Label: "Test", Configured: true,
 			Availability: api.Available(),
 			Runtime:      api.Model{Name: "test-model", Backend: api.BackendOpenAI},
 		}}}
-		service := aichat.NewService(aichat.ServiceOptions{
-			Resolver: resolver,
-			Tools: aichat.ToolProviderFunc(func(context.Context) (aichat.ToolSet, error) {
-				return aichat.ToolSet{Definitions: []api.ToolDefinition{{
-					Name: "invoice_get", Group: "billing", Description: "Get invoice",
-					InputSchema: map[string]any{"type": "object"},
-					Handler:     func(context.Context, map[string]any) (any, error) { return nil, nil },
-				}}}, nil
-			}),
-			MCP: aichat.ToolProviderFunc(func(context.Context) (aichat.ToolSet, error) {
-				return aichat.ToolSet{Definitions: []api.ToolDefinition{{
-					Name: "docs_search", Group: "docs", Description: "Search documentation",
-					Handler: func(context.Context, map[string]any) (any, error) { return nil, nil },
-				}}}, nil
-			}),
-		})
+		service := aichat.NewService(aichat.ServiceOptions{Resolver: resolver})
 
 		models := httptest.NewRecorder()
 		service.Handler().ServeHTTP(models, httptest.NewRequest(http.MethodGet, "/api/chat/models", nil))
 		Expect(models.Code).To(Equal(http.StatusOK))
 		Expect(models.Body.String()).To(MatchJSON(`[{"id":"openai/test-model","provider":"openai","label":"Test","runtime":{"model":"test-model","backend":"openai"},"reasoning":false,"temperature":false,"configured":true,"availability":{"state":"available"},"contextWindow":0,"inputMediaTypes":null}]`))
-
-		tools := httptest.NewRecorder()
-		service.Handler().ServeHTTP(tools, httptest.NewRequest(http.MethodGet, "/api/chat/tools", nil))
-		Expect(tools.Code).To(Equal(http.StatusOK))
-		var catalog aichat.ToolCatalogResponse
-		Expect(json.Unmarshal(tools.Body.Bytes(), &catalog)).To(Succeed())
-		Expect(catalog.Tools).To(HaveLen(2))
-		Expect(catalog.Tools[0].Name).To(Equal("invoice_get"))
-		Expect(catalog.Tools[0].Source).To(Equal("custom"))
-		Expect(catalog.Tools[1].Name).To(Equal("docs_search"))
-		Expect(catalog.Tools[1].Source).To(Equal("mcp"))
 	})
 
 	It("maps the HTTP request directly into api.Spec and streams provider events", func() {

--- a/pkg/cli/plan.go
+++ b/pkg/cli/plan.go
@@ -87,7 +87,7 @@ const latestTranscriptPlanPageLimit = 100
 
 func resolveLatestTranscriptPlan(
 	ctx context.Context,
-	db sessionListStore,
+	db latestPlanStore,
 	query latestTranscriptPlanQuery,
 ) (*PlanResult, error) {
 	filter := captaindb.SessionListFilter{
@@ -98,7 +98,6 @@ func resolveLatestTranscriptPlan(
 	if query.Source != "all" {
 		filter.Source = query.Source
 	}
-	plans, _ := db.(planStore)
 	seen := map[string]struct{}{}
 	for {
 		page, err := db.ListSessionSummaries(ctx, filter)
@@ -107,14 +106,12 @@ func resolveLatestTranscriptPlan(
 		}
 		for i := range page.Rows {
 			overview := overviewFromSummary(page.Rows[i])
-			if plans != nil {
-				plan, ok, err := resolveNativePlan(ctx, plans, overview)
-				if err != nil {
-					return nil, err
-				}
-				if ok {
-					return plan, nil
-				}
+			native, ok, err := resolveNativePlan(ctx, db, overview)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				return native, nil
 			}
 			candidate := candidateFromOverview(overview)
 			if candidate.path == "" {
@@ -139,6 +136,12 @@ func resolveLatestTranscriptPlan(
 // planStore reads persisted plan revisions independently of transcript storage.
 type planStore interface {
 	ListPlans(context.Context, captaindb.PlanFilter) ([]captaindb.Plan, error)
+}
+
+// latestPlanStore lists candidate sessions and their persisted plan revisions.
+type latestPlanStore interface {
+	sessionListStore
+	planStore
 }
 
 // planIdentityStore resolves an identity to every matching session overview and

--- a/pkg/cli/plan.go
+++ b/pkg/cli/plan.go
@@ -98,6 +98,7 @@ func resolveLatestTranscriptPlan(
 	if query.Source != "all" {
 		filter.Source = query.Source
 	}
+	plans, _ := db.(planStore)
 	seen := map[string]struct{}{}
 	for {
 		page, err := db.ListSessionSummaries(ctx, filter)
@@ -105,7 +106,17 @@ func resolveLatestTranscriptPlan(
 			return nil, fmt.Errorf("list Captain sessions while resolving latest plan: %w", err)
 		}
 		for i := range page.Rows {
-			candidate := candidateFromOverview(overviewFromSummary(page.Rows[i]))
+			overview := overviewFromSummary(page.Rows[i])
+			if plans != nil {
+				plan, ok, err := resolveNativePlan(ctx, plans, overview)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					return plan, nil
+				}
+			}
+			candidate := candidateFromOverview(overview)
 			if candidate.path == "" {
 				continue
 			}
@@ -125,11 +136,16 @@ func resolveLatestTranscriptPlan(
 	}
 }
 
+// planStore reads persisted plan revisions independently of transcript storage.
+type planStore interface {
+	ListPlans(context.Context, captaindb.PlanFilter) ([]captaindb.Plan, error)
+}
+
 // planIdentityStore resolves an identity to every matching session overview and
 // reads the plans recorded against a Captain session UUID.
 type planIdentityStore interface {
 	sessionOverviewStore
-	ListPlans(context.Context, captaindb.PlanFilter) ([]captaindb.Plan, error)
+	planStore
 }
 
 // resolveIdentityPlan resolves a Captain UUID or provider session ID to a plan.
@@ -186,7 +202,7 @@ func resolveIdentityPlan(ctx context.Context, db planIdentityStore, identity, so
 // otherwise the latest immutable revision of the newest plan variant is returned.
 func resolveNativePlan(
 	ctx context.Context,
-	db planIdentityStore,
+	db planStore,
 	session captaindb.SessionOverview,
 ) (*PlanResult, bool, error) {
 	plans, err := db.ListPlans(ctx, captaindb.PlanFilter{SourceSessionID: &session.ID})

--- a/pkg/cli/plan_search_ginkgo_test.go
+++ b/pkg/cli/plan_search_ginkgo_test.go
@@ -81,3 +81,7 @@ func (s *planListStore) ListSessionSummaries(
 	s.filters = append(s.filters, filter)
 	return s.pages[filter.Cursor], nil
 }
+
+func (*planListStore) ListPlans(context.Context, database.PlanFilter) ([]database.Plan, error) {
+	return nil, nil
+}

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -166,7 +166,6 @@ func RunServe(ctx context.Context, rootCmd *cobra.Command, opts ServeOptions, ve
 	mux := http.NewServeMux()
 	mux.Handle("GET /api/openapi.json", handleCaptainOpenAPI(openAPISpec, false))
 	mux.Handle("GET /api/openapi.yaml", handleCaptainOpenAPI(openAPISpec, true))
-	mux.HandleFunc("GET /api/entities", rpcServer.HandleEntities)
 	mux.HandleFunc("GET /health", rpcServer.HandleHealth)
 	rpcServer.RegisterExecutionRoutes(mux)
 	mux.HandleFunc("POST /api/captain/chat/threads/from-agent", handleThreadFromAgent(threadStore))
@@ -174,7 +173,6 @@ func RunServe(ctx context.Context, rootCmd *cobra.Command, opts ServeOptions, ve
 	mux.HandleFunc("GET /api/captain/projects", handleProjects())
 	mux.HandleFunc("GET /api/captain/sessions/live", handleSessionsLive())
 	mux.HandleFunc("GET /api/captain/sessions/throughput", handleSessionsThroughput())
-	mux.HandleFunc("GET /api/captain/sessions/{id}", handleSessionGet())
 	mux.HandleFunc("POST /api/captain/hooks/{provider}", handleMonitorHookEvent())
 	mux.HandleFunc("GET /api/captain/ai/permissions/catalog", handlePermissionCatalog(cwd))
 	mux.HandleFunc("GET /api/captain/ai/prompt/schema", handlePromptSchema())
@@ -195,14 +193,20 @@ func RunServe(ctx context.Context, rootCmd *cobra.Command, opts ServeOptions, ve
 	mux.Handle("POST /api/captain/prompt/runs/{runId}/interrupt", handlePromptRunInterrupt(promptChats))
 	mux.Handle("POST /api/captain/prompt/runs/{runId}/stop", handlePromptRunStop(promptRuns, promptChats))
 	mux.Handle("POST /api/captain/sessions/{id}/message", handleSessionMessage(promptChats))
-	mux.Handle("/api/chat", chat.Handler())
-	mux.Handle("/api/chat/", chat.Handler())
+	chatHandler := chat.Handler()
+	mux.Handle("/api/chat", chatHandler)
+	mux.Handle("/api/chat/", chatHandler)
 
 	uiHandler, err := newCaptainWebappHandler()
 	if err != nil {
 		return err
 	}
-	mux.Handle("/", uiHandler)
+	// Keep API matching separate so unknown paths and method mismatches cannot
+	// fall through to the SPA's client-side routing fallback.
+	root := http.NewServeMux()
+	root.Handle("/api/", mux)
+	root.Handle("/health", mux)
+	root.Handle("/", uiHandler)
 
 	// Export the serve URL so every captain-launched agent (and the hook
 	// receiver subprocesses its sessions spawn) delivers hook events to this
@@ -213,7 +217,7 @@ func RunServe(ctx context.Context, rootCmd *cobra.Command, opts ServeOptions, ve
 	httpSrv := &http.Server{
 		Addr: addr,
 		Handler: rpchttp.TimingMiddleware(
-			DatabaseContextMiddleware(PromptDirsMiddleware(mux, opts.PromptDirs))),
+			DatabaseContextMiddleware(PromptDirsMiddleware(root, opts.PromptDirs))),
 		ReadTimeout: 30 * time.Second,
 		// /api/chat streams SSE; a fixed write timeout truncates long turns.
 		IdleTimeout: 60 * time.Second,

--- a/pkg/cli/serve_sessions.go
+++ b/pkg/cli/serve_sessions.go
@@ -145,30 +145,3 @@ func handleProjects() http.HandlerFunc {
 		writeServeJSON(w, http.StatusOK, result)
 	}
 }
-
-func handleSessionGet() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		id := strings.TrimSpace(r.PathValue("id"))
-		if id == "" {
-			http.Error(w, "session id is required", http.StatusBadRequest)
-			return
-		}
-		query := r.URL.Query()
-		s, err := RunSessionGet(r.Context(), SessionGetOptions{
-			ID: id, Offset: queryInt(query.Get("offset")), Limit: queryInt(query.Get("limit")), Tail: queryInt(query.Get("tail")),
-		})
-		if err != nil {
-			http.Error(w, err.Error(), serveRunStatus(err, http.StatusNotFound))
-			return
-		}
-		writeServeJSON(w, http.StatusOK, s)
-	}
-}
-
-func queryInt(value string) int {
-	n, err := strconv.Atoi(strings.TrimSpace(value))
-	if err != nil || n < 0 {
-		return 0
-	}
-	return n
-}

--- a/pkg/cli/serve_test.go
+++ b/pkg/cli/serve_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/flanksource/captain/pkg/aichat"
 	"github.com/flanksource/captain/pkg/claude"
-	"github.com/flanksource/captain/pkg/database"
 )
 
 func TestHandleThreadFromAgentCreatesThread(t *testing.T) {
@@ -60,63 +59,6 @@ func TestHandleThreadFromAgentRequiresProviderSession(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "providerSessionId is required") {
 		t.Fatalf("body = %q", rec.Body.String())
-	}
-}
-
-func TestHandleSessionGetReturnsAllMatches(t *testing.T) {
-	home := t.TempDir()
-	db := withTestCaptainDB(t)
-	t.Setenv("HOME", home)
-	project := filepath.Join(home, "work", "project")
-	if err := os.MkdirAll(project, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(project)
-	markProjectRoot(t, project)
-
-	sessionFile := filepath.Join(home, ".claude", "projects", claude.NormalizePath(project), "sess-web.jsonl")
-	writeJSONL(t, sessionFile,
-		map[string]any{
-			"type": "assistant", "sessionId": "sess-web", "uuid": "a1",
-			"timestamp": "2026-07-06T10:00:00Z", "cwd": project,
-			"message": map[string]any{
-				"role": "assistant", "model": "claude-opus-4-5",
-				"content": []any{map[string]any{"type": "text", "text": "hello from the model"}},
-			},
-		},
-	)
-	for _, input := range []database.CreateSessionInput{
-		{ProviderSessionID: "sess-web", Source: "claude", HostID: "test-host", Path: sessionFile, Project: "example", CWD: project},
-		{ProviderSessionID: "sess-web", Source: "gavel", Provider: "cmux", HostID: "local"},
-		{ProviderSessionID: "sess-web", Source: "claude", Provider: "cmux", HostID: "local"},
-	} {
-		if _, err := db.CreateOrGetSession(t.Context(), input); err != nil {
-			t.Fatalf("create duplicate session: %v", err)
-		}
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/captain/sessions/sess-web", nil)
-	req.SetPathValue("id", "sess-web")
-	rec := httptest.NewRecorder()
-	handleSessionGet()(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
-	}
-	var got SessionGetResult
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("unmarshal: %v (body=%s)", err, rec.Body.String())
-	}
-	if got.Total != 3 || len(got.Sessions) != 3 {
-		t.Fatalf("result = %+v", got)
-	}
-	item := got.Sessions[0]
-	detail := item.Detail
-	if detail == nil || detail.ID != item.CaptainID || detail.ProviderSessionID != "sess-web" || detail.Source != "claude" {
-		t.Fatalf("session = %+v", detail)
-	}
-	if len(detail.Messages) == 0 || detail.Messages[0].Parts[0].Text != "hello from the model" {
-		t.Fatalf("messages = %+v", detail.Messages)
 	}
 }
 


### PR DESCRIPTION
Unmatched API requests and method mismatches could fall through to the SPA handler and return HTML with status 200. Captain also retained duplicate or unused session, entity, and chat-tool routes.

Separate API routing from the SPA fallback, remove the dead routes, reuse one chat handler, and make bare `captain plan` prefer persisted native plans.

Addresses #56.