### PR TITLE
fix: preserve model-call cost accounting consistency

### DIFF
--- a/migrations/60_view_session_overview.sql
+++ b/migrations/60_view_session_overview.sql
@@ -94,6 +94,7 @@ SELECT
   COALESCE(call_stats.cache_write_tokens, 0) AS cache_write_tokens,
   COALESCE(call_stats.input_tokens, 0)
     + COALESCE(call_stats.output_tokens, 0)
+    + COALESCE(call_stats.reasoning_tokens, 0)
     + COALESCE(call_stats.cache_read_tokens, 0)
     + COALESCE(call_stats.cache_write_tokens, 0) AS total_tokens,
   COALESCE(call_stats.cost_usd, 0::numeric) AS cost_usd,

--- a/migrations/62_view_session_turns.sql
+++ b/migrations/62_view_session_turns.sql
@@ -46,6 +46,7 @@ SELECT
   COALESCE(call_stats.cache_write_tokens, 0) AS cache_write_tokens,
   COALESCE(call_stats.input_tokens, 0)
     + COALESCE(call_stats.output_tokens, 0)
+    + COALESCE(call_stats.reasoning_tokens, 0)
     + COALESCE(call_stats.cache_read_tokens, 0)
     + COALESCE(call_stats.cache_write_tokens, 0) AS total_tokens,
   COALESCE(call_stats.cost_usd, 0::numeric) AS cost_usd,

--- a/migrations/63_view_session_agents.sql
+++ b/migrations/63_view_session_agents.sql
@@ -28,6 +28,7 @@ SELECT
   COALESCE(call_stats.cache_write_tokens, 0) AS cache_write_tokens,
   COALESCE(call_stats.input_tokens, 0)
     + COALESCE(call_stats.output_tokens, 0)
+    + COALESCE(call_stats.reasoning_tokens, 0)
     + COALESCE(call_stats.cache_read_tokens, 0)
     + COALESCE(call_stats.cache_write_tokens, 0) AS total_tokens,
   COALESCE(call_stats.cost_usd, 0::numeric) AS cost_usd

--- a/migrations/67_view_session_costs.sql
+++ b/migrations/67_view_session_costs.sql
@@ -26,6 +26,7 @@ SELECT
   (
     sum(c.input_tokens)
     + sum(c.output_tokens)
+    + sum(c.reasoning_tokens)
     + sum(c.cache_read_tokens)
     + sum(c.cache_write_tokens)
   )::bigint AS total_tokens,
@@ -34,9 +35,9 @@ SELECT
   sum(c.reasoning_cost) AS reasoning_cost,
   sum(c.cache_read_cost) AS cache_read_cost,
   sum(c.cache_write_cost) AS cache_write_cost,
-  -- Mirrors api.Cost.Total(): the provider's reported figure is authoritative
-  -- per call, with the list-price bucket sum as the fallback. Decided per row,
-  -- not per group, so a mix of priced and provider-reported calls still totals.
+  -- Mirrors api.Cost.Total(): prefer provider-reported cost or estimates per
+  -- call, with the list-price bucket sum as the fallback. Decided per row, not
+  -- per group, so a mix of list-priced and provider-reported calls still totals.
   sum(
     CASE
       WHEN c.provider_cost_usd > 0 THEN c.provider_cost_usd

--- a/migrations/69_view_prompt_run_overview.sql
+++ b/migrations/69_view_prompt_run_overview.sql
@@ -52,6 +52,7 @@ SELECT
   COALESCE(call_stats.cache_write_tokens, 0) AS cache_write_tokens,
   COALESCE(call_stats.input_tokens, 0)
     + COALESCE(call_stats.output_tokens, 0)
+    + COALESCE(call_stats.reasoning_tokens, 0)
     + COALESCE(call_stats.cache_read_tokens, 0)
     + COALESCE(call_stats.cache_write_tokens, 0) AS total_tokens,
   COALESCE(call_stats.cost_usd, 0::numeric) AS cost_usd,
@@ -59,7 +60,23 @@ SELECT
   plan_stats.latest_plan_id,
   plan_stats.latest_plan_approval_state,
   plan_stats.latest_plan_revision,
-  r.execution_session_id
+  r.execution_session_id,
+  -- Appended after initial release: CREATE OR REPLACE VIEW only allows adding
+  -- columns at the end, so later additions must stay below this line.
+  r.turn_id,
+  r.runtime,
+  r.approval_state,
+  r.provider_checkpoint_codec,
+  r.provider_checkpoint_version,
+  r.provider_checkpoint,
+  -- cost_usd resolves provider-reported cost or estimates against Captain's
+  -- list-price reconstruction per call; these components preserve provenance.
+  COALESCE(call_stats.provider_cost_usd, 0::numeric) AS provider_cost_usd,
+  COALESCE(call_stats.input_cost, 0::numeric) AS input_cost,
+  COALESCE(call_stats.output_cost, 0::numeric) AS output_cost,
+  COALESCE(call_stats.reasoning_cost, 0::numeric) AS reasoning_cost,
+  COALESCE(call_stats.cache_read_cost, 0::numeric) AS cache_read_cost,
+  COALESCE(call_stats.cache_write_cost, 0::numeric) AS cache_write_cost
 FROM public.captain_prompt_runs r
 LEFT JOIN LATERAL (
   SELECT
@@ -85,12 +102,22 @@ LEFT JOIN LATERAL (
     COALESCE(sum(c.cache_read_tokens), 0)::bigint AS cache_read_tokens,
     COALESCE(sum(c.cache_write_tokens), 0)::bigint AS cache_write_tokens,
     COALESCE(sum(
-      c.input_cost
-      + c.output_cost
-      + c.reasoning_cost
-      + c.cache_read_cost
-      + c.cache_write_cost
-    ) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS cost_usd
+      CASE
+        WHEN c.provider_cost_usd > 0 THEN c.provider_cost_usd
+        ELSE c.input_cost
+          + c.output_cost
+          + c.reasoning_cost
+          + c.cache_read_cost
+          + c.cache_write_cost
+      END
+    ) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS cost_usd,
+    COALESCE(sum(c.provider_cost_usd)
+      FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS provider_cost_usd,
+    COALESCE(sum(c.input_cost) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS input_cost,
+    COALESCE(sum(c.output_cost) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS output_cost,
+    COALESCE(sum(c.reasoning_cost) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS reasoning_cost,
+    COALESCE(sum(c.cache_read_cost) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS cache_read_cost,
+    COALESCE(sum(c.cache_write_cost) FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS cache_write_cost
   FROM public.captain_model_calls c
   WHERE c.prompt_run_id = r.id
 ) call_stats ON true
@@ -112,4 +139,4 @@ LEFT JOIN LATERAL (
 ) plan_stats ON true;
 
 COMMENT ON VIEW public.captain_prompt_run_overview IS
-  'Prompt-run control-plane state with iteration, plan, usage, cost and verification summaries.';
+  'Prompt-run control-plane state with iteration, plan, usage, provider-reported/list-price cost, and verification summaries.';

--- a/migrations/69_view_prompt_run_overview.sql
+++ b/migrations/69_view_prompt_run_overview.sql
@@ -65,10 +65,8 @@ SELECT
   -- columns at the end, so later additions must stay below this line.
   r.turn_id,
   r.runtime,
-  r.approval_state,
   r.provider_checkpoint_codec,
   r.provider_checkpoint_version,
-  r.provider_checkpoint,
   -- cost_usd resolves provider-reported cost or estimates against Captain's
   -- list-price reconstruction per call; these components preserve provenance.
   COALESCE(call_stats.provider_cost_usd, 0::numeric) AS provider_cost_usd,

--- a/pkg/database/caller_tool_store_integration_test.go
+++ b/pkg/database/caller_tool_store_integration_test.go
@@ -95,5 +95,9 @@ func createCallerToolRun(t *testing.T, db *DB) (*Session, *ChatTurn, *PromptRun,
 		TurnID: turn.ID, PromptRunID: run.ID, Model: "sonnet", Backend: string(api.BackendClaudeAgent),
 	})
 	require.NoError(t, err)
+	var currency string
+	require.NoError(t, db.Gorm().Model(&modelCallRecord{}).
+		Select("currency").Where("id = ?", modelCallID).Scan(&currency).Error)
+	assert.Equal(t, "USD", currency)
 	return session, turn, run, modelCallID
 }

--- a/pkg/database/session_chat_store.go
+++ b/pkg/database/session_chat_store.go
@@ -210,7 +210,7 @@ func (db *DB) CreateChatModelCall(ctx context.Context, input CreateChatModelCall
 	record := modelCallRecord{
 		ID: uuid.New(), TurnID: input.TurnID, PromptRunID: &input.PromptRunID,
 		CallIndex: index, Model: strings.TrimSpace(input.Model), Backend: strings.TrimSpace(input.Backend),
-		Effort: nullableTrimmed(input.Effort), Status: "running", StartedAt: &now,
+		Effort: nullableTrimmed(input.Effort), Status: "running", Currency: "USD", StartedAt: &now,
 	}
 	if err := db.gorm.WithContext(ctx).Create(&record).Error; err != nil {
 		return uuid.Nil, fmt.Errorf("create Captain chat model call: %w", err)

--- a/pkg/database/session_ingest_store.go
+++ b/pkg/database/session_ingest_store.go
@@ -89,6 +89,7 @@ type modelCallRecord struct {
 	CacheReadCost       float64    `gorm:"column:cache_read_cost"`
 	CacheWriteCost      float64    `gorm:"column:cache_write_cost"`
 	ProviderCostUSD     float64    `gorm:"column:provider_cost_usd"`
+	Currency            string     `gorm:"column:currency"`
 	StartedAt           *time.Time `gorm:"column:started_at"`
 	EndedAt             *time.Time `gorm:"column:ended_at"`
 }
@@ -159,8 +160,10 @@ type IngestModelCall struct {
 	ContextWindowTokens int64
 	InputCost           float64
 	OutputCost          float64
+	ReasoningCost       float64
 	CacheReadCost       float64
 	CacheWriteCost      float64
+	Currency            string
 	StartedAt           *time.Time
 	EndedAt             *time.Time
 }
@@ -477,14 +480,19 @@ func turnCallRecord(turnID uuid.UUID, call IngestModelCall) modelCallRecord {
 	if backend == "" {
 		backend = "unknown"
 	}
+	currency := strings.ToUpper(strings.TrimSpace(call.Currency))
+	if currency == "" {
+		currency = "USD"
+	}
 	return modelCallRecord{
 		ID: uuid.New(), TurnID: turnID, CallIndex: 0, Model: model, Backend: backend,
 		Effort: nullableTrimmed(call.Effort), Status: "succeeded", StopReason: nullableTrimmed(call.StopReason),
 		InputTokens: call.InputTokens, OutputTokens: call.OutputTokens, ReasoningTokens: call.ReasoningTokens,
 		CacheReadTokens: call.CacheReadTokens, CacheWriteTokens: call.CacheWriteTokens,
 		ContextTokens: call.ContextTokens, ContextWindowTokens: call.ContextWindowTokens,
-		InputCost: call.InputCost, OutputCost: call.OutputCost,
+		InputCost: call.InputCost, OutputCost: call.OutputCost, ReasoningCost: call.ReasoningCost,
 		CacheReadCost: call.CacheReadCost, CacheWriteCost: call.CacheWriteCost,
+		Currency:  currency,
 		StartedAt: call.StartedAt, EndedAt: call.EndedAt,
 	}
 }

--- a/pkg/database/session_ingest_store_integration_test.go
+++ b/pkg/database/session_ingest_store_integration_test.go
@@ -57,18 +57,20 @@ func testIngestBatch(modTime time.Time, byteOffset int64) IngestTranscriptInput 
 				Index: 0, ProviderTurnID: "turn-0", Status: TurnStatusEnded,
 				StartedAt: &started, EndedAt: &turn0End,
 				Call: &IngestModelCall{
-					Model: "claude-sonnet-5", Backend: "claude", InputTokens: 1000, OutputTokens: 200,
-					CacheReadTokens: 5000, ContextTokens: 40000, ContextWindowTokens: 200000,
-					InputCost: 0.003, OutputCost: 0.003,
+					Model: "claude-sonnet-5", Backend: "claude", InputTokens: 1000, OutputTokens: 200, ReasoningTokens: 100,
+					CacheReadTokens: 5000, CacheWriteTokens: 250, ContextTokens: 40000, ContextWindowTokens: 200000,
+					InputCost: 0.003, OutputCost: 0.003, ReasoningCost: 0.001,
+					CacheReadCost: 0.002, CacheWriteCost: 0.004, Currency: "USD",
 				},
 			},
 			{
 				Index: 1, ProviderTurnID: "turn-1", Status: TurnStatusEnded,
 				StartedAt: &turn0End, EndedAt: &modTime,
 				Call: &IngestModelCall{
-					Model: "claude-sonnet-5", Backend: "claude", Effort: "high", InputTokens: 2000, OutputTokens: 400,
-					CacheReadTokens: 8000, ContextTokens: 60000, ContextWindowTokens: 200000,
-					InputCost: 0.006, OutputCost: 0.006,
+					Model: "claude-sonnet-5", Backend: "claude", Effort: "high", InputTokens: 2000, OutputTokens: 400, ReasoningTokens: 200,
+					CacheReadTokens: 8000, CacheWriteTokens: 500, ContextTokens: 60000, ContextWindowTokens: 200000,
+					InputCost: 0.006, OutputCost: 0.006, ReasoningCost: 0.002,
+					CacheReadCost: 0.004, CacheWriteCost: 0.008, Currency: "USD",
 				},
 			},
 		},
@@ -103,8 +105,10 @@ func TestIngestTranscriptAndReadStores(t *testing.T) {
 		assert.EqualValues(t, 2, overview.TurnCount)
 		assert.EqualValues(t, 3000, overview.InputTokens)
 		assert.EqualValues(t, 600, overview.OutputTokens)
+		assert.EqualValues(t, 300, overview.ReasoningTokens)
 		assert.EqualValues(t, 13000, overview.CacheReadTokens)
-		assert.InDelta(t, 0.018, overview.CostUSD, 1e-9)
+		assert.EqualValues(t, 750, overview.CacheWriteTokens)
+		assert.InDelta(t, 0.039, overview.CostUSD, 1e-9)
 		require.NotNil(t, overview.ContextFreePercent)
 		assert.Equal(t, 70, *overview.ContextFreePercent, "latest call: 1-60000/200000 = 70%")
 		require.NotNil(t, overview.Model)
@@ -121,14 +125,64 @@ func TestIngestTranscriptAndReadStores(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, session.ID, byPrefix.ID)
 
-		replayed, err := db.IngestTranscript(t.Context(), testIngestBatch(modTime, 4096))
+		var firstCall modelCallRecord
+		require.NoError(t, db.gorm.WithContext(t.Context()).
+			Joins("JOIN captain_turns turn ON turn.id = captain_model_calls.turn_id").
+			Where("turn.session_id = ? AND turn.turn_index = 0", session.ID).
+			First(&firstCall).Error)
+		require.NoError(t, db.gorm.WithContext(t.Context()).Model(&modelCallRecord{}).
+			Where("id = ?", firstCall.ID).Update("provider_cost_usd", 0.5).Error)
+
+		replay := testIngestBatch(modTime, 4096)
+		replay.Turns[0].Call.InputCost = 0.011
+		replay.Turns[0].Call.OutputCost = 0.012
+		replay.Turns[0].Call.ReasoningCost = 0.013
+		replay.Turns[0].Call.CacheReadCost = 0.014
+		replay.Turns[0].Call.CacheWriteCost = 0.015
+		replay.Turns[0].Call.Currency = "usd"
+		replay.Turns[1].Call.InputCost = 0.021
+		replay.Turns[1].Call.OutputCost = 0.022
+		replay.Turns[1].Call.ReasoningCost = 0.023
+		replay.Turns[1].Call.CacheReadCost = 0.024
+		replay.Turns[1].Call.CacheWriteCost = 0.025
+		replayed, err := db.IngestTranscript(t.Context(), replay)
 		require.NoError(t, err)
 		assert.Equal(t, session.ID, replayed.ID)
+
+		var calls []modelCallRecord
+		require.NoError(t, db.gorm.WithContext(t.Context()).
+			Select("captain_model_calls.*").
+			Joins("JOIN captain_turns turn ON turn.id = captain_model_calls.turn_id").
+			Where("turn.session_id = ?", session.ID).
+			Order("turn.turn_index").Find(&calls).Error)
+		require.Len(t, calls, 2)
+		assert.Equal(t, "USD", calls[0].Currency)
+		assert.InDelta(t, 0.011, calls[0].InputCost, 1e-9)
+		assert.InDelta(t, 0.012, calls[0].OutputCost, 1e-9)
+		assert.InDelta(t, 0.013, calls[0].ReasoningCost, 1e-9)
+		assert.InDelta(t, 0.014, calls[0].CacheReadCost, 1e-9)
+		assert.InDelta(t, 0.015, calls[0].CacheWriteCost, 1e-9)
+		assert.InDelta(t, 0.5, calls[0].ProviderCostUSD, 1e-9,
+			"transcript replay must not erase provider-reported cost from another writer")
+		assert.Equal(t, "USD", calls[1].Currency)
+		assert.InDelta(t, 0.021, calls[1].InputCost, 1e-9)
+		assert.InDelta(t, 0.022, calls[1].OutputCost, 1e-9)
+		assert.InDelta(t, 0.023, calls[1].ReasoningCost, 1e-9)
+		assert.InDelta(t, 0.024, calls[1].CacheReadCost, 1e-9)
+		assert.InDelta(t, 0.025, calls[1].CacheWriteCost, 1e-9)
+
 		overview, err := db.GetSessionOverviewByIdentity(t.Context(), testProviderSessionID)
 		require.NoError(t, err)
 		assert.EqualValues(t, 4, overview.MessageCount, "replay must not duplicate messages")
 		assert.EqualValues(t, 2, overview.TurnCount, "replay must not duplicate turns")
 		assert.EqualValues(t, 3000, overview.InputTokens, "replay must not duplicate model calls")
+		assert.InDelta(t, 0.615, overview.CostUSD, 1e-9,
+			"resolved total chooses provider-reported cost per call, then list-price buckets")
+
+		require.NoError(t, db.gorm.WithContext(t.Context()).Model(&modelCallRecord{}).
+			Where("id = ?", firstCall.ID).Update("provider_cost_usd", 0).Error)
+		_, err = db.IngestTranscript(t.Context(), testIngestBatch(modTime, 4096))
+		require.NoError(t, err)
 	})
 
 	t.Run("provider message replay with shifted sequence is idempotent", func(t *testing.T) {

--- a/pkg/database/session_list_store.go
+++ b/pkg/database/session_list_store.go
@@ -262,7 +262,7 @@ WITH latest_call AS MATERIALIZED (
     COALESCE(sum(c.output_tokens), 0)::bigint AS output_tokens,
     COALESCE(sum(c.cache_read_tokens), 0)::bigint AS cache_read_tokens,
     COALESCE(sum(c.cache_write_tokens), 0)::bigint AS cache_write_tokens,
-    COALESCE(sum(c.input_tokens + c.output_tokens + c.cache_read_tokens + c.cache_write_tokens), 0)::bigint AS total_tokens,
+    COALESCE(sum(c.input_tokens + c.output_tokens + c.reasoning_tokens + c.cache_read_tokens + c.cache_write_tokens), 0)::bigint AS total_tokens,
     COALESCE(sum(CASE WHEN c.provider_cost_usd > 0 THEN c.provider_cost_usd
       ELSE c.input_cost + c.output_cost + c.reasoning_cost + c.cache_read_cost + c.cache_write_cost END)
       FILTER (WHERE upper(c.currency) = 'USD'), 0::numeric) AS cost_usd,

--- a/pkg/database/session_message_ingest.go
+++ b/pkg/database/session_message_ingest.go
@@ -21,7 +21,7 @@ func (db *DB) upsertTurnCalls(ctx context.Context, calls []modelCallRecord) erro
 			"model", "backend", "effort", "stop_reason",
 			"input_tokens", "output_tokens", "reasoning_tokens", "cache_read_tokens", "cache_write_tokens",
 			"context_tokens", "context_window_tokens",
-			"input_cost", "output_cost", "cache_read_cost", "cache_write_cost",
+			"input_cost", "output_cost", "reasoning_cost", "cache_read_cost", "cache_write_cost", "currency",
 			"started_at", "ended_at",
 		}),
 	}).CreateInBatches(&calls, ingestBatchSize).Error

--- a/pkg/database/session_overview_ginkgo_test.go
+++ b/pkg/database/session_overview_ginkgo_test.go
@@ -67,20 +67,34 @@ var _ = Describe("Session overview aggregates", func() {
 			VALUES (?, ?, 0, 'ended'), (?, ?, 1, 'ended'), (?, ?, 0, 'ended')`,
 			turnOne, rootID, turnTwo, rootID, otherTurn, otherID,
 		).Error).NotTo(HaveOccurred())
+		promptRunID := uuid.MustParse("00000000-0000-0000-0000-000000003101")
+		checkpoint := []byte("provider-checkpoint-v1")
+		Expect(db.Gorm().Exec(`
+			INSERT INTO captain_prompt_runs
+			  (id, session_id, turn_id, root_session_id, state, phase, runtime, approval_state,
+			   provider_checkpoint_codec, provider_checkpoint_version, provider_checkpoint)
+			VALUES (?, ?, ?, ?, 'succeeded', 'finished', ?::jsonb, ?::jsonb, 'test-codec', 1, ?)`,
+			promptRunID, rootID, turnOne, rootID, `{"mode":"run"}`, `{"decision":"allow"}`, checkpoint,
+		).Error).NotTo(HaveOccurred())
+		Expect(db.Gorm().Exec(`
+			INSERT INTO captain_prompt_runs (session_id, root_session_id, state, phase)
+			VALUES (?, ?, 'failed', 'finished'), (?, ?, 'succeeded', 'finished')`,
+			rootID, rootID, otherID, otherID,
+		).Error).NotTo(HaveOccurred())
 		Expect(db.Gorm().Exec(`
 			INSERT INTO captain_model_calls
-			  (turn_id, call_index, model, backend, effort, input_tokens, output_tokens,
+			  (turn_id, call_index, prompt_run_id, model, backend, effort, input_tokens, output_tokens,
 			   reasoning_tokens, cache_read_tokens, cache_write_tokens, context_tokens,
 			   context_window_tokens, input_cost, output_cost, reasoning_cost,
-			   cache_read_cost, cache_write_cost, currency, started_at, ended_at)
+			   cache_read_cost, cache_write_cost, provider_cost_usd, currency, started_at, ended_at)
 			VALUES
-			  (?, 0, 'model-old', 'codex', 'low', 10, 4, 2, 3, 1, 20, 100,
-			   0.10, 0.04, 0.02, 0.03, 0.01, 'USD', '2026-07-16 10:00:00+00', '2026-07-16 10:01:00+00'),
-			  (?, 0, 'model-latest', 'codex', 'high', 20, 8, 4, 6, 2, 75, 100,
-			   0.20, 0.08, 0.04, 0.06, 0.02, 'USD', '2026-07-16 11:00:00+00', '2026-07-16 11:01:00+00'),
-			  (?, 1, 'model-eur', 'codex', NULL, 100, 50, 25, 10, 5, 50, 100,
-			   9, 9, 9, 9, 9, 'EUR', '2026-07-16 09:00:00+00', '2026-07-16 09:01:00+00')`,
-			turnOne, turnTwo, turnTwo,
+			  (?, 0, ?, 'model-old', 'codex', 'low', 10, 4, 2, 3, 1, 20, 100,
+			   0.10, 0.04, 0.02, 0.03, 0.01, 0.25, 'USD', '2026-07-16 10:00:00+00', '2026-07-16 10:01:00+00'),
+			  (?, 0, ?, 'model-latest', 'codex', 'high', 20, 8, 4, 6, 2, 75, 100,
+			   0.20, 0.08, 0.04, 0.06, 0.02, 0, 'USD', '2026-07-16 11:00:00+00', '2026-07-16 11:01:00+00'),
+			  (?, 1, ?, 'model-eur', 'codex', NULL, 100, 50, 25, 10, 5, 50, 100,
+			   9, 9, 9, 9, 9, 9, 'EUR', '2026-07-16 09:00:00+00', '2026-07-16 09:01:00+00')`,
+			turnOne, promptRunID, turnTwo, promptRunID, turnTwo, promptRunID,
 		).Error).NotTo(HaveOccurred())
 
 		Expect(db.Gorm().Exec(`
@@ -97,11 +111,6 @@ var _ = Describe("Session overview aggregates", func() {
 			INSERT INTO captain_events (session_id, kind)
 			VALUES (?, 'assistant.delta'), (?, 'tool.completed'), (?, 'other-session')`,
 			rootID, rootID, otherID,
-		).Error).NotTo(HaveOccurred())
-		Expect(db.Gorm().Exec(`
-			INSERT INTO captain_prompt_runs (session_id, root_session_id, state, phase)
-			VALUES (?, ?, 'succeeded', 'finished'), (?, ?, 'failed', 'finished'), (?, ?, 'succeeded', 'finished')`,
-			rootID, rootID, rootID, rootID, otherID, otherID,
 		).Error).NotTo(HaveOccurred())
 		Expect(db.Gorm().Exec(`
 			INSERT INTO captain_plans (source_session_id, title)
@@ -195,8 +204,86 @@ var _ = Describe("Session overview aggregates", func() {
 			ContextTokens: 75, ContextWindowTokens: 100, ContextFreePercent: 25,
 			InputTokens: 130, OutputTokens: 62, ReasoningTokens: 31,
 			CacheReadTokens: 19, CacheWriteTokens: 8, TotalTokens: 219,
-			CostUSD: 0.60,
+			CostUSD: 0.65,
 		}))
+
+		turns, err := db.ListThreadTurns(ctx, rootID)
+		Expect(err).NotTo(HaveOccurred())
+		var turnCost float64
+		for _, turn := range turns {
+			turnCost += turn.CostUSD
+		}
+		agents, err := db.ListThreadAgents(ctx, rootID)
+		Expect(err).NotTo(HaveOccurred())
+		var agentCost float64
+		for _, agent := range agents {
+			agentCost += agent.CostUSD
+		}
+		costs, err := db.ListThreadCosts(ctx, rootID)
+		Expect(err).NotTo(HaveOccurred())
+		var groupedCost float64
+		for _, cost := range costs {
+			if cost.Currency == "USD" {
+				groupedCost += cost.TotalCost
+			}
+		}
+		page, err := db.ListSessionSummaries(ctx, SessionListFilter{RootsOnly: true, Limit: 10})
+		Expect(err).NotTo(HaveOccurred())
+		var listCost float64
+		for _, row := range page.Rows {
+			if row.ID == rootID {
+				listCost = row.CostUSD
+			}
+		}
+
+		var promptOverview struct {
+			TurnID                    uuid.UUID
+			Runtime                   string
+			ApprovalState             string
+			ProviderCheckpointCodec   string
+			ProviderCheckpointVersion int
+			ProviderCheckpoint        []byte
+			TotalTokens               int64
+			CostUSD                   float64
+			ProviderCostUSD           float64
+			InputCost                 float64
+			OutputCost                float64
+			ReasoningCost             float64
+			CacheReadCost             float64
+			CacheWriteCost            float64
+		}
+		Expect(db.Gorm().Raw(`
+			SELECT turn_id, runtime::text AS runtime, approval_state::text AS approval_state,
+			  provider_checkpoint_codec, provider_checkpoint_version, provider_checkpoint,
+			  total_tokens, cost_usd, provider_cost_usd, input_cost, output_cost,
+			  reasoning_cost, cache_read_cost, cache_write_cost
+			FROM captain_prompt_run_overview
+			WHERE id = ?`, promptRunID,
+		).Scan(&promptOverview).Error).NotTo(HaveOccurred())
+		Expect(promptOverview.TurnID).To(Equal(turnOne))
+		Expect(promptOverview.Runtime).To(MatchJSON(`{"mode":"run"}`))
+		Expect(promptOverview.ApprovalState).To(MatchJSON(`{"decision":"allow"}`))
+		Expect(promptOverview.ProviderCheckpointCodec).To(Equal("test-codec"))
+		Expect(promptOverview.ProviderCheckpointVersion).To(Equal(1))
+		Expect(promptOverview.ProviderCheckpoint).To(Equal(checkpoint))
+		Expect(promptOverview.TotalTokens).To(Equal(int64(250)), "reasoning belongs in prompt-run total tokens")
+		Expect(promptOverview.ProviderCostUSD).To(BeNumerically("~", 0.25, 1e-9))
+		Expect(promptOverview.InputCost).To(BeNumerically("~", 0.30, 1e-9))
+		Expect(promptOverview.OutputCost).To(BeNumerically("~", 0.12, 1e-9))
+		Expect(promptOverview.ReasoningCost).To(BeNumerically("~", 0.06, 1e-9))
+		Expect(promptOverview.CacheReadCost).To(BeNumerically("~", 0.09, 1e-9))
+		Expect(promptOverview.CacheWriteCost).To(BeNumerically("~", 0.03, 1e-9))
+
+		for surface, cost := range map[string]float64{
+			"session overview": overview.CostUSD,
+			"session turns":    turnCost,
+			"session agents":   agentCost,
+			"session costs":    groupedCost,
+			"session list":     listCost,
+			"prompt run":       promptOverview.CostUSD,
+		} {
+			Expect(cost).To(BeNumerically("~", 0.65, 1e-9), surface)
+		}
 
 		var securityBarrier bool
 		Expect(db.Gorm().Raw(`SELECT 'security_barrier=true' = ANY(COALESCE(reloptions, '{}')) FROM pg_class

--- a/pkg/database/session_overview_ginkgo_test.go
+++ b/pkg/database/session_overview_ginkgo_test.go
@@ -203,26 +203,32 @@ var _ = Describe("Session overview aggregates", func() {
 			Model: "model-latest", Backend: "codex", Effort: "high",
 			ContextTokens: 75, ContextWindowTokens: 100, ContextFreePercent: 25,
 			InputTokens: 130, OutputTokens: 62, ReasoningTokens: 31,
-			CacheReadTokens: 19, CacheWriteTokens: 8, TotalTokens: 219,
+			CacheReadTokens: 19, CacheWriteTokens: 8, TotalTokens: 250,
 			CostUSD: 0.65,
 		}))
 
 		turns, err := db.ListThreadTurns(ctx, rootID)
 		Expect(err).NotTo(HaveOccurred())
 		var turnCost float64
+		var turnTokens int64
 		for _, turn := range turns {
 			turnCost += turn.CostUSD
+			turnTokens += turn.TotalTokens
 		}
 		agents, err := db.ListThreadAgents(ctx, rootID)
 		Expect(err).NotTo(HaveOccurred())
 		var agentCost float64
+		var agentTokens int64
 		for _, agent := range agents {
 			agentCost += agent.CostUSD
+			agentTokens += agent.TotalTokens
 		}
 		costs, err := db.ListThreadCosts(ctx, rootID)
 		Expect(err).NotTo(HaveOccurred())
 		var groupedCost float64
+		var groupedTokens int64
 		for _, cost := range costs {
+			groupedTokens += cost.TotalTokens
 			if cost.Currency == "USD" {
 				groupedCost += cost.TotalCost
 			}
@@ -230,19 +236,19 @@ var _ = Describe("Session overview aggregates", func() {
 		page, err := db.ListSessionSummaries(ctx, SessionListFilter{RootsOnly: true, Limit: 10})
 		Expect(err).NotTo(HaveOccurred())
 		var listCost float64
+		var listTokens int64
 		for _, row := range page.Rows {
 			if row.ID == rootID {
 				listCost = row.CostUSD
+				listTokens = row.TotalTokens
 			}
 		}
 
 		var promptOverview struct {
 			TurnID                    uuid.UUID
 			Runtime                   string
-			ApprovalState             string
 			ProviderCheckpointCodec   string
 			ProviderCheckpointVersion int
-			ProviderCheckpoint        []byte
 			TotalTokens               int64
 			CostUSD                   float64
 			ProviderCostUSD           float64
@@ -253,8 +259,8 @@ var _ = Describe("Session overview aggregates", func() {
 			CacheWriteCost            float64
 		}
 		Expect(db.Gorm().Raw(`
-			SELECT turn_id, runtime::text AS runtime, approval_state::text AS approval_state,
-			  provider_checkpoint_codec, provider_checkpoint_version, provider_checkpoint,
+			SELECT turn_id, runtime::text AS runtime,
+			  provider_checkpoint_codec, provider_checkpoint_version,
 			  total_tokens, cost_usd, provider_cost_usd, input_cost, output_cost,
 			  reasoning_cost, cache_read_cost, cache_write_cost
 			FROM captain_prompt_run_overview
@@ -262,10 +268,8 @@ var _ = Describe("Session overview aggregates", func() {
 		).Scan(&promptOverview).Error).NotTo(HaveOccurred())
 		Expect(promptOverview.TurnID).To(Equal(turnOne))
 		Expect(promptOverview.Runtime).To(MatchJSON(`{"mode":"run"}`))
-		Expect(promptOverview.ApprovalState).To(MatchJSON(`{"decision":"allow"}`))
 		Expect(promptOverview.ProviderCheckpointCodec).To(Equal("test-codec"))
 		Expect(promptOverview.ProviderCheckpointVersion).To(Equal(1))
-		Expect(promptOverview.ProviderCheckpoint).To(Equal(checkpoint))
 		Expect(promptOverview.TotalTokens).To(Equal(int64(250)), "reasoning belongs in prompt-run total tokens")
 		Expect(promptOverview.ProviderCostUSD).To(BeNumerically("~", 0.25, 1e-9))
 		Expect(promptOverview.InputCost).To(BeNumerically("~", 0.30, 1e-9))
@@ -273,6 +277,15 @@ var _ = Describe("Session overview aggregates", func() {
 		Expect(promptOverview.ReasoningCost).To(BeNumerically("~", 0.06, 1e-9))
 		Expect(promptOverview.CacheReadCost).To(BeNumerically("~", 0.09, 1e-9))
 		Expect(promptOverview.CacheWriteCost).To(BeNumerically("~", 0.03, 1e-9))
+		var sensitiveColumnCount int64
+		Expect(db.Gorm().Raw(`
+			SELECT count(*)
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = 'captain_prompt_run_overview'
+			  AND column_name IN ('approval_state', 'provider_checkpoint')
+		`).Scan(&sensitiveColumnCount).Error).NotTo(HaveOccurred())
+		Expect(sensitiveColumnCount).To(BeZero(), "private approval/checkpoint state must not be exposed by the view")
 
 		for surface, cost := range map[string]float64{
 			"session overview": overview.CostUSD,
@@ -283,6 +296,16 @@ var _ = Describe("Session overview aggregates", func() {
 			"prompt run":       promptOverview.CostUSD,
 		} {
 			Expect(cost).To(BeNumerically("~", 0.65, 1e-9), surface)
+		}
+		for surface, tokens := range map[string]int64{
+			"session overview": overview.TotalTokens,
+			"session turns":    turnTokens,
+			"session agents":   agentTokens,
+			"session costs":    groupedTokens,
+			"session list":     listTokens,
+			"prompt run":       promptOverview.TotalTokens,
+		} {
+			Expect(tokens).To(Equal(int64(250)), surface)
 		}
 
 		var securityBarrier bool

--- a/pkg/monitor/ingest.go
+++ b/pkg/monitor/ingest.go
@@ -303,8 +303,9 @@ func unifiedIngestInput(s *session.Session, backend string, sequence func(sessio
 				InputTokens:  int64(turn.Usage.InputTokens),
 				OutputTokens: int64(turn.Usage.OutputTokens), ReasoningTokens: int64(turn.Usage.ReasoningTokens),
 				CacheReadTokens: int64(turn.Usage.CacheReadTokens), CacheWriteTokens: int64(turn.Usage.CacheWriteTokens),
-				InputCost: turn.Cost.InputCost, OutputCost: turn.Cost.OutputCost,
+				InputCost: turn.Cost.InputCost, OutputCost: turn.Cost.OutputCost, ReasoningCost: turn.Cost.ReasoningCost,
 				CacheReadCost: turn.Cost.CacheReadCost, CacheWriteCost: turn.Cost.CacheWriteCost,
+				Currency:  "USD",
 				StartedAt: turn.StartedAt, EndedAt: turn.EndedAt,
 			},
 		}

--- a/pkg/session/build_codex.go
+++ b/pkg/session/build_codex.go
@@ -551,13 +551,13 @@ func codexCostFromUsage(model string, usage api.Usage) api.Cost {
 	// Sonnet rates (finding C1). A registry miss leaves the bucket costs zero
 	// rather than inventing a wrong number.
 	//
-	// Reasoning is priced with output: OpenAI bills it at the output rate, and
-	// the two buckets are disjoint here only so the counts do not double-count.
-	billedOutput := usage.OutputTokens + usage.ReasoningTokens
+	// OpenAI list-prices reasoning at the output rate. Keep the two costs
+	// separate so persistence retains the same bucket split as the token counts.
 	for _, id := range []string{"openai/" + model, model} {
-		if res, err := pricing.CalculateCost(id, usage.InputTokens, billedOutput, 0, usage.CacheReadTokens, 0); err == nil {
+		if res, err := pricing.CalculateCost(id, usage.InputTokens, usage.OutputTokens, usage.ReasoningTokens, usage.CacheReadTokens, 0); err == nil {
 			cost.InputCost = res.InputCost
 			cost.OutputCost = res.OutputCost
+			cost.ReasoningCost = res.ReasoningCost
 			cost.CacheReadCost = res.CacheReadCost
 			break
 		}


### PR DESCRIPTION
## Summary
- Preserve Codex output and reasoning costs as independent buckets, then carry all five list-price buckets and explicit USD currency through transcript re-ingest without overwriting provider-reported cost or estimates written elsewhere.
- Write USD explicitly when monitored and live-chat model calls are created.
- Align all six accounting surfaces on the per-call provider-preference cost rule and additive token totals, including reasoning tokens.
- Expose prompt-run turn/runtime and checkpoint codec/version metadata while keeping raw approval and provider-checkpoint state private.
- Extend seeded PostgreSQL coverage to verify bucket persistence, re-ingest convergence, the public view contract, and equal 250-token/resolved-cost totals across all six surfaces.

## Verification
- `go test ./pkg/session ./pkg/monitor`
- `go test ./migrations`
- `go test -v ./pkg/database -run '^TestDatabaseOptions$' -count=1 -ginkgo.focus='preserves every detail metric within its session security boundary'`
- `go test ./pkg/database -count=1`
- `go vet ./pkg/session ./pkg/monitor ./pkg/database ./migrations`
- `golangci-lint run --new-from-rev=origin/main ./pkg/session ./pkg/monitor ./pkg/database ./migrations`

## Scope
This implements the actionable cost-accounting consistency slice of #58. It does not acquire or attribute provider cost for externally monitored histories, distribute session totals onto model calls, or claim provider billing authority. Those provenance and acquisition decisions remain follow-up work, so this PR does not close #58.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session and prompt-run metrics now include reasoning tokens in total token counts.
  * Cost tracking now supports reasoning costs, cache costs, currencies, and provider-reported costs with list-price fallback.
  * Prompt-run overviews now expose runtime, checkpoint, and detailed cost metadata.

* **Bug Fixes**
  * Improved accuracy and consistency of session, agent, turn, and prompt-run totals.
  * Model-call records now default to USD and preserve updated cost details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->