### PR TITLE
fix: unify chat streaming and persistence outcomes

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@ai-sdk/react": "^3.0.201",
     "@astrojs/mdx": "^7.0.2",
     "@astrojs/react": "^6.0.1",
-    "@flanksource/clicky-ui": "0.3.24",
+    "@flanksource/clicky-ui": "0.3.25",
     "@mdxeditor/editor": "^4.0.4",
     "@shikijs/langs": "^1.24.0",
     "@shikijs/themes": "^1.24.0",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yaml@2.9.0)
       '@flanksource/clicky-ui':
-        specifier: 0.3.24
-        version: 0.3.24(@ai-sdk/react@3.0.264(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@mdxeditor/editor@4.0.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.31))(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@18.3.31)(ai@6.0.219(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.56.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.9.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.2)
+        specifier: 0.3.25
+        version: 0.3.25(@ai-sdk/react@3.0.264(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@mdxeditor/editor@4.0.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.31))(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@18.3.31)(ai@6.0.219(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.56.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.9.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.2)
       '@mdxeditor/editor':
         specifier: ^4.0.4
         version: 4.0.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.31)
@@ -641,8 +641,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@flanksource/clicky-ui@0.3.24':
-    resolution: {integrity: sha512-hAia0MFMvhAdVl1oVVgDMFZ+dwpG1OOVMiioXXgmWI9mY2YtMPFwvwvzAS4wAWXvhUHkChrmhE9G4CjnbOnQZg==}
+  '@flanksource/clicky-ui@0.3.25':
+    resolution: {integrity: sha512-YsPyxwJxpYDn4GFcWKSDrA1VDjsR0REtnEvNyUzTfsfQ5piOJnuG4FJuDwh3z2YhHssfl2uS/BKoetG5aSEeAw==}
     peerDependencies:
       '@ai-sdk/react': ^3.0.0
       '@mdxeditor/editor': ^4.0.4
@@ -4457,7 +4457,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@flanksource/clicky-ui@0.3.24(@ai-sdk/react@3.0.264(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@mdxeditor/editor@4.0.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.31))(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@18.3.31)(ai@6.0.219(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.56.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.9.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.2)':
+  '@flanksource/clicky-ui@0.3.25(@ai-sdk/react@3.0.264(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@mdxeditor/editor@4.0.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.31))(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@18.3.31)(ai@6.0.219(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.56.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.9.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.2)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.4

--- a/pkg/aichat/approval_execution.go
+++ b/pkg/aichat/approval_execution.go
@@ -124,6 +124,13 @@ func (s *Service) resumeToolApproval(ctx context.Context, threadID string, conti
 	// the thread total is recomputed from the database on the next read.
 	resumed := s.persistedEvents(streamContext, persistedEventOptions{
 		Request: request, TurnID: execution.TurnID(), Model: continuation.Spec.Model, Runtime: runtime,
+		terminalMetadata: terminalMetadataContext{
+			CaptainSessionID:  execution.CaptainSessionID(),
+			ProviderSessionID: config.SessionID,
+			ThreadID:          threadID,
+			TurnID:            execution.TurnID(),
+			Runtime:           runtime,
+		},
 	}, events)
 	for event := range resumed {
 		if event.Kind == api.EventError {

--- a/pkg/aichat/events.go
+++ b/pkg/aichat/events.go
@@ -16,18 +16,19 @@ type toolState struct {
 }
 
 type eventStream struct {
-	writer    *SSEWriter
-	messageID string
-	blockType string
-	blockID   string
-	nextBlock int
-	tools     map[string]toolState
-	metadata  *MessageMetadata
-	costs     *TurnCosts
-	sessionID string
-	model     string
-	terminal  bool
-	finished  bool
+	writer           *SSEWriter
+	messageID        string
+	blockType        string
+	blockID          string
+	nextBlock        int
+	tools            map[string]toolState
+	metadata         *MessageMetadata
+	terminalMetadata terminalMetadataContext
+	costs            *TurnCosts
+	sessionID        string
+	model            string
+	terminal         bool
+	finished         bool
 }
 
 // EventStreamOptions carries request state needed to finish the resumed UI message.
@@ -36,7 +37,8 @@ type EventStreamOptions struct {
 	MessageID    string
 	// Costs, when set, supplies the finish part's priced breakdown and the
 	// thread's cumulative cost. Nil for streams with no thread to accrue against.
-	Costs *TurnCosts
+	Costs            *TurnCosts
+	terminalMetadata terminalMetadataContext
 }
 
 // WriteEventStream translates a Captain event channel into one complete UI Message Stream.
@@ -49,7 +51,7 @@ func WriteEventStream(writer *SSEWriter, events <-chan api.Event, options EventS
 		}
 	}
 	stream := &eventStream{
-		writer: writer, messageID: options.MessageID,
+		writer: writer, messageID: options.MessageID, terminalMetadata: options.terminalMetadata,
 		tools: map[string]toolState{}, costs: options.Costs,
 	}
 	if err := stream.start(); err != nil {
@@ -61,6 +63,9 @@ func WriteEventStream(writer *SSEWriter, events <-chan api.Event, options EventS
 	for event := range events {
 		if err := stream.event(event); err != nil {
 			return stream.fail(err)
+		}
+		if stream.terminal {
+			return stream.finish()
 		}
 	}
 	if err := stream.finish(); err != nil {
@@ -156,10 +161,8 @@ func (s *eventStream) interrupted(event api.Event) error {
 	}); err != nil {
 		return err
 	}
-	success := false
-	s.metadata = &MessageMetadata{
-		ProviderSessionID: s.sessionID, Model: s.model, Success: &success, Interrupted: true,
-	}
+	s.metadata = s.terminalMetadata.message(s.sessionID, s.model, false)
+	s.metadata.Interrupted = true
 	s.terminal = true
 	return nil
 }
@@ -237,11 +240,19 @@ func (s *eventStream) toolResult(event api.Event) error {
 	if _, err := s.correlatedTool("result", event); err != nil {
 		return err
 	}
-	output := map[string]any{"output": event.Text}
-	if !event.Success {
-		output["isError"] = true
+	part := Part{ToolCallID: event.ToolCallID}
+	if event.Success {
+		output, err := jsonValue(event.Text)
+		if err != nil {
+			return fmt.Errorf("decode tool %q output: %w", event.Tool, err)
+		}
+		part.Type = "tool-output-available"
+		part.Output = output
+	} else {
+		part.Type = "tool-output-error"
+		part.ErrorText = event.Text
 	}
-	if err := s.writer.WritePart(Part{Type: "tool-output-available", ToolCallID: event.ToolCallID, Output: output}); err != nil {
+	if err := s.writer.WritePart(part); err != nil {
 		return err
 	}
 	delete(s.tools, event.ToolCallID)
@@ -292,13 +303,8 @@ func (s *eventStream) result(event api.Event) error {
 			return err
 		}
 	}
-	success := event.Success
-	s.metadata = &MessageMetadata{
-		ProviderSessionID: s.sessionID,
-		Model:             s.model,
-		Cost:              event.CostUSD,
-		Success:           &success,
-	}
+	s.metadata = s.terminalMetadata.message(s.sessionID, s.model, event.Success)
+	s.metadata.Cost = event.CostUSD
 	if event.Usage != nil {
 		s.metadata.Usage = usageMetadata(*event.Usage)
 		s.metadata.ContextTokens = contextTokens(*event.Usage)
@@ -386,6 +392,7 @@ func (s *eventStream) providerError(event api.Event) error {
 	if err := s.terminalizeTools(event.Error); err != nil {
 		return err
 	}
+	s.metadata = s.terminalMetadata.message(s.sessionID, s.model, false)
 	s.terminal = true
 	return s.writer.WritePart(Part{Type: "error", ErrorText: event.Error})
 }
@@ -464,6 +471,7 @@ func (s *eventStream) fail(cause error) error {
 	if s.finished {
 		return cause
 	}
+	s.metadata = s.terminalMetadata.message(s.sessionID, s.model, false)
 	if err := s.closeBlock(); err != nil {
 		return err
 	}

--- a/pkg/aichat/persistence.go
+++ b/pkg/aichat/persistence.go
@@ -11,26 +11,29 @@ import (
 )
 
 type assistantMessageBuilder struct {
-	message   UIMessage
-	toolParts map[string]int
-	sessionID string
-	model     string
-	replace   bool
+	message          UIMessage
+	toolParts        map[string]int
+	terminalMetadata terminalMetadataContext
+	sessionID        string
+	model            string
+	replace          bool
 }
 
 type assistantMessageBuilderOptions struct {
-	MessageID string
-	TurnID    string
-	Replace   bool
-	Seed      *UIMessage
-	Resume    *api.ToolApprovalResume
+	MessageID        string
+	TurnID           string
+	Replace          bool
+	Seed             *UIMessage
+	Resume           *api.ToolApprovalResume
+	terminalMetadata terminalMetadataContext
 }
 
 func newAssistantMessageBuilder(options assistantMessageBuilderOptions) (*assistantMessageBuilder, error) {
 	builder := &assistantMessageBuilder{
-		message:   UIMessage{ID: options.MessageID, TurnID: options.TurnID, Role: string(api.RoleAssistant), Parts: []UIPart{}},
-		toolParts: map[string]int{},
-		replace:   options.Replace || options.Resume != nil,
+		message:          UIMessage{ID: options.MessageID, TurnID: options.TurnID, Role: string(api.RoleAssistant), Parts: []UIPart{}},
+		toolParts:        map[string]int{},
+		terminalMetadata: options.terminalMetadata,
+		replace:          options.Replace || options.Resume != nil,
 	}
 	if options.Resume == nil {
 		return builder, nil
@@ -79,11 +82,12 @@ func newAssistantMessageBuilder(options assistantMessageBuilderOptions) (*assist
 // which thread and turn it belongs to, which model produced it (for pricing),
 // and where to record the resulting costs for the finish part.
 type persistedEventOptions struct {
-	Request ChatRequest
-	TurnID  string
-	Model   api.Model
-	Runtime func() api.Model
-	Costs   *TurnCosts
+	Request          ChatRequest
+	TurnID           string
+	Model            api.Model
+	Runtime          func() api.Model
+	Costs            *TurnCosts
+	terminalMetadata terminalMetadataContext
 }
 
 func (o persistedEventOptions) runtime() api.Model {
@@ -110,6 +114,7 @@ func (s *Service) persistedEvents(ctx context.Context, options persistedEventOpt
 		replace := request.Trigger == "regenerate-message"
 		builder, err := newAssistantMessageBuilder(assistantMessageBuilderOptions{
 			MessageID: messageID, TurnID: turnID, Replace: replace, Seed: seed, Resume: request.ToolApproval,
+			terminalMetadata: options.terminalMetadata,
 		})
 		if err != nil {
 			sendEvent(ctx, out, api.Event{Kind: api.EventError, Error: err.Error()})
@@ -127,7 +132,8 @@ func (s *Service) persistedEvents(ctx context.Context, options persistedEventOpt
 					return
 				}
 			}
-			if !persisted && (event.Kind == api.EventResult || event.Kind == api.EventError || event.Kind == api.EventInterrupted) {
+			terminal := event.Kind == api.EventResult || event.Kind == api.EventError || event.Kind == api.EventInterrupted
+			if !persisted && terminal {
 				if err := s.persistCompletedTurn(ctx, request.ThreadID, builder, event, options); err != nil {
 					sendEvent(ctx, out, api.Event{Kind: api.EventError, Error: err.Error(), Model: event.Model})
 					return
@@ -135,6 +141,9 @@ func (s *Service) persistedEvents(ctx context.Context, options persistedEventOpt
 				persisted = true
 			}
 			if !sendEvent(ctx, out, event) {
+				return
+			}
+			if terminal {
 				return
 			}
 		}
@@ -191,6 +200,10 @@ func (s *Service) persistCompletedTurn(
 	if err := s.persistEvent(ctx, threadID, event, options.runtime(), options.Costs); err != nil {
 		return err
 	}
+	if builder.message.Metadata != nil && options.Costs != nil {
+		builder.message.Metadata.CostBreakdown = options.Costs.Breakdown
+		builder.message.Metadata.ThreadCostUSD = options.Costs.ThreadCostUSD
+	}
 	if len(builder.message.Parts) == 0 {
 		return fmt.Errorf("completed assistant turn has no message parts")
 	}
@@ -241,6 +254,7 @@ func (b *assistantMessageBuilder) apply(event api.Event) error {
 		return b.result(event)
 	case api.EventError:
 		b.terminalizeTools(event.Error)
+		b.message.Metadata = b.terminalMetadata.message(b.sessionID, b.model, false)
 		payload, err := json.Marshal(map[string]string{"error": event.Error})
 		if err != nil {
 			return err
@@ -260,10 +274,8 @@ func (b *assistantMessageBuilder) interrupted(reason string) error {
 		return err
 	}
 	b.message.Parts = append(b.message.Parts, UIPart{Type: "data-result", Data: data})
-	success := false
-	b.message.Metadata = &MessageMetadata{
-		ProviderSessionID: b.sessionID, Model: b.model, Success: &success, Interrupted: true,
-	}
+	b.message.Metadata = b.terminalMetadata.message(b.sessionID, b.model, false)
+	b.message.Metadata.Interrupted = true
 	return nil
 }
 
@@ -397,10 +409,8 @@ func (b *assistantMessageBuilder) result(event api.Event) error {
 		}
 	}
 	b.message.Parts = append(b.message.Parts, UIPart{Type: dataType, Data: data})
-	success := event.Success
-	b.message.Metadata = &MessageMetadata{
-		ProviderSessionID: b.sessionID, Model: b.model, Cost: event.CostUSD, Success: &success,
-	}
+	b.message.Metadata = b.terminalMetadata.message(b.sessionID, b.model, event.Success)
+	b.message.Metadata.Cost = event.CostUSD
 	if event.Usage != nil {
 		b.message.Metadata.Usage = usageMetadata(*event.Usage)
 		b.message.Metadata.ContextTokens = contextTokens(*event.Usage)

--- a/pkg/aichat/service.go
+++ b/pkg/aichat/service.go
@@ -312,6 +312,13 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 	runtime := func() api.Model { return providerRuntime(provider, config.Model) }
+	terminalMetadata := terminalMetadataContext{
+		CaptainSessionID:  config.CaptainSessionID,
+		ProviderSessionID: config.SessionID,
+		ThreadID:          chat.ThreadID,
+		TurnID:            turnID,
+		Runtime:           runtime,
+	}
 	events = s.bindThreadRuntime(streamContext, chat.ThreadID, execution, runtime, events)
 	events = mergeExecutionEvents(streamContext, events, callerToolEvents, definitions)
 	if active != nil {
@@ -326,11 +333,13 @@ func (s *Service) handleChat(w http.ResponseWriter, request *http.Request) {
 	costs := &TurnCosts{}
 	persisted := s.persistedEvents(streamContext, persistedEventOptions{
 		Request: chat, TurnID: turnID, Model: config.Model, Runtime: runtime, Costs: costs,
+		terminalMetadata: terminalMetadata,
 	}, events)
 	if err := WriteEventStream(writer, persisted, EventStreamOptions{
-		ToolApproval: chat.ToolApproval,
-		MessageID:    assistantMessageID(chat, turnID),
-		Costs:        costs,
+		ToolApproval:     chat.ToolApproval,
+		MessageID:        assistantMessageID(chat, turnID),
+		Costs:            costs,
+		terminalMetadata: terminalMetadata,
 	}); err != nil {
 		serviceLog.Errorf("stream chat response: %v", err)
 	}

--- a/pkg/aichat/sse.go
+++ b/pkg/aichat/sse.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/flanksource/captain/pkg/api"
 )
 
 // Part is one AI SDK v6 UI Message Stream chunk.
@@ -53,8 +55,13 @@ type CostBreakdownMetadata struct {
 
 // MessageMetadata is attached to the assistant UIMessage by the finish part.
 type MessageMetadata struct {
-	ProviderSessionID string                 `json:"providerSessionId,omitempty"`
+	Backend           api.Backend            `json:"backend,omitempty"`
+	ExecutionMode     api.RuntimeMode        `json:"executionMode,omitempty"`
 	Model             string                 `json:"model,omitempty"`
+	CaptainSessionID  string                 `json:"captainSessionId,omitempty"`
+	ProviderSessionID string                 `json:"providerSessionId,omitempty"`
+	ThreadID          string                 `json:"threadId,omitempty"`
+	TurnID            string                 `json:"turnId,omitempty"`
 	Usage             *UsageMetadata         `json:"usage,omitempty"`
 	Cost              float64                `json:"cost,omitempty"`
 	CostBreakdown     *CostBreakdownMetadata `json:"costBreakdown,omitempty"`
@@ -65,6 +72,38 @@ type MessageMetadata struct {
 	ContextTokens int     `json:"contextTokens,omitempty"`
 	Success       *bool   `json:"success,omitempty"`
 	Interrupted   bool    `json:"interrupted,omitempty"`
+}
+
+type terminalMetadataContext struct {
+	CaptainSessionID  string
+	ProviderSessionID string
+	ThreadID          string
+	TurnID            string
+	Runtime           func() api.Model
+}
+
+func (c terminalMetadataContext) message(providerSessionID, eventModel string, success bool) *MessageMetadata {
+	if providerSessionID == "" {
+		providerSessionID = c.ProviderSessionID
+	}
+	runtime := api.Model{Name: eventModel}
+	if c.Runtime != nil {
+		selected := c.Runtime()
+		if selected.Name != "" {
+			runtime.Name = selected.Name
+		}
+		runtime.Backend = selected.Backend
+		runtime.Mode = selected.Mode
+	}
+	mode := runtime.Backend.Mode()
+	if mode == "" {
+		mode = runtime.Mode
+	}
+	return &MessageMetadata{
+		Backend: runtime.Backend, ExecutionMode: mode, Model: runtime.Name,
+		CaptainSessionID: c.CaptainSessionID, ProviderSessionID: providerSessionID,
+		ThreadID: c.ThreadID, TurnID: c.TurnID, Success: &success,
+	}
 }
 
 // TurnCosts is written by the persistence layer as a turn completes and read by

--- a/pkg/aichat/stream_ginkgo_test.go
+++ b/pkg/aichat/stream_ginkgo_test.go
@@ -143,7 +143,7 @@ var _ = Describe("AI SDK v6 event stream", func() {
 			HaveKeyWithValue("approvalId", "approval-call-1"),
 			HaveKeyWithValue("toolCallId", "call-1"),
 		))
-		Expect(parts[11]["output"]).To(Equal(map[string]any{"output": `{"status":"draft"}`}))
+		Expect(parts[11]["output"]).To(Equal(map[string]any{"status": "draft"}))
 		Expect(parts[15]["data"]).To(Equal(map[string]any{"invoiceId": "inv-1"}))
 		Expect(parts[17]["messageMetadata"]).To(Equal(map[string]any{
 			"providerSessionId": "session-1",

--- a/pkg/cli/webapp/package.json
+++ b/pkg/cli/webapp/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.201",
-    "@flanksource/clicky-ui": "0.3.24",
+    "@flanksource/clicky-ui": "0.3.25",
     "@shikijs/langs": "^1.24.0",
     "@shikijs/themes": "^1.24.0",
     "@shikijs/transformers": "^1.24.0",

--- a/pkg/cli/webapp/pnpm-lock.yaml
+++ b/pkg/cli/webapp/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^3.0.201
         version: 3.0.216(react@18.3.1)(zod@4.4.3)
       '@flanksource/clicky-ui':
-        specifier: 0.3.24
-        version: 0.3.24(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)
+        specifier: 0.3.25
+        version: 0.3.25(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)
       '@shikijs/langs':
         specifier: ^1.24.0
         version: 1.29.2
@@ -426,8 +426,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@flanksource/clicky-ui@0.3.24':
-    resolution: {integrity: sha512-hAia0MFMvhAdVl1oVVgDMFZ+dwpG1OOVMiioXXgmWI9mY2YtMPFwvwvzAS4wAWXvhUHkChrmhE9G4CjnbOnQZg==}
+  '@flanksource/clicky-ui@0.3.25':
+    resolution: {integrity: sha512-YsPyxwJxpYDn4GFcWKSDrA1VDjsR0REtnEvNyUzTfsfQ5piOJnuG4FJuDwh3z2YhHssfl2uS/BKoetG5aSEeAw==}
     peerDependencies:
       '@ai-sdk/react': ^3.0.0
       '@mdxeditor/editor': ^4.0.4
@@ -2771,7 +2771,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@flanksource/clicky-ui@0.3.24(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)':
+  '@flanksource/clicky-ui@0.3.25(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0


### PR DESCRIPTION
Captain chat could expose conflicting terminal events and serialize live tool results differently from persisted history, leaving reloaded conversations and runtime telemetry inconsistent.

- Latch the first terminal event across SSE and persistence.
- Normalize tool outputs and attach authoritative runtime, session, usage, and cost metadata.
- Update Clicky UI to 0.3.25 so the context meter consumes that metadata.

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added richer execution metadata to persisted assistant messages and streamed events, including session, thread, turn, runtime, backend, and execution details.
  * Streams now finish promptly after terminal events.
  * Successful tool results are returned directly as decoded data, while failures provide dedicated error details.
  * Completed turns now include cost information in message metadata.

* **Chores**
  * Updated the Clicky UI package to version 0.3.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->