### PR TITLE
feat: capture Claude CLI session cost estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,10 +694,13 @@ If you want to use hooks:
 line, with Claude's normal custom-status-line UI effects. Captain composes with
 an existing status-line command and captures `cost.total_cost_usd` as Claude's
 client-side session estimate. It is never attributed to model calls or written
-as provider-reported billing. Without the flag, monitor installation changes
-only the existing lifecycle hooks and Codex notify configuration. Ordinary
-Claude transcripts and Codex's local artifacts do not expose a monetary total,
-so those histories keep Captain's token-based list-price estimate.
+as provider-reported billing. If the current project defines a higher-precedence
+`.claude/settings.json` or `.claude/settings.local.json` status line, installation
+fails rather than silently configuring an overridden user command. Without the
+flag, monitor installation changes only the existing lifecycle hooks and Codex
+notify configuration. Ordinary Claude transcripts and Codex's local artifacts
+do not expose a monetary total, so those histories keep Captain's token-based
+list-price estimate.
 
 Start the web UI:
 

--- a/README.md
+++ b/README.md
@@ -685,7 +685,19 @@ If you want to use hooks:
 ```bash
 .bin/captain hook bash-check install --user
 .bin/captain hook dod install --user
+.bin/captain hook monitor install
+# Opt in to Claude CLI estimate capture:
+.bin/captain hook monitor install --capture-cost
 ```
+
+`--capture-cost` is opt-in because it configures a Claude Code custom status
+line, with Claude's normal custom-status-line UI effects. Captain composes with
+an existing status-line command and captures `cost.total_cost_usd` as Claude's
+client-side session estimate. It is never attributed to model calls or written
+as provider-reported billing. Without the flag, monitor installation changes
+only the existing lifecycle hooks and Codex notify configuration. Ordinary
+Claude transcripts and Codex's local artifacts do not expose a monetary total,
+so those histories keep Captain's token-based list-price estimate.
 
 Start the web UI:
 

--- a/cmd/captain/main.go
+++ b/cmd/captain/main.go
@@ -249,6 +249,17 @@ func main() {
 	monitorNotifyCmd.Flags().String("provider", "claude", "Hook payload provider: claude or codex")
 	monitorNotifyCmd.Flags().String("url", "", "Captain serve base URL (default $CAPTAIN_SERVER_URL or http://localhost:9020)")
 	monitorHookCmd.AddCommand(monitorNotifyCmd)
+	monitorStatusLineCmd := &cobra.Command{
+		Use:   "statusline",
+		Short: "Capture Claude Code's session cost estimate and pass stdin through",
+		Long:  "Internal status-line adapter: passes Claude's status-line payload through unchanged and gives local estimate delivery a 10ms best-effort deadline.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			url, _ := cmd.Flags().GetString("url")
+			return cli.RunHookMonitorStatusline(cli.HookMonitorStatuslineOptions{URL: url})
+		},
+	}
+	monitorStatusLineCmd.Flags().String("url", "", "Captain serve base URL (default $CAPTAIN_SERVER_URL or http://localhost:9020)")
+	monitorHookCmd.AddCommand(monitorStatusLineCmd)
 	monitorInstallCmd := clicky.AddNamedCommand("install", monitorHookCmd, cli.HookMonitorInstallOptions{}, cli.RunHookMonitorInstall)
 	monitorInstallCmd.Short = "Install session-monitoring hooks into ~/.claude/settings.json and ~/.codex/config.toml"
 

--- a/migrations/10_sessions.pg.hcl
+++ b/migrations/10_sessions.pg.hcl
@@ -119,6 +119,14 @@ table "captain_sessions" {
     null = true
     type = timestamptz
   }
+  column "claude_cli_cost_usd" {
+    null = true
+    type = numeric(20, 8)
+  }
+  column "claude_cli_cost_observed_at" {
+    null = true
+    type = timestamptz
+  }
   column "created_at" {
     null    = false
     type    = timestamptz
@@ -204,6 +212,9 @@ table "captain_sessions" {
   }
   check "captain_sessions_time_order" {
     expr = "ended_at IS NULL OR started_at IS NULL OR ended_at >= started_at"
+  }
+  check "captain_sessions_claude_cli_cost_complete" {
+    expr = "(claude_cli_cost_usd IS NULL AND claude_cli_cost_observed_at IS NULL) OR (claude_cli_cost_usd IS NOT NULL AND claude_cli_cost_usd >= 0 AND claude_cli_cost_observed_at IS NOT NULL)"
   }
 }
 

--- a/migrations/60_view_session_overview.sql
+++ b/migrations/60_view_session_overview.sql
@@ -116,7 +116,10 @@ SELECT
   COALESCE(call_stats.output_cost, 0::numeric) AS output_cost,
   COALESCE(call_stats.reasoning_cost, 0::numeric) AS reasoning_cost,
   COALESCE(call_stats.cache_read_cost, 0::numeric) AS cache_read_cost,
-  COALESCE(call_stats.cache_write_cost, 0::numeric) AS cache_write_cost
+  COALESCE(call_stats.cache_write_cost, 0::numeric) AS cache_write_cost,
+  -- Claude's whole-session client estimate has no per-call attribution.
+  s.claude_cli_cost_usd,
+  s.claude_cli_cost_observed_at
 FROM public.captain_sessions s
 LEFT JOIN LATERAL (
   SELECT p.*

--- a/pkg/claude/session.go
+++ b/pkg/claude/session.go
@@ -492,7 +492,8 @@ type SessionCost struct {
 	Context   *ContextBreakdown  `json:"context,omitempty"`
 	ToolCosts []ToolTokenSummary `json:"toolCosts,omitempty"`
 
-	CostSource string `json:"costSource,omitempty"`
+	CostSource  string `json:"costSource,omitempty"`
+	HistoryFile string `json:"-"`
 	// responses deduplicates the per-content-block lines a single API response
 	// is written across. This is the no-result fallback — claude transcripts
 	// carry no result record to read instead. See api.ResponseSet.
@@ -573,10 +574,11 @@ func costsFromEntries(sessionFile string, entries []HistoryEntry, projectRoot st
 		sc, ok := costs[key]
 		if !ok {
 			sc = &SessionCost{
-				SessionID: entry.SessionID,
-				Project:   project,
-				Start:     ts,
-				End:       ts,
+				SessionID:   entry.SessionID,
+				Project:     project,
+				Start:       ts,
+				End:         ts,
+				HistoryFile: sessionFile,
 			}
 			costs[key] = sc
 			order = append(order, key)

--- a/pkg/claude/session.go
+++ b/pkg/claude/session.go
@@ -492,6 +492,7 @@ type SessionCost struct {
 	Context   *ContextBreakdown  `json:"context,omitempty"`
 	ToolCosts []ToolTokenSummary `json:"toolCosts,omitempty"`
 
+	CostSource string `json:"costSource,omitempty"`
 	// responses deduplicates the per-content-block lines a single API response
 	// is written across. This is the no-result fallback — claude transcripts
 	// carry no result record to read instead. See api.ResponseSet.

--- a/pkg/cli/cost.go
+++ b/pkg/cli/cost.go
@@ -12,6 +12,14 @@ import (
 	"github.com/flanksource/captain/pkg/session"
 )
 
+const (
+	costSourceCaptain   = "captain_estimate"
+	costSourceClaudeCLI = "claude_cli_estimate"
+	costSourceProvider  = "provider"
+	costSourceMixed     = "mixed"
+	costSourceAllocated = "allocated"
+)
+
 type CostOptions struct {
 	Since     time.Time `flag:"since" help:"Only include sessions after this time" default:"now-7d" short:"s"`
 	All       bool      `flag:"all" help:"Search all projects" short:"a"`
@@ -29,13 +37,15 @@ type CostRow struct {
 	CacheWrite string `json:"cacheWrite" pretty:"label=Cache Write,table"`
 	Msgs       int    `json:"msgs" pretty:"label=Msgs,table"`
 	APICost    string `json:"apiCost" pretty:"label=API Cost,table"`
+	CostBasis  string `json:"costBasis" pretty:"label=Cost Basis,table"`
 	Time       string `json:"time" pretty:"label=Time,table"`
 }
 
 type CostResult struct {
-	TotalAPICost string    `json:"totalApiCost" pretty:"label=Total API Cost (equivalent)"`
-	TotalTokens  string    `json:"totalTokens" pretty:"label=Total Tokens"`
-	Rows         []CostRow `json:"rows"`
+	TotalAPICost   string    `json:"totalApiCost" pretty:"label=Total API Cost (equivalent)"`
+	TotalCostBasis string    `json:"totalCostBasis" pretty:"label=Total Cost Basis"`
+	TotalTokens    string    `json:"totalTokens" pretty:"label=Total Tokens"`
+	Rows           []CostRow `json:"rows"`
 }
 
 type ToolCostRow struct {
@@ -78,8 +88,8 @@ func RunCost(ctx context.Context, opts CostOptions) (any, error) {
 		return nil, err
 	}
 	sessions = filterCostsBySessionID(sessions, sessionIDs)
-	// Transcripts hold no result record, so prefer the figures captain recorded
-	// from the provider's own results for any session it ran.
+	// Transcripts hold no result total, so prefer a complete provider-attributed
+	// thread and then a positive Claude CLI estimate Captain observed.
 	applyResultCosts(ctx, sessions)
 
 	grouped := groupSessions(sessions, opts.GroupBy)
@@ -89,8 +99,11 @@ func RunCost(ctx context.Context, opts CostOptions) (any, error) {
 	})
 
 	var total claude.TokenSummary
+	var totalSource string
 	rows := make([]CostRow, 0, len(grouped))
 	for _, s := range grouped {
+		source := sessionCostSource(s)
+		totalSource = mergeCostSource(totalSource, source)
 		total.InputTokens += s.Tokens.InputTokens
 		total.OutputTokens += s.Tokens.OutputTokens
 		total.CacheWriteTokens += s.Tokens.CacheWriteTokens
@@ -107,15 +120,17 @@ func RunCost(ctx context.Context, opts CostOptions) (any, error) {
 			CacheRead:  session.FormatTokens(s.Tokens.CacheReadTokens),
 			CacheWrite: session.FormatTokens(s.Tokens.CacheWriteTokens),
 			Msgs:       s.Messages,
-			APICost:    session.FormatCostEstimated(s.Tokens.TotalCost, s.Tokens.Estimated()),
+			APICost:    session.FormatCostEstimated(s.Tokens.TotalCost, costSourceEstimated(source)),
+			CostBasis:  costSourceLabel(source),
 			Time:       claude.FormatTimeAgo(&s.End),
 		})
 	}
 
 	return CostResult{
-		TotalAPICost: session.FormatCostEstimated(total.TotalCost, total.Estimated()),
-		TotalTokens:  session.FormatTokens(total.TotalTokens()),
-		Rows:         rows,
+		TotalAPICost:   session.FormatCostEstimated(total.TotalCost, costSourceEstimated(totalSource)),
+		TotalCostBasis: costSourceLabel(totalSource),
+		TotalTokens:    session.FormatTokens(total.TotalTokens()),
+		Rows:           rows,
 	}, nil
 }
 
@@ -275,13 +290,14 @@ func groupByPath(sessions []claude.SessionCost, mode string) []claude.SessionCos
 
 		for _, key := range keys {
 			split := claude.SessionCost{
-				SessionID: s.SessionID,
-				Project:   key,
-				Model:     s.Model,
-				Tier:      s.Tier,
-				Start:     s.Start,
-				End:       s.End,
-				Messages:  s.Messages,
+				SessionID:  s.SessionID,
+				Project:    key,
+				Model:      s.Model,
+				Tier:       s.Tier,
+				Start:      s.Start,
+				End:        s.End,
+				Messages:   s.Messages,
+				CostSource: costSourceAllocated,
 				Tokens: claude.TokenSummary{
 					InputTokens:      int(float64(s.Tokens.InputTokens) * fraction),
 					OutputTokens:     int(float64(s.Tokens.OutputTokens) * fraction),
@@ -325,6 +341,7 @@ func uniquePaths(files []string, mode string) []string {
 }
 
 func mergeInto(g *claude.SessionCost, s claude.SessionCost) {
+	g.CostSource = mergeCostSource(sessionCostSource(*g), sessionCostSource(s))
 	g.Tokens.InputTokens += s.Tokens.InputTokens
 	g.Tokens.OutputTokens += s.Tokens.OutputTokens
 	g.Tokens.CacheWriteTokens += s.Tokens.CacheWriteTokens
@@ -343,5 +360,39 @@ func mergeInto(g *claude.SessionCost, s claude.SessionCost) {
 	}
 	if s.Tier != "" {
 		g.Tier = s.Tier
+	}
+}
+
+func sessionCostSource(cost claude.SessionCost) string {
+	if cost.CostSource != "" {
+		return cost.CostSource
+	}
+	if cost.Tokens.ProviderCostUSD > 0 {
+		return costSourceProvider
+	}
+	return costSourceCaptain
+}
+
+func mergeCostSource(current, next string) string {
+	if current == "" || current == next {
+		return next
+	}
+	return costSourceMixed
+}
+
+func costSourceEstimated(source string) bool { return source != costSourceProvider }
+
+func costSourceLabel(source string) string {
+	switch source {
+	case costSourceClaudeCLI:
+		return "Claude CLI estimate"
+	case costSourceProvider:
+		return "Provider reported"
+	case costSourceMixed:
+		return "Mixed cost sources"
+	case costSourceAllocated:
+		return "Allocated session estimate"
+	default:
+		return "Captain list-price estimate"
 	}
 }

--- a/pkg/cli/history_cost_test.go
+++ b/pkg/cli/history_cost_test.go
@@ -77,16 +77,27 @@ func TestRunHistory_CostWithoutClaudeFlag(t *testing.T) {
 func TestResultCostLookupThreadProviderPriority(t *testing.T) {
 	db := withTestCaptainDB(t)
 	rootID, providerChildID, siblingID, estimateID, zeroID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	const (
+		rootPath          = "/tmp/root-cost.jsonl"
+		providerChildPath = "/tmp/provider-child-cost.jsonl"
+		siblingPath       = "/tmp/sibling-cost.jsonl"
+		estimatePath      = "/tmp/estimate-cost.jsonl"
+		zeroPath          = "/tmp/zero-cost.jsonl"
+	)
 	for _, input := range []database.CreateSessionInput{
-		{ID: rootID, ProviderSessionID: "root-cost", Source: "claude", HostID: "cost-test"},
-		{ID: providerChildID, Source: "claude", HostID: "cost-test", ParentSessionID: &rootID, RootSessionID: &rootID},
-		{ID: siblingID, ProviderSessionID: "sibling-cost", Source: "claude", HostID: "cost-test", ParentSessionID: &rootID, RootSessionID: &rootID},
-		{ID: estimateID, ProviderSessionID: "estimate-cost", Source: "claude", HostID: "cost-test"},
-		{ID: zeroID, ProviderSessionID: "zero-cost", Source: "claude", HostID: "cost-test"},
+		{ID: rootID, ProviderSessionID: "root-cost", Source: "claude", HostID: "cost-test", Path: rootPath},
+		{ID: providerChildID, ProviderSessionID: "provider-child-cost", Source: "claude", HostID: "cost-test", Path: providerChildPath, ParentSessionID: &rootID, RootSessionID: &rootID},
+		{ID: siblingID, ProviderSessionID: "sibling-cost", Source: "claude", HostID: "cost-test", Path: siblingPath, ParentSessionID: &rootID, RootSessionID: &rootID},
+		{ID: estimateID, ProviderSessionID: "estimate-cost", Source: "claude", HostID: "cost-test", Path: estimatePath},
+		{ID: zeroID, ProviderSessionID: "zero-cost", Source: "claude", HostID: "cost-test", Path: zeroPath},
 	} {
 		_, err := db.CreateOrGetSession(t.Context(), input)
 		require.NoError(t, err)
 	}
+	_, err := db.CreateOrGetSession(t.Context(), database.CreateSessionInput{
+		ProviderSessionID: "estimate-cost", Source: "gavel", HostID: "cost-test", Path: "/tmp/gavel-estimate-cost.jsonl",
+	})
+	require.NoError(t, err)
 	require.NoError(t, db.ReportClaudeCLICost(t.Context(), rootID, 0.2, time.Now().UTC()))
 	require.NoError(t, db.ReportClaudeCLICost(t.Context(), estimateID, 0.3, time.Now().UTC()))
 	require.NoError(t, db.ReportClaudeCLICost(t.Context(), zeroID, 0, time.Now().UTC()))
@@ -101,20 +112,37 @@ func TestResultCostLookupThreadProviderPriority(t *testing.T) {
 		VALUES (?, 0, 'claude-test', 'claude', 'succeeded', 10, 0.1, 0.75, 'USD')`, turnID).Error)
 
 	lookup := resultCostLookup{db: db}
-	for _, identity := range []string{"root-cost", "sibling-cost"} {
-		cost, ok := lookup.find(t.Context(), identity)
-		require.True(t, ok)
-		require.InDelta(t, 0.75, cost.ProviderUSD, 1e-9)
-		require.InDelta(t, 0.75, cost.TotalUSD, 1e-9)
+	cost, ok := lookup.find(t.Context(), "provider-child-cost", providerChildPath)
+	require.True(t, ok)
+	require.InDelta(t, 0.75, cost.ProviderUSD, 1e-9)
+	require.InDelta(t, 0.75, cost.TotalUSD, 1e-9)
+	for identity, path := range map[string]string{"root-cost": rootPath, "sibling-cost": siblingPath} {
+		_, ok := lookup.find(t.Context(), identity, path)
+		require.False(t, ok, "thread priority must not copy a whole-thread result onto %s", identity)
 	}
-	_, ok := lookup.find(t.Context(), "zero-cost")
+	_, ok = lookup.find(t.Context(), "zero-cost", zeroPath)
 	require.False(t, ok, "a zero CLI sample must not replace a fresh transcript estimate")
+	cost, ok = lookup.find(t.Context(), "estimate-cost", estimatePath)
+	require.True(t, ok, "the Claude transcript row must win over another source with the same provider ID")
+	require.InDelta(t, 0.3, cost.TotalUSD, 1e-9)
+
+	threadSessions := []claude.SessionCost{
+		{SessionID: "root-cost", HistoryFile: rootPath, Tokens: claude.TokenSummary{TotalCost: 0.1}},
+		{SessionID: "provider-child-cost", HistoryFile: providerChildPath, Tokens: claude.TokenSummary{TotalCost: 0.2}},
+		{SessionID: "sibling-cost", HistoryFile: siblingPath, Tokens: claude.TokenSummary{TotalCost: 0.3}},
+	}
+	applyResultCosts(t.Context(), threadSessions)
+	require.InDelta(t, 0.1, threadSessions[0].Tokens.TotalCost, 1e-9)
+	require.InDelta(t, 0.75, threadSessions[1].Tokens.TotalCost, 1e-9)
+	require.InDelta(t, 0.3, threadSessions[2].Tokens.TotalCost, 1e-9)
+	require.InDelta(t, 1.15, threadSessions[0].Tokens.TotalCost+threadSessions[1].Tokens.TotalCost+threadSessions[2].Tokens.TotalCost, 1e-9)
 
 	sessions := []claude.SessionCost{{
-		SessionID: "estimate-cost",
-		Project:   "project",
-		Files:     []string{"a.go", "b.go"},
-		Tokens:    claude.TokenSummary{TotalCost: 0.1},
+		SessionID:   "estimate-cost",
+		Project:     "project",
+		Files:       []string{"a.go", "b.go"},
+		HistoryFile: estimatePath,
+		Tokens:      claude.TokenSummary{TotalCost: 0.1},
 	}}
 	applyResultCosts(t.Context(), sessions)
 	require.InDelta(t, 0.3, sessions[0].Tokens.TotalCost, 1e-9)

--- a/pkg/cli/history_cost_test.go
+++ b/pkg/cli/history_cost_test.go
@@ -116,26 +116,24 @@ func TestResultCostLookupThreadProviderPriority(t *testing.T) {
 	require.True(t, ok)
 	require.InDelta(t, 0.75, cost.ProviderUSD, 1e-9)
 	require.InDelta(t, 0.75, cost.TotalUSD, 1e-9)
-	for identity, path := range map[string]string{"root-cost": rootPath, "sibling-cost": siblingPath} {
-		_, ok := lookup.find(t.Context(), identity, path)
-		require.False(t, ok, "thread priority must not copy a whole-thread result onto %s", identity)
-	}
+	cost, ok = lookup.find(t.Context(), "root-cost", rootPath)
+	require.True(t, ok, "the root transcript must include provider costs recorded on its children")
+	require.InDelta(t, 0.75, cost.ProviderUSD, 1e-9)
+	require.InDelta(t, 0.75, cost.TotalUSD, 1e-9)
+	_, ok = lookup.find(t.Context(), "sibling-cost", siblingPath)
+	require.False(t, ok, "a separately supplied child transcript must not duplicate a sibling's cost")
 	_, ok = lookup.find(t.Context(), "zero-cost", zeroPath)
 	require.False(t, ok, "a zero CLI sample must not replace a fresh transcript estimate")
 	cost, ok = lookup.find(t.Context(), "estimate-cost", estimatePath)
 	require.True(t, ok, "the Claude transcript row must win over another source with the same provider ID")
 	require.InDelta(t, 0.3, cost.TotalUSD, 1e-9)
 
-	threadSessions := []claude.SessionCost{
-		{SessionID: "root-cost", HistoryFile: rootPath, Tokens: claude.TokenSummary{TotalCost: 0.1}},
-		{SessionID: "provider-child-cost", HistoryFile: providerChildPath, Tokens: claude.TokenSummary{TotalCost: 0.2}},
-		{SessionID: "sibling-cost", HistoryFile: siblingPath, Tokens: claude.TokenSummary{TotalCost: 0.3}},
-	}
+	threadSessions := []claude.SessionCost{{
+		SessionID: "root-cost", HistoryFile: rootPath, Tokens: claude.TokenSummary{TotalCost: 0.1},
+	}}
 	applyResultCosts(t.Context(), threadSessions)
-	require.InDelta(t, 0.1, threadSessions[0].Tokens.TotalCost, 1e-9)
-	require.InDelta(t, 0.75, threadSessions[1].Tokens.TotalCost, 1e-9)
-	require.InDelta(t, 0.3, threadSessions[2].Tokens.TotalCost, 1e-9)
-	require.InDelta(t, 1.15, threadSessions[0].Tokens.TotalCost+threadSessions[1].Tokens.TotalCost+threadSessions[2].Tokens.TotalCost, 1e-9)
+	require.InDelta(t, 0.75, threadSessions[0].Tokens.TotalCost, 1e-9)
+	require.InDelta(t, 0.75, threadSessions[0].Tokens.ProviderCostUSD, 1e-9)
 
 	sessions := []claude.SessionCost{{
 		SessionID:   "estimate-cost",

--- a/pkg/cli/history_cost_test.go
+++ b/pkg/cli/history_cost_test.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/flanksource/captain/pkg/claude"
+	"github.com/flanksource/captain/pkg/database"
 	"github.com/flanksource/captain/pkg/session"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 // TestRunHistory_CostWithoutClaudeFlag is the F5 regression: `history --cost`
@@ -68,5 +71,70 @@ func TestRunHistory_CostWithoutClaudeFlag(t *testing.T) {
 	}
 	if withCost == 0 {
 		t.Errorf("no row carried a cost with --cost and default (both-source) scope; F5 regression")
+	}
+}
+
+func TestResultCostLookupThreadProviderPriority(t *testing.T) {
+	db := withTestCaptainDB(t)
+	rootID, providerChildID, siblingID, estimateID, zeroID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	for _, input := range []database.CreateSessionInput{
+		{ID: rootID, ProviderSessionID: "root-cost", Source: "claude", HostID: "cost-test"},
+		{ID: providerChildID, Source: "claude", HostID: "cost-test", ParentSessionID: &rootID, RootSessionID: &rootID},
+		{ID: siblingID, ProviderSessionID: "sibling-cost", Source: "claude", HostID: "cost-test", ParentSessionID: &rootID, RootSessionID: &rootID},
+		{ID: estimateID, ProviderSessionID: "estimate-cost", Source: "claude", HostID: "cost-test"},
+		{ID: zeroID, ProviderSessionID: "zero-cost", Source: "claude", HostID: "cost-test"},
+	} {
+		_, err := db.CreateOrGetSession(t.Context(), input)
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.ReportClaudeCLICost(t.Context(), rootID, 0.2, time.Now().UTC()))
+	require.NoError(t, db.ReportClaudeCLICost(t.Context(), estimateID, 0.3, time.Now().UTC()))
+	require.NoError(t, db.ReportClaudeCLICost(t.Context(), zeroID, 0, time.Now().UTC()))
+
+	turnID := uuid.New()
+	require.NoError(t, db.Gorm().Exec(`
+		INSERT INTO captain_turns (id, session_id, turn_index, status)
+		VALUES (?, ?, 0, 'ended')`, turnID, providerChildID).Error)
+	require.NoError(t, db.Gorm().Exec(`
+		INSERT INTO captain_model_calls
+		  (turn_id, call_index, model, backend, status, input_tokens, input_cost, provider_cost_usd, currency)
+		VALUES (?, 0, 'claude-test', 'claude', 'succeeded', 10, 0.1, 0.75, 'USD')`, turnID).Error)
+
+	lookup := resultCostLookup{db: db}
+	for _, identity := range []string{"root-cost", "sibling-cost"} {
+		cost, ok := lookup.find(t.Context(), identity)
+		require.True(t, ok)
+		require.InDelta(t, 0.75, cost.ProviderUSD, 1e-9)
+		require.InDelta(t, 0.75, cost.TotalUSD, 1e-9)
+	}
+	_, ok := lookup.find(t.Context(), "zero-cost")
+	require.False(t, ok, "a zero CLI sample must not replace a fresh transcript estimate")
+
+	sessions := []claude.SessionCost{{
+		SessionID: "estimate-cost",
+		Project:   "project",
+		Files:     []string{"a.go", "b.go"},
+		Tokens:    claude.TokenSummary{TotalCost: 0.1},
+	}}
+	applyResultCosts(t.Context(), sessions)
+	require.InDelta(t, 0.3, sessions[0].Tokens.TotalCost, 1e-9)
+	require.Zero(t, sessions[0].Tokens.ProviderCostUSD)
+	require.Equal(t, costSourceClaudeCLI, sessions[0].CostSource)
+	require.Equal(t, "Claude CLI estimate", costSourceLabel(sessionCostSource(sessions[0])))
+
+	mixed := groupSessions(append(sessions, claude.SessionCost{
+		SessionID: "fresh-cost",
+		Project:   "project",
+		Tokens:    claude.TokenSummary{TotalCost: 0.1},
+	}), "project")
+	require.Len(t, mixed, 1)
+	require.Equal(t, "Mixed cost sources", costSourceLabel(sessionCostSource(mixed[0])))
+	require.True(t, costSourceEstimated(sessionCostSource(mixed[0])))
+
+	allocated := groupSessions(sessions, "file")
+	require.Len(t, allocated, 2)
+	for _, row := range allocated {
+		require.Equal(t, "Allocated session estimate", costSourceLabel(sessionCostSource(row)))
+		require.True(t, costSourceEstimated(sessionCostSource(row)))
 	}
 }

--- a/pkg/cli/hook.go
+++ b/pkg/cli/hook.go
@@ -128,9 +128,9 @@ func resolveSettingsTarget(userGlobal bool) (string, error) {
 	return target, nil
 }
 
-// installHook idempotently adds a hook command entry to the given event type in the settings file.
+// installHook idempotently ensures a hook command entry exists for the given event type.
 // matcher is used for PreToolUse tool matching (e.g. "Bash"); pass "" for Stop hooks.
-// existingCheck is a substring used to detect if the hook is already installed.
+// existingCheck identifies the command entry Captain owns and may update.
 func installHook(target, eventType, matcher, hookCommand, existingCheck string, timeout int) (string, error) {
 	data, err := os.ReadFile(target)
 	if err != nil {
@@ -149,6 +149,9 @@ func installHook(target, eventType, matcher, hookCommand, existingCheck string, 
 	}
 
 	existingHooks, _ := hooks[eventType].([]any)
+	action := "installed"
+	updated := false
+findExisting:
 	for _, h := range existingHooks {
 		m, ok := h.(map[string]any)
 		if !ok {
@@ -157,22 +160,32 @@ func installHook(target, eventType, matcher, hookCommand, existingCheck string, 
 		for _, ih := range asSlice(m["hooks"]) {
 			hook, _ := ih.(map[string]any)
 			if cmd, _ := hook["command"].(string); strings.Contains(cmd, existingCheck) {
-				return fmt.Sprintf("%s hook: already installed in %s", eventType, target), nil
+				existingTimeout, _ := hook["timeout"].(float64)
+				if cmd == hookCommand && existingTimeout == float64(timeout) {
+					return fmt.Sprintf("%s hook: already installed in %s", eventType, target), nil
+				}
+				hook["command"] = hookCommand
+				hook["timeout"] = timeout
+				action = "updated"
+				updated = true
+				break findExisting
 			}
 		}
 	}
 
-	entry := map[string]any{
-		"type":    "command",
-		"command": hookCommand,
-		"timeout": timeout,
-	}
-	matcherEntry := map[string]any{"hooks": []any{entry}}
-	if matcher != "" {
-		matcherEntry["matcher"] = matcher
-	}
+	if !updated {
+		entry := map[string]any{
+			"type":    "command",
+			"command": hookCommand,
+			"timeout": timeout,
+		}
+		matcherEntry := map[string]any{"hooks": []any{entry}}
+		if matcher != "" {
+			matcherEntry["matcher"] = matcher
+		}
 
-	hooks[eventType] = append(existingHooks, matcherEntry)
+		hooks[eventType] = append(existingHooks, matcherEntry)
+	}
 
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
@@ -181,7 +194,7 @@ func installHook(target, eventType, matcher, hookCommand, existingCheck string, 
 	if err := os.WriteFile(target, append(out, '\n'), 0644); err != nil {
 		return "", fmt.Errorf("writing %s: %w", target, err)
 	}
-	return fmt.Sprintf("%s hook: installed in %s (%s)", eventType, target, hookCommand), nil
+	return fmt.Sprintf("%s hook: %s in %s (%s)", eventType, action, target, hookCommand), nil
 }
 
 func installSkills() (string, error) {

--- a/pkg/cli/hook_monitor.go
+++ b/pkg/cli/hook_monitor.go
@@ -211,19 +211,34 @@ func installClaudeStatusLine(target, captainCommand string) (string, error) {
 	if err := json.Unmarshal(data, &settings); err != nil {
 		return "", fmt.Errorf("parsing %s: %w", target, err)
 	}
+	action := "installed"
 	if raw, exists := settings["statusLine"]; exists {
 		statusLine, ok := raw.(map[string]any)
 		if !ok {
 			return "", fmt.Errorf("%s statusLine is not a command object; cannot compose session cost capture", target)
 		}
 		command, _ := statusLine["command"].(string)
-		if strings.Contains(command, "hook monitor statusline") {
-			return fmt.Sprintf("StatusLine cost capture: already installed in %s", target), nil
+		if marker := strings.Index(command, "hook monitor statusline"); marker >= 0 {
+			var suffix string
+			if separator := strings.Index(command, " | ("); separator > marker {
+				suffix = command[separator:]
+			} else if strings.HasSuffix(command, " >/dev/null") {
+				suffix = " >/dev/null"
+			} else {
+				return "", fmt.Errorf("%s has an unrecognized Captain statusLine wrapper; cannot update session cost capture", target)
+			}
+			updatedCommand := captainCommand + suffix
+			if command == updatedCommand {
+				return fmt.Sprintf("StatusLine cost capture: already installed in %s", target), nil
+			}
+			statusLine["command"] = updatedCommand
+			action = "updated"
+		} else {
+			if kind, _ := statusLine["type"].(string); kind != "command" || strings.TrimSpace(command) == "" {
+				return "", fmt.Errorf("%s statusLine must have type=command and a command to compose session cost capture", target)
+			}
+			statusLine["command"] = captainCommand + " | (" + command + ")"
 		}
-		if kind, _ := statusLine["type"].(string); kind != "command" || strings.TrimSpace(command) == "" {
-			return "", fmt.Errorf("%s statusLine must have type=command and a command to compose session cost capture", target)
-		}
-		statusLine["command"] = captainCommand + " | (" + command + ")"
 	} else {
 		settings["statusLine"] = map[string]any{
 			"type": "command", "command": captainCommand + " >/dev/null",
@@ -236,7 +251,7 @@ func installClaudeStatusLine(target, captainCommand string) (string, error) {
 	if err := os.WriteFile(target, append(out, '\n'), 0o644); err != nil {
 		return "", fmt.Errorf("writing %s: %w", target, err)
 	}
-	return fmt.Sprintf("StatusLine cost capture: installed in %s", target), nil
+	return fmt.Sprintf("StatusLine cost capture: %s in %s", action, target), nil
 }
 
 // ensureUserClaudeSettings returns the user-level settings.json path, creating

--- a/pkg/cli/hook_monitor.go
+++ b/pkg/cli/hook_monitor.go
@@ -111,6 +111,15 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 	if err != nil {
 		captainPath = "captain"
 	}
+	if opts.CaptureCost {
+		projectStatusLine, alreadyInstalled, err := higherPrecedenceClaudeStatusLine()
+		if err != nil {
+			return nil, err
+		}
+		if projectStatusLine != "" && !alreadyInstalled {
+			return nil, fmt.Errorf("%s defines a higher-precedence Claude statusLine; compose cost capture there or remove it before installing user-wide capture", projectStatusLine)
+		}
+	}
 	urlSuffix := ""
 	if opts.URL != "" {
 		urlSuffix = " --url " + opts.URL
@@ -156,6 +165,38 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 		results = append(results, "Claude CLI cost estimate capture uses a custom status line; missed delivery retries on Claude's next refresh.")
 	}
 	return strings.Join(results, "\n"), nil
+}
+
+func higherPrecedenceClaudeStatusLine() (string, bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false, fmt.Errorf("resolve current project for Claude statusLine: %w", err)
+	}
+	root := claude.FindProjectRoot(cwd)
+	for _, target := range []string{
+		filepath.Join(root, ".claude", "settings.local.json"),
+		filepath.Join(root, ".claude", "settings.json"),
+	} {
+		data, err := os.ReadFile(target)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return "", false, fmt.Errorf("reading %s: %w", target, err)
+		}
+		var settings map[string]any
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return "", false, fmt.Errorf("parsing %s: %w", target, err)
+		}
+		raw, exists := settings["statusLine"]
+		if !exists {
+			continue
+		}
+		statusLine, _ := raw.(map[string]any)
+		command, _ := statusLine["command"].(string)
+		return target, strings.Contains(command, "hook monitor statusline"), nil
+	}
+	return "", false, nil
 }
 
 // installClaudeStatusLine wraps an existing command as the downstream side of

--- a/pkg/cli/hook_monitor.go
+++ b/pkg/cli/hook_monitor.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,9 +21,14 @@ type HookMonitorNotifyOptions struct {
 	URL      string // serve base URL override; default monitor.ServeBaseURL()
 }
 
-// hookNotifyTimeout bounds hook delivery so an agent turn is never held up:
-// deliver within it or drop the event (recon reconciles drops).
-const hookNotifyTimeout = time.Second
+const (
+	// Lifecycle events tolerate a longer delivery attempt because recon can
+	// reconstruct them when Captain is unavailable.
+	hookNotifyTimeout = time.Second
+	// Claude cancels slow status-line commands, so local estimate delivery gets
+	// only a small best-effort window. Claude retries on its next refresh.
+	statusLineNotifyTimeout = 10 * time.Millisecond
+)
 
 // RunHookMonitorNotify is the hook receiver both providers invoke: Claude Code
 // pipes the payload on stdin, codex appends it as the final argv argument. It
@@ -47,9 +54,42 @@ func RunHookMonitorNotify(opts HookMonitorNotifyOptions, args []string) error {
 	return nil
 }
 
+type HookMonitorStatuslineOptions struct {
+	URL string
+}
+
+// RunHookMonitorStatusline forwards Claude Code's status-line stdin unchanged
+// for composition with an existing status-line command, while best-effort
+// reporting the cumulative CLI estimate to Captain.
+func RunHookMonitorStatusline(opts HookMonitorStatuslineOptions) error {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "captain hook monitor statusline: reading stdin: %v\n", err)
+		return nil
+	}
+	if _, err := os.Stdout.Write(data); err != nil {
+		fmt.Fprintf(os.Stderr, "captain hook monitor statusline: forwarding stdin: %v\n", err)
+	}
+	ev, err := monitor.ParseClaudeStatusLinePayload(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "captain hook monitor statusline: %v\n", err)
+		return nil
+	}
+	baseURL := opts.URL
+	if baseURL == "" {
+		baseURL = api.ServeBaseURL()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), statusLineNotifyTimeout)
+	defer cancel()
+	// Delivery is best-effort; server failures must not alter status-line output.
+	_ = monitor.PostHookEvent(ctx, baseURL, ev)
+	return nil
+}
+
 type HookMonitorInstallOptions struct {
-	Timeout int    `flag:"timeout" help:"Hook timeout in seconds" default:"10"`
-	URL     string `flag:"url" help:"Captain serve base URL baked into the hook command (for non-default ports)"`
+	Timeout     int    `flag:"timeout" help:"Hook timeout in seconds" default:"10"`
+	URL         string `flag:"url" help:"Captain serve base URL baked into the hook command (for non-default ports)"`
+	CaptureCost bool   `flag:"capture-cost" help:"Capture Claude's client-estimated session cost by configuring a custom status line"`
 }
 
 // monitorHookEvents are the Claude Code lifecycle events captain subscribes to
@@ -80,8 +120,19 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	claudeCommand := fmt.Sprintf("%s hook monitor notify --provider claude%s", captainPath, urlSuffix)
 	var results []string
+	if opts.CaptureCost {
+		statusLineCommand := shellQuote(captainPath) + " hook monitor statusline"
+		if opts.URL != "" {
+			statusLineCommand += " --url " + shellQuote(opts.URL)
+		}
+		statusLineResult, err := installClaudeStatusLine(target, statusLineCommand)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, statusLineResult)
+	}
+	claudeCommand := fmt.Sprintf("%s hook monitor notify --provider claude%s", captainPath, urlSuffix)
 	for _, event := range monitorHookEvents {
 		result, err := installHook(target, string(event), "", claudeCommand, "hook monitor notify --provider claude", opts.Timeout)
 		if err != nil {
@@ -101,7 +152,50 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 	results = append(results, codexResult)
 
 	results = append(results, "Events are delivered to a running `captain serve`; when it is down they are dropped and the daily recon backfills them.")
+	if opts.CaptureCost {
+		results = append(results, "Claude CLI cost estimate capture uses a custom status line; missed delivery retries on Claude's next refresh.")
+	}
 	return strings.Join(results, "\n"), nil
+}
+
+// installClaudeStatusLine wraps an existing command as the downstream side of
+// a pipeline. Captain passes stdin through byte-for-byte, preserving the user's
+// rendered status line; without an existing command its output is discarded.
+func installClaudeStatusLine(target, captainCommand string) (string, error) {
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", target, err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", target, err)
+	}
+	if raw, exists := settings["statusLine"]; exists {
+		statusLine, ok := raw.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%s statusLine is not a command object; cannot compose session cost capture", target)
+		}
+		command, _ := statusLine["command"].(string)
+		if strings.Contains(command, "hook monitor statusline") {
+			return fmt.Sprintf("StatusLine cost capture: already installed in %s", target), nil
+		}
+		if kind, _ := statusLine["type"].(string); kind != "command" || strings.TrimSpace(command) == "" {
+			return "", fmt.Errorf("%s statusLine must have type=command and a command to compose session cost capture", target)
+		}
+		statusLine["command"] = captainCommand + " | (" + command + ")"
+	} else {
+		settings["statusLine"] = map[string]any{
+			"type": "command", "command": captainCommand + " >/dev/null",
+		}
+	}
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode %s statusLine: %w", target, err)
+	}
+	if err := os.WriteFile(target, append(out, '\n'), 0o644); err != nil {
+		return "", fmt.Errorf("writing %s: %w", target, err)
+	}
+	return fmt.Sprintf("StatusLine cost capture: installed in %s", target), nil
 }
 
 // ensureUserClaudeSettings returns the user-level settings.json path, creating

--- a/pkg/cli/hook_monitor.go
+++ b/pkg/cli/hook_monitor.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/claude"
 	"github.com/flanksource/captain/pkg/codexconfig"
+	"github.com/flanksource/captain/pkg/container"
 	"github.com/flanksource/captain/pkg/monitor"
 )
 
@@ -111,6 +113,7 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 	if err != nil {
 		captainPath = "captain"
 	}
+	statusLineTarget := ""
 	if opts.CaptureCost {
 		projectStatusLine, alreadyInstalled, err := higherPrecedenceClaudeStatusLine()
 		if err != nil {
@@ -119,6 +122,7 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 		if projectStatusLine != "" && !alreadyInstalled {
 			return nil, fmt.Errorf("%s defines a higher-precedence Claude statusLine; compose cost capture there or remove it before installing user-wide capture", projectStatusLine)
 		}
+		statusLineTarget = projectStatusLine
 	}
 	urlSuffix := ""
 	if opts.URL != "" {
@@ -135,7 +139,10 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 		if opts.URL != "" {
 			statusLineCommand += " --url " + shellQuote(opts.URL)
 		}
-		statusLineResult, err := installClaudeStatusLine(target, statusLineCommand)
+		if statusLineTarget == "" {
+			statusLineTarget = target
+		}
+		statusLineResult, err := installClaudeStatusLine(statusLineTarget, statusLineCommand)
 		if err != nil {
 			return nil, err
 		}
@@ -167,16 +174,27 @@ func RunHookMonitorInstall(opts HookMonitorInstallOptions) (any, error) {
 	return strings.Join(results, "\n"), nil
 }
 
+// higherPrecedenceClaudeStatusLine returns the effective project status-line
+// file in Claude's precedence order: Git-root local, legacy launch-directory
+// local, then launch-directory shared settings.
 func higherPrecedenceClaudeStatusLine() (string, bool, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", false, fmt.Errorf("resolve current project for Claude statusLine: %w", err)
 	}
-	root := claude.FindProjectRoot(cwd)
-	for _, target := range []string{
-		filepath.Join(root, ".claude", "settings.local.json"),
-		filepath.Join(root, ".claude", "settings.json"),
-	} {
+	targets := make([]string, 0, 3)
+	if runtime.GOOS != "windows" {
+		gitRoot := container.FindGitRoot(cwd)
+		home, _ := os.UserHomeDir()
+		if gitRoot != "" && gitRoot != cwd && filepath.Clean(gitRoot) != filepath.Clean(home) {
+			targets = append(targets, filepath.Join(gitRoot, ".claude", "settings.local.json"))
+		}
+	}
+	targets = append(targets,
+		filepath.Join(cwd, ".claude", "settings.local.json"),
+		filepath.Join(cwd, ".claude", "settings.json"),
+	)
+	for _, target := range targets {
 		data, err := os.ReadFile(target)
 		if os.IsNotExist(err) {
 			continue

--- a/pkg/cli/hook_monitor_test.go
+++ b/pkg/cli/hook_monitor_test.go
@@ -75,6 +75,18 @@ func TestRunHookMonitorInstall(t *testing.T) {
 		command := statusLine["command"].(string)
 		assert.Contains(t, command, "hook monitor statusline")
 		assert.Contains(t, command, "| (jq -r .cwd)")
+
+		_, err = RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10, URL: "http://localhost:1234", CaptureCost: true})
+		require.NoError(t, err)
+		_, err = RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10, URL: "http://localhost:5678", CaptureCost: true})
+		require.NoError(t, err)
+		data, err = os.ReadFile(settingsPath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &settings))
+		command = settings["statusLine"].(map[string]any)["command"].(string)
+		assert.Contains(t, command, "--url 'http://localhost:5678'")
+		assert.NotContains(t, command, "http://localhost:1234")
+		assert.Contains(t, command, "| (jq -r .cwd)", "updating Captain must preserve the existing status line")
 	})
 
 	for _, filename := range []string{"settings.json", "settings.local.json"} {

--- a/pkg/cli/hook_monitor_test.go
+++ b/pkg/cli/hook_monitor_test.go
@@ -32,10 +32,16 @@ func TestRunHookMonitorInstall(t *testing.T) {
 	_, err := RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10})
 	require.NoError(t, err)
 
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	hooks := readHookEvents()
 	for _, event := range []string{"SessionStart", "UserPromptSubmit", "Stop", "SubagentStop", "SessionEnd"} {
 		assert.Len(t, hooks[event], 1, "event %s must be installed", event)
 	}
+	data, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+	assert.NotContains(t, settings, "statusLine", "cost capture must be opt-in")
 
 	codexData, err := os.ReadFile(codexPath)
 	require.NoError(t, err)
@@ -48,5 +54,26 @@ func TestRunHookMonitorInstall(t *testing.T) {
 		for _, event := range []string{"SessionStart", "UserPromptSubmit", "Stop", "SubagentStop", "SessionEnd"} {
 			assert.Len(t, hooks[event], 1, "event %s must not be duplicated", event)
 		}
+	})
+
+	t.Run("capture cost composes an existing status line", func(t *testing.T) {
+		data, err := os.ReadFile(settingsPath)
+		require.NoError(t, err)
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+		settings["statusLine"] = map[string]any{"type": "command", "command": "jq -r .cwd"}
+		data, err = json.MarshalIndent(settings, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(settingsPath, append(data, '\n'), 0o644))
+
+		_, err = RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10, CaptureCost: true})
+		require.NoError(t, err)
+		data, err = os.ReadFile(settingsPath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &settings))
+		statusLine := settings["statusLine"].(map[string]any)
+		command := statusLine["command"].(string)
+		assert.Contains(t, command, "hook monitor statusline")
+		assert.Contains(t, command, "| (jq -r .cwd)")
 	})
 }

--- a/pkg/cli/hook_monitor_test.go
+++ b/pkg/cli/hook_monitor_test.go
@@ -76,4 +76,20 @@ func TestRunHookMonitorInstall(t *testing.T) {
 		assert.Contains(t, command, "hook monitor statusline")
 		assert.Contains(t, command, "| (jq -r .cwd)")
 	})
+
+	for _, filename := range []string{"settings.json", "settings.local.json"} {
+		t.Run("capture cost rejects higher precedence "+filename, func(t *testing.T) {
+			project := t.TempDir()
+			t.Chdir(project)
+			require.NoError(t, os.WriteFile(filepath.Join(project, "go.mod"), []byte("module example.com/project\n"), 0o644))
+			settingsDir := filepath.Join(project, ".claude")
+			require.NoError(t, os.MkdirAll(settingsDir, 0o755))
+			target := filepath.Join(settingsDir, filename)
+			require.NoError(t, os.WriteFile(target, []byte(`{"statusLine":{"type":"command","command":"jq -r .cwd"}}`), 0o644))
+
+			_, err := RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10, CaptureCost: true})
+			require.ErrorContains(t, err, target)
+			require.ErrorContains(t, err, "higher-precedence Claude statusLine")
+		})
+	}
 }

--- a/pkg/cli/hook_monitor_test.go
+++ b/pkg/cli/hook_monitor_test.go
@@ -104,4 +104,41 @@ func TestRunHookMonitorInstall(t *testing.T) {
 			require.ErrorContains(t, err, "higher-precedence Claude statusLine")
 		})
 	}
+
+	t.Run("capture cost detects launch-directory shared settings", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+		launchDir := filepath.Join(root, "packages", "app")
+		settingsDir := filepath.Join(launchDir, ".claude")
+		require.NoError(t, os.MkdirAll(settingsDir, 0o755))
+		target := filepath.Join(settingsDir, "settings.json")
+		require.NoError(t, os.WriteFile(target, []byte(`{"statusLine":{"type":"command","command":"jq -r .cwd"}}`), 0o644))
+		t.Chdir(launchDir)
+
+		_, err := RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10, CaptureCost: true})
+		require.ErrorContains(t, err, target)
+	})
+
+	t.Run("capture cost updates effective git-root local wrapper", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+		launchDir := filepath.Join(root, "packages", "app")
+		require.NoError(t, os.MkdirAll(launchDir, 0o755))
+		settingsDir := filepath.Join(root, ".claude")
+		require.NoError(t, os.Mkdir(settingsDir, 0o755))
+		target := filepath.Join(settingsDir, "settings.local.json")
+		require.NoError(t, os.WriteFile(target, []byte(`{"statusLine":{"type":"command","command":"'/old/captain' hook monitor statusline --url 'http://localhost:1234' | (jq -r .cwd)"}}`), 0o644))
+		t.Chdir(launchDir)
+
+		_, err := RunHookMonitorInstall(HookMonitorInstallOptions{Timeout: 10, URL: "http://localhost:5678", CaptureCost: true})
+		require.NoError(t, err)
+		data, err := os.ReadFile(target)
+		require.NoError(t, err)
+		var settings map[string]any
+		require.NoError(t, json.Unmarshal(data, &settings))
+		command := settings["statusLine"].(map[string]any)["command"].(string)
+		assert.Contains(t, command, "--url 'http://localhost:5678'")
+		assert.NotContains(t, command, "/old/captain")
+		assert.Contains(t, command, "| (jq -r .cwd)")
+	})
 }

--- a/pkg/cli/result_costs.go
+++ b/pkg/cli/result_costs.go
@@ -8,8 +8,8 @@ import (
 	"github.com/flanksource/captain/pkg/database"
 )
 
-// resultCostLookup resolves the result-derived cost captain recorded for the
-// sessions it ran itself.
+// resultCostLookup resolves attributed provider cost or Claude Code's
+// client-estimated session total for a transcript session.
 //
 // A stored claude transcript carries no result record — no invocation summary,
 // no running total — so replaying one can only rebuild the numbers from each
@@ -18,10 +18,8 @@ import (
 // (1-hour cache writes, for one), and on a real session it came out ~9% under
 // the billed figure.
 //
-// Captain does hold the provider's own answer for any session it executed:
-// pkg/aichat writes each EventResult's Usage and CostUSD to captain_model_calls.
-// This looks that up so the replay surfaces report the billed figure rather than
-// their own recomputation.
+// Claude Code's status-line total remains a whole-session CLI estimate rather
+// than being promoted to provider billing or attributed to model calls.
 type resultCostLookup struct {
 	db *database.DB
 }
@@ -50,10 +48,9 @@ type resultCost struct {
 // find returns the result captain recorded for a session identity (a provider
 // session id or captain id).
 //
-// It reports a hit only when the stored rows carry a provider-reported cost.
-// A row without one is not a result — it is another reconstruction, written by
-// transcript ingest from the same per-message usage the caller already has, and
-// possibly staler. Preferring it would trade a fresh estimate for an old one.
+// It reports a hit only for a positive Claude CLI estimate or when the complete
+// thread carries provider-reported cost. Rows containing only Captain's
+// reconstructed buckets are not preferred over a fresh transcript parse.
 func (l *resultCostLookup) find(ctx context.Context, identity string) (resultCost, bool) {
 	if l == nil || l.db == nil || identity == "" {
 		return resultCost{}, false
@@ -64,11 +61,18 @@ func (l *resultCostLookup) find(ctx context.Context, identity string) (resultCos
 	if err != nil || overview == nil {
 		return resultCost{}, false
 	}
-	rows, err := l.db.ListThreadCosts(ctx, overview.ID)
-	if err != nil || len(rows) == 0 {
+	rootID := overview.ID
+	if overview.RootSessionID != nil {
+		rootID = *overview.RootSessionID
+	}
+	rows, err := l.db.ListThreadCosts(ctx, rootID)
+	if err != nil {
 		return resultCost{}, false
 	}
-	out := resultCost{Model: rows[0].Model}
+	var out resultCost
+	if len(rows) > 0 {
+		out.Model = rows[0].Model
+	}
 	for i := range rows {
 		out.Usage.InputTokens += int(rows[i].InputTokens)
 		out.Usage.OutputTokens += int(rows[i].OutputTokens)
@@ -81,13 +85,19 @@ func (l *resultCostLookup) find(ctx context.Context, identity string) (resultCos
 		out.TotalUSD += rows[i].TotalCost
 		out.ProviderUSD += rows[i].ProviderCostUSD
 	}
-	return out, out.ProviderUSD > 0
+	if out.ProviderUSD > 0 {
+		return out, true
+	}
+	if overview.ClaudeCLICostUSD != nil && *overview.ClaudeCLICostUSD > 0 {
+		return resultCost{TotalUSD: *overview.ClaudeCLICostUSD}, true
+	}
+	return resultCost{}, false
 }
 
-// applyResultCosts replaces each session's reconstructed usage and cost with the
-// figures captain recorded from the provider's results, where it has them.
-// Sessions captain never ran keep their reconstruction, which stays marked as an
-// estimate because no provider cost is set on it.
+// applyResultCosts prefers stored provider-attributed calls, then a positive
+// Claude CLI estimate. The estimate replaces only TotalCost, preserving
+// transcript usage and a zero ProviderCostUSD so output remains estimated and
+// carries the Claude CLI label.
 func applyResultCosts(ctx context.Context, sessions []claude.SessionCost) {
 	if len(sessions) == 0 {
 		return
@@ -100,6 +110,15 @@ func applyResultCosts(ctx context.Context, sessions []claude.SessionCost) {
 		cost, ok := lookup.find(ctx, sessions[i].SessionID)
 		if !ok {
 			continue
+		}
+		if cost.ProviderUSD <= 0 {
+			sessions[i].Tokens.TotalCost = cost.TotalUSD
+			sessions[i].CostSource = costSourceClaudeCLI
+			continue
+		}
+		sessions[i].CostSource = costSourceProvider
+		if cost.TotalUSD-cost.ProviderUSD > 1e-9 {
+			sessions[i].CostSource = costSourceMixed
 		}
 		sessions[i].Tokens = claude.TokenSummary{
 			InputTokens:      cost.Usage.InputTokens,

--- a/pkg/cli/result_costs.go
+++ b/pkg/cli/result_costs.go
@@ -46,12 +46,13 @@ type resultCost struct {
 	ProviderUSD float64
 }
 
-// find returns the result Captain recorded for one Claude transcript session.
+// find returns the result Captain recorded for one Claude transcript.
 //
-// Provider-attributed replacement remains per transcript, but only after a
-// complete-thread check prevents a lower-authority CLI estimate from masking a
-// provider cost on another agent. Reconstructed database buckets are not
-// preferred over a fresh transcript parse.
+// ParseCosts emits root transcripts only, so a root result must include model
+// calls from every child in the thread. A separately supplied child transcript
+// remains scoped to that child to avoid duplicating its cost. Reconstructed
+// database buckets are not preferred over a fresh transcript parse unless the
+// thread also contains a provider-reported cost.
 func (l *resultCostLookup) find(ctx context.Context, identity, historyFile string) (resultCost, bool) {
 	if l == nil || l.db == nil || identity == "" {
 		return resultCost{}, false
@@ -73,21 +74,37 @@ func (l *resultCostLookup) find(ctx context.Context, identity, historyFile strin
 		threadProviderUSD += rows[i].ProviderCostUSD
 	}
 	if threadProviderUSD > 0 {
-		if overview.ProviderCostUSD <= 0 {
-			return resultCost{}, false
+		if overview.RootSessionID != nil {
+			if overview.ProviderCostUSD <= 0 {
+				return resultCost{}, false
+			}
+			out := resultCost{
+				Usage: api.Usage{
+					InputTokens:      int(overview.InputTokens),
+					OutputTokens:     int(overview.OutputTokens),
+					ReasoningTokens:  int(overview.ReasoningTokens),
+					CacheReadTokens:  int(overview.CacheReadTokens),
+					CacheWriteTokens: int(overview.CacheWriteTokens),
+				},
+				TotalUSD: overview.CostUSD, ProviderUSD: overview.ProviderCostUSD,
+			}
+			if overview.Model != nil {
+				out.Model = *overview.Model
+			}
+			return out, true
 		}
-		out := resultCost{
-			Usage: api.Usage{
-				InputTokens:      int(overview.InputTokens),
-				OutputTokens:     int(overview.OutputTokens),
-				ReasoningTokens:  int(overview.ReasoningTokens),
-				CacheReadTokens:  int(overview.CacheReadTokens),
-				CacheWriteTokens: int(overview.CacheWriteTokens),
-			},
-			TotalUSD: overview.CostUSD, ProviderUSD: overview.ProviderCostUSD,
-		}
-		if overview.Model != nil {
-			out.Model = *overview.Model
+		out := resultCost{}
+		for i := range rows {
+			out.Usage.InputTokens += int(rows[i].InputTokens)
+			out.Usage.OutputTokens += int(rows[i].OutputTokens)
+			out.Usage.ReasoningTokens += int(rows[i].ReasoningTokens)
+			out.Usage.CacheReadTokens += int(rows[i].CacheReadTokens)
+			out.Usage.CacheWriteTokens += int(rows[i].CacheWriteTokens)
+			out.TotalUSD += rows[i].TotalCost
+			out.ProviderUSD += rows[i].ProviderCostUSD
+			if out.Model == "" {
+				out.Model = rows[i].Model
+			}
 		}
 		return out, true
 	}

--- a/pkg/cli/result_costs.go
+++ b/pkg/cli/result_costs.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/flanksource/captain/pkg/api"
 	"github.com/flanksource/captain/pkg/claude"
@@ -45,20 +46,18 @@ type resultCost struct {
 	ProviderUSD float64
 }
 
-// find returns the result captain recorded for a session identity (a provider
-// session id or captain id).
+// find returns the result Captain recorded for one Claude transcript session.
 //
-// It reports a hit only for a positive Claude CLI estimate or when the complete
-// thread carries provider-reported cost. Rows containing only Captain's
-// reconstructed buckets are not preferred over a fresh transcript parse.
-func (l *resultCostLookup) find(ctx context.Context, identity string) (resultCost, bool) {
+// Provider-attributed replacement remains per transcript, but only after a
+// complete-thread check prevents a lower-authority CLI estimate from masking a
+// provider cost on another agent. Reconstructed database buckets are not
+// preferred over a fresh transcript parse.
+func (l *resultCostLookup) find(ctx context.Context, identity, historyFile string) (resultCost, bool) {
 	if l == nil || l.db == nil || identity == "" {
 		return resultCost{}, false
 	}
-	overview, err := l.db.GetSessionOverviewByIdentity(ctx, identity)
-	// An ambiguous identity (SessionConflictError) or a plain miss both mean
-	// there is no single authoritative row to prefer.
-	if err != nil || overview == nil {
+	overview, ok := l.findClaudeTranscript(ctx, identity, historyFile)
+	if !ok {
 		return resultCost{}, false
 	}
 	rootID := overview.ID
@@ -69,29 +68,60 @@ func (l *resultCostLookup) find(ctx context.Context, identity string) (resultCos
 	if err != nil {
 		return resultCost{}, false
 	}
-	var out resultCost
-	if len(rows) > 0 {
-		out.Model = rows[0].Model
-	}
+	var threadProviderUSD float64
 	for i := range rows {
-		out.Usage.InputTokens += int(rows[i].InputTokens)
-		out.Usage.OutputTokens += int(rows[i].OutputTokens)
-		out.Usage.ReasoningTokens += int(rows[i].ReasoningTokens)
-		out.Usage.CacheReadTokens += int(rows[i].CacheReadTokens)
-		out.Usage.CacheWriteTokens += int(rows[i].CacheWriteTokens)
-		// total_cost already resolves provider-reported against list-price per
-		// underlying call (see 67_view_session_costs.sql); provider_cost_usd is
-		// how much of it the provider itself reported.
-		out.TotalUSD += rows[i].TotalCost
-		out.ProviderUSD += rows[i].ProviderCostUSD
+		threadProviderUSD += rows[i].ProviderCostUSD
 	}
-	if out.ProviderUSD > 0 {
+	if threadProviderUSD > 0 {
+		if overview.ProviderCostUSD <= 0 {
+			return resultCost{}, false
+		}
+		out := resultCost{
+			Usage: api.Usage{
+				InputTokens:      int(overview.InputTokens),
+				OutputTokens:     int(overview.OutputTokens),
+				ReasoningTokens:  int(overview.ReasoningTokens),
+				CacheReadTokens:  int(overview.CacheReadTokens),
+				CacheWriteTokens: int(overview.CacheWriteTokens),
+			},
+			TotalUSD: overview.CostUSD, ProviderUSD: overview.ProviderCostUSD,
+		}
+		if overview.Model != nil {
+			out.Model = *overview.Model
+		}
 		return out, true
 	}
 	if overview.ClaudeCLICostUSD != nil && *overview.ClaudeCLICostUSD > 0 {
 		return resultCost{TotalUSD: *overview.ClaudeCLICostUSD}, true
 	}
 	return resultCost{}, false
+}
+
+func (l *resultCostLookup) findClaudeTranscript(ctx context.Context, identity, historyFile string) (*database.SessionOverview, bool) {
+	rows, err := l.db.ListSessionOverviewsByProviderSessionID(ctx, identity)
+	if err != nil {
+		return nil, false
+	}
+	var match *database.SessionOverview
+	for i := range rows {
+		if rows[i].Source != "claude" || !overviewMatchesHistoryFile(rows[i], historyFile) {
+			continue
+		}
+		if match != nil {
+			return nil, false
+		}
+		match = &rows[i]
+	}
+	return match, match != nil
+}
+
+func overviewMatchesHistoryFile(overview database.SessionOverview, historyFile string) bool {
+	if historyFile == "" {
+		return true
+	}
+	want := filepath.Clean(historyFile)
+	return (overview.HistoryFile != nil && filepath.Clean(*overview.HistoryFile) == want) ||
+		(overview.Path != nil && filepath.Clean(*overview.Path) == want)
 }
 
 // applyResultCosts prefers stored provider-attributed calls, then a positive
@@ -107,7 +137,7 @@ func applyResultCosts(ctx context.Context, sessions []claude.SessionCost) {
 		return
 	}
 	for i := range sessions {
-		cost, ok := lookup.find(ctx, sessions[i].SessionID)
+		cost, ok := lookup.find(ctx, sessions[i].SessionID, sessions[i].HistoryFile)
 		if !ok {
 			continue
 		}

--- a/pkg/database/migration_integration_test.go
+++ b/pkg/database/migration_integration_test.go
@@ -76,7 +76,7 @@ func TestCaptainMigrationsAreIdempotentAndShareOnePool(t *testing.T) {
 	require.EqualValues(t, 1, activityTriggerCount, "session activity projection must remain installed")
 
 	for table, columns := range map[string][]string{
-		"captain_sessions":              {"id", "lifecycle_status", "activity_state", "health_state", "state_version"},
+		"captain_sessions":              {"id", "lifecycle_status", "activity_state", "health_state", "state_version", "claude_cli_cost_usd", "claude_cli_cost_observed_at"},
 		"captain_prompt_runs":           {"id", "session_id", "root_session_id", "phase", "state", "version"},
 		"captain_prompt_run_iterations": {"id", "prompt_run_id", "state"},
 		"captain_plans":                 {"id", "source_session_id", "approved_revision_id", "approval_state"},

--- a/pkg/database/session_prompt_store.go
+++ b/pkg/database/session_prompt_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -287,6 +288,34 @@ func (db *DB) CreateOrGetSession(ctx context.Context, input CreateSessionInput) 
 		}
 	}
 	return db.GetSession(ctx, existing.ID)
+}
+
+// ReportClaudeCLICost stores Claude Code's cumulative whole-session client
+// estimate without attributing it to model calls. Only a larger amount writes,
+// so unchanged refreshes and delayed lower reports are no-ops.
+func (db *DB) ReportClaudeCLICost(ctx context.Context, sessionID uuid.UUID, costUSD float64, observedAt time.Time) error {
+	if err := db.requireGorm(); err != nil {
+		return err
+	}
+	if sessionID == uuid.Nil {
+		return fmt.Errorf("%w: session ID is required", ErrInvalidSession)
+	}
+	if math.IsNaN(costUSD) || math.IsInf(costUSD, 0) || costUSD < 0 || observedAt.IsZero() {
+		return fmt.Errorf("%w: Claude CLI estimate needs a nonnegative finite amount and observation time", ErrInvalidSession)
+	}
+	observedAt = observedAt.UTC()
+	if err := db.gorm.WithContext(ctx).Model(&sessionRecord{}).
+		Where("id = ?", sessionID).
+		Where("claude_cli_cost_usd IS NULL OR claude_cli_cost_usd < ?", costUSD).
+		Updates(map[string]any{
+			"claude_cli_cost_usd": costUSD,
+			"claude_cli_cost_observed_at": gorm.Expr(
+				"GREATEST(COALESCE(claude_cli_cost_observed_at, ?), ?)", observedAt, observedAt,
+			),
+		}).Error; err != nil {
+		return fmt.Errorf("record Claude CLI session cost estimate: %w", err)
+	}
+	return nil
 }
 
 type UpdateSessionStateInput struct {

--- a/pkg/database/session_read_store.go
+++ b/pkg/database/session_read_store.go
@@ -82,12 +82,14 @@ type SessionOverview struct {
 	// ProviderCostUSD is how much of CostUSD the providers reported themselves;
 	// the bucket costs are what CostUSD otherwise falls back to. Zero provider
 	// cost means the total is a reconstruction, not a billed figure.
-	ProviderCostUSD float64 `gorm:"column:provider_cost_usd" json:"providerCostUsd,omitempty"`
-	InputCost       float64 `gorm:"column:input_cost" json:"inputCost,omitempty"`
-	OutputCost      float64 `gorm:"column:output_cost" json:"outputCost,omitempty"`
-	ReasoningCost   float64 `gorm:"column:reasoning_cost" json:"reasoningCost,omitempty"`
-	CacheReadCost   float64 `gorm:"column:cache_read_cost" json:"cacheReadCost,omitempty"`
-	CacheWriteCost  float64 `gorm:"column:cache_write_cost" json:"cacheWriteCost,omitempty"`
+	ProviderCostUSD         float64    `gorm:"column:provider_cost_usd" json:"providerCostUsd,omitempty"`
+	InputCost               float64    `gorm:"column:input_cost" json:"inputCost,omitempty"`
+	OutputCost              float64    `gorm:"column:output_cost" json:"outputCost,omitempty"`
+	ReasoningCost           float64    `gorm:"column:reasoning_cost" json:"reasoningCost,omitempty"`
+	CacheReadCost           float64    `gorm:"column:cache_read_cost" json:"cacheReadCost,omitempty"`
+	CacheWriteCost          float64    `gorm:"column:cache_write_cost" json:"cacheWriteCost,omitempty"`
+	ClaudeCLICostUSD        *float64   `gorm:"column:claude_cli_cost_usd" json:"claudeCliCostUsd,omitempty"`
+	ClaudeCLICostObservedAt *time.Time `gorm:"column:claude_cli_cost_observed_at" json:"claudeCliCostObservedAt,omitempty"`
 }
 
 func (SessionOverview) TableName() string { return "captain_session_overview" }

--- a/pkg/monitor/hookpayload.go
+++ b/pkg/monitor/hookpayload.go
@@ -34,6 +34,40 @@ func ParseClaudeHookPayload(data []byte) (HookEvent, error) {
 	}, nil
 }
 
+type claudeStatusLinePayload struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	CWD            string `json:"cwd"`
+	Cost           struct {
+		TotalCostUSD *float64 `json:"total_cost_usd"`
+	} `json:"cost"`
+}
+
+// ParseClaudeStatusLinePayload maps Claude Code's status-line stdin contract
+// onto a session-level CLI estimate. The status-line payload is the only normal
+// interactive artifact that carries Claude Code's cumulative USD estimate;
+// transcript and lifecycle-hook records do not carry it.
+func ParseClaudeStatusLinePayload(data []byte) (HookEvent, error) {
+	var payload claudeStatusLinePayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return HookEvent{}, fmt.Errorf("parse claude status-line payload: %w", err)
+	}
+	if strings.TrimSpace(payload.SessionID) == "" {
+		return HookEvent{}, fmt.Errorf("claude status-line payload has no session_id")
+	}
+	if strings.TrimSpace(payload.TranscriptPath) == "" {
+		return HookEvent{}, fmt.Errorf("claude status-line payload has no transcript_path")
+	}
+	if payload.Cost.TotalCostUSD == nil || *payload.Cost.TotalCostUSD < 0 {
+		return HookEvent{}, fmt.Errorf("claude status-line payload has no nonnegative cost.total_cost_usd")
+	}
+	return HookEvent{
+		Provider: "claude", Event: ClaudeEventStatusLine, SessionID: strings.TrimSpace(payload.SessionID),
+		TranscriptPath: payload.TranscriptPath, CWD: payload.CWD,
+		ClaudeCLICostUSD: payload.Cost.TotalCostUSD,
+	}, nil
+}
+
 // codexNotifyPayload is the JSON codex appends as the final notify argv
 // argument (codex-rs legacy_notify): kebab-case keys, one event type.
 type codexNotifyPayload struct {
@@ -68,8 +102,7 @@ func ParseCodexNotifyPayload(args []string) (HookEvent, error) {
 }
 
 // PostHookEvent delivers one hook event to a captain serve instance. Callers
-// own the context deadline; any failure is their cue to drop the event (the
-// documented degraded mode — recon reconciles missed events).
+// own the context deadline.
 func PostHookEvent(ctx context.Context, baseURL string, ev HookEvent) error {
 	body, err := json.Marshal(ev)
 	if err != nil {

--- a/pkg/monitor/hooks.go
+++ b/pkg/monitor/hooks.go
@@ -35,16 +35,19 @@ type HookEvent struct {
 	ReceivedAt       time.Time `json:"-"`
 }
 
-// NotifyHookEvent enqueues a hook event without blocking. Events are dropped
-// (with a debug log) when the buffer is full or no locked run loop is draining
-// it — hook delivery is best-effort by design; the startup/daily recon and the
-// stale-process reaper converge the database over dropped events.
+// NotifyHookEvent enqueues a hook event without blocking. Status-line refreshes
+// use a separate queue so they cannot displace lifecycle events. Events are
+// dropped when their queue is full or no locked run loop is draining it.
 func (m *Monitor) NotifyHookEvent(ev HookEvent) {
 	if ev.ReceivedAt.IsZero() {
 		ev.ReceivedAt = time.Now().UTC()
 	}
+	events := m.hookEvents
+	if ev.Event == ClaudeEventStatusLine {
+		events = m.statusLineEvents
+	}
 	select {
-	case m.hookEvents <- ev:
+	case events <- ev:
 	default:
 		log.Debugf("hook event queue full; dropping %s %s for %s", ev.Provider, ev.Event, ev.SessionID)
 	}
@@ -54,7 +57,6 @@ func (m *Monitor) NotifyHookEvent(ev HookEvent) {
 // the session and arms tailing, activity events trigger a targeted ingest, and
 // SessionEnd finalizes the transcript and closes the session's process rows.
 func (m *Monitor) handleHookEvent(ctx context.Context, watcher *transcriptWatcher, ingestor *ingestor, ev HookEvent) {
-	m.noteActivity(ev.ReceivedAt)
 	path := ev.TranscriptPath
 	if ev.Provider == "codex" && path == "" {
 		path = resolveCodexTranscript(ev.SessionID)
@@ -87,6 +89,7 @@ func (m *Monitor) handleHookEvent(ctx context.Context, watcher *transcriptWatche
 		m.recordClaudeStatusLineCost(ctx, ev, path)
 		return
 	}
+	m.noteActivity(ev.ReceivedAt)
 
 	switch ev.Event {
 	case string(claude.HookEventSessionStart):

--- a/pkg/monitor/hooks.go
+++ b/pkg/monitor/hooks.go
@@ -13,22 +13,26 @@ import (
 	"github.com/flanksource/captain/pkg/database"
 )
 
-// CodexEventTurnComplete is the only event codex's notify mechanism emits.
-const CodexEventTurnComplete = "agent-turn-complete"
+const (
+	// CodexEventTurnComplete is the only event codex's notify mechanism emits.
+	CodexEventTurnComplete = "agent-turn-complete"
+	// ClaudeEventStatusLine carries Claude Code's client-estimated session total.
+	ClaudeEventStatusLine = "StatusLine"
+)
 
-// HookEvent is one normalized real-time signal from a provider hook: a Claude
-// Code lifecycle hook (SessionStart/UserPromptSubmit/Stop/SubagentStop/
-// SessionEnd) or codex's notify agent-turn-complete. Hooks carry exact session
-// identity and transcript location, replacing ps-based discovery for sessions
-// that have them installed.
+// HookEvent is one normalized real-time signal: a Claude Code lifecycle or
+// status-line event, or codex's notify agent-turn-complete. Events carry exact
+// session identity and transcript location, replacing ps-based discovery for
+// sessions that have hooks installed.
 type HookEvent struct {
-	Provider       string    `json:"provider,omitempty"` // claude | codex
-	Event          string    `json:"event"`
-	SessionID      string    `json:"sessionId,omitempty"` // provider session id / codex thread id
-	TranscriptPath string    `json:"transcriptPath,omitempty"`
-	CWD            string    `json:"cwd,omitempty"`
-	Detail         string    `json:"detail,omitempty"` // SessionStart source / SessionEnd reason
-	ReceivedAt     time.Time `json:"-"`
+	Provider         string    `json:"provider,omitempty"` // claude | codex
+	Event            string    `json:"event"`
+	SessionID        string    `json:"sessionId,omitempty"` // provider session id / codex thread id
+	TranscriptPath   string    `json:"transcriptPath,omitempty"`
+	CWD              string    `json:"cwd,omitempty"`
+	Detail           string    `json:"detail,omitempty"` // SessionStart source / SessionEnd reason
+	ClaudeCLICostUSD *float64  `json:"claudeCliCostUsd,omitempty"`
+	ReceivedAt       time.Time `json:"-"`
 }
 
 // NotifyHookEvent enqueues a hook event without blocking. Events are dropped
@@ -79,6 +83,10 @@ func (m *Monitor) handleHookEvent(ctx context.Context, watcher *transcriptWatche
 			return
 		}
 	}
+	if ev.Event == ClaudeEventStatusLine {
+		m.recordClaudeStatusLineCost(ctx, ev, path)
+		return
+	}
 
 	switch ev.Event {
 	case string(claude.HookEventSessionStart):
@@ -114,6 +122,31 @@ func (m *Monitor) handleHookEvent(ctx context.Context, watcher *transcriptWatche
 				log.Warnf("hook %s/%s: ingest %s: %v", ev.Provider, ev.Event, path, err)
 			}
 		}
+	}
+}
+
+// recordClaudeStatusLineCost persists Claude Code's whole-session client
+// estimate at session scope. The server derives the source and observation time
+// rather than accepting either from the unauthenticated localhost payload.
+func (m *Monitor) recordClaudeStatusLineCost(ctx context.Context, ev HookEvent, path string) {
+	if ev.Provider != "claude" || ev.SessionID == "" || path == "" || ev.ClaudeCLICostUSD == nil {
+		log.Warnf("hook %s/%s: session ID, transcript path, and CLI cost estimate are required", ev.Provider, ev.Event)
+		return
+	}
+	session, err := m.db.CreateOrGetSession(ctx, database.CreateSessionInput{
+		ProviderSessionID: ev.SessionID, Source: ev.Provider, HostID: m.cfg.HostID,
+		CWD: ev.CWD, Path: path,
+	})
+	if err != nil {
+		log.Warnf("hook claude/%s: bind session %s: %v", ev.Event, ev.SessionID, err)
+		return
+	}
+	observedAt := ev.ReceivedAt.UTC()
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	if err := m.db.ReportClaudeCLICost(ctx, session.ID, *ev.ClaudeCLICostUSD, observedAt); err != nil {
+		log.Warnf("hook claude/%s: record session %s CLI cost estimate: %v", ev.Event, ev.SessionID, err)
 	}
 }
 

--- a/pkg/monitor/hooks_integration_test.go
+++ b/pkg/monitor/hooks_integration_test.go
@@ -36,24 +36,61 @@ func TestHookEventsDriveIngest(t *testing.T) {
 		assert.Equal(t, "claude", m.trackedPaths()[path])
 	})
 
-	t.Run("Stop ingests the transcript", func(t *testing.T) {
+	t.Run("StatusLine estimate advances without refresh churn and survives re-ingest", func(t *testing.T) {
+		observedAt := time.Now().UTC()
+		payload := []byte(`{"session_id":"` + fixtureSessionID + `","transcript_path":"` + path +
+			`","cwd":"` + fixtureCWD + `","cost":{"total_cost_usd":0.12345678}}`)
+		event, err := ParseClaudeStatusLinePayload(payload)
+		require.NoError(t, err)
+		event.ReceivedAt = observedAt
+		m.handleHookEvent(t.Context(), watcher, ingestor, event)
+		event.ReceivedAt = observedAt.Add(time.Second)
+		m.handleHookEvent(t.Context(), watcher, ingestor, event)
+
+		lower := []byte(`{"session_id":"` + fixtureSessionID + `","transcript_path":"` + path +
+			`","cwd":"` + fixtureCWD + `","cost":{"total_cost_usd":0.1}}`)
+		event, err = ParseClaudeStatusLinePayload(lower)
+		require.NoError(t, err)
+		event.ReceivedAt = observedAt.Add(time.Second)
+		m.handleHookEvent(t.Context(), watcher, ingestor, event)
+
+		m.handleHookEvent(t.Context(), watcher, ingestor, HookEvent{
+			Provider: "claude", Event: "Stop", SessionID: fixtureSessionID,
+			TranscriptPath: path, CWD: fixtureCWD, ReceivedAt: time.Now().UTC(),
+		})
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		require.NoError(t, err)
+		_, err = f.WriteString(fixtureAppendLine)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
 		m.handleHookEvent(t.Context(), watcher, ingestor, HookEvent{
 			Provider: "claude", Event: "Stop", SessionID: fixtureSessionID,
 			TranscriptPath: path, CWD: fixtureCWD, ReceivedAt: time.Now().UTC(),
 		})
 		overview, err := db.GetSessionOverviewByIdentity(t.Context(), fixtureSessionID)
 		require.NoError(t, err)
-		assert.EqualValues(t, 2, overview.MessageCount)
+		assert.EqualValues(t, 3, overview.MessageCount)
+		require.NotNil(t, overview.ClaudeCLICostUSD)
+		assert.InDelta(t, 0.12345678, *overview.ClaudeCLICostUSD, 1e-9,
+			"unchanged and delayed lower estimates plus transcript re-ingest must not move the session backwards")
+		require.NotNil(t, overview.ClaudeCLICostObservedAt)
+		assert.WithinDuration(t, observedAt, *overview.ClaudeCLICostObservedAt, time.Millisecond,
+			"an unchanged estimate must not churn its observation timestamp")
+		assert.Zero(t, overview.ProviderCostUSD, "a session estimate must not become per-call provider cost")
 	})
 
 	t.Run("transcript outside the provider root is rejected", func(t *testing.T) {
+		outsideCost := 0.9
 		m.handleHookEvent(t.Context(), watcher, ingestor, HookEvent{
-			Provider: "claude", Event: "Stop", SessionID: fixtureSessionID,
-			TranscriptPath: "/etc/passwd", ReceivedAt: time.Now().UTC(),
+			Provider: "claude", Event: ClaudeEventStatusLine, SessionID: fixtureSessionID,
+			TranscriptPath: "/etc/passwd", ClaudeCLICostUSD: &outsideCost, ReceivedAt: time.Now().UTC(),
 		})
 		overview, err := db.GetSessionOverviewByIdentity(t.Context(), fixtureSessionID)
 		require.NoError(t, err)
-		assert.EqualValues(t, 2, overview.MessageCount, "rejected path must not ingest")
+		assert.EqualValues(t, 3, overview.MessageCount, "rejected path must not ingest")
+		require.NotNil(t, overview.ClaudeCLICostUSD)
+		assert.InDelta(t, 0.12345678, *overview.ClaudeCLICostUSD, 1e-9, "rejected path must not update cost")
 	})
 
 	t.Run("SessionEnd closes the session's process rows and untracks", func(t *testing.T) {

--- a/pkg/monitor/hooks_test.go
+++ b/pkg/monitor/hooks_test.go
@@ -26,11 +26,25 @@ func TestNextPollInterval(t *testing.T) {
 }
 
 func TestNotifyHookEventNeverBlocks(t *testing.T) {
-	m := &Monitor{cfg: Config{ProcessInterval: 5 * time.Second, IdleProcessInterval: time.Minute}, hookEvents: make(chan HookEvent, 2)}
-	for range 5 {
-		m.NotifyHookEvent(HookEvent{Provider: "claude", Event: "Stop", SessionID: "s"})
+	m := &Monitor{
+		cfg:        Config{ProcessInterval: 5 * time.Second, IdleProcessInterval: time.Minute},
+		hookEvents: make(chan HookEvent, 2), statusLineEvents: make(chan HookEvent, 2),
 	}
-	assert.Len(t, m.hookEvents, 2, "overflow events must be dropped, not block")
+	for range 5 {
+		m.NotifyHookEvent(HookEvent{Provider: "claude", Event: ClaudeEventStatusLine, SessionID: "s"})
+	}
+	m.NotifyHookEvent(HookEvent{Provider: "claude", Event: "Stop", SessionID: "s"})
+	assert.Len(t, m.statusLineEvents, 2, "overflow events must be dropped, not block")
+	assert.Len(t, m.hookEvents, 1, "status-line refreshes must not displace lifecycle events")
+}
+
+func TestStatusLineDoesNotCountAsActivity(t *testing.T) {
+	lastActivity := time.Now().Add(-activityWindow - time.Second)
+	m := &Monitor{lastActivity: lastActivity}
+
+	m.handleHookEvent(t.Context(), nil, nil, HookEvent{Provider: "claude", Event: ClaudeEventStatusLine})
+
+	assert.Equal(t, lastActivity, m.lastActivity)
 }
 
 func TestWithinHookRoot(t *testing.T) {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -58,7 +58,7 @@ type Config struct {
 }
 
 // activityWindow is how long after the last observed session activity (agent
-// process seen, hook event received) the process poll stays on the fast cadence.
+// process seen, lifecycle hook received) the process poll stays on the fast cadence.
 const activityWindow = 2 * time.Minute
 
 type Monitor struct {
@@ -68,7 +68,8 @@ type Monitor struct {
 	mu      sync.Mutex
 	tracked map[string]string // transcript path -> source kind, the live tail set
 
-	hookEvents chan HookEvent
+	hookEvents       chan HookEvent
+	statusLineEvents chan HookEvent
 
 	activityMu   sync.Mutex
 	lastActivity time.Time
@@ -107,13 +108,14 @@ func New(cfg Config) (*Monitor, error) {
 	}
 	return &Monitor{
 		cfg: cfg, db: cfg.DB, tracked: map[string]string{},
-		hookEvents: make(chan HookEvent, 128),
-		ready:      make(chan struct{}),
+		hookEvents:       make(chan HookEvent, 128),
+		statusLineEvents: make(chan HookEvent, 128),
+		ready:            make(chan struct{}),
 	}, nil
 }
 
 // noteActivity records session activity: an agent process observed by the
-// poll or a hook event. It keeps the process poll on the fast cadence.
+// poll or a lifecycle hook. It keeps the process poll on the fast cadence.
 func (m *Monitor) noteActivity(at time.Time) {
 	if at.IsZero() {
 		at = time.Now().UTC()
@@ -279,6 +281,8 @@ func (m *Monitor) runLocked(ctx context.Context, lock *sql.Conn) error {
 			if wasIdle {
 				processTicker.Reset(m.cfg.ProcessInterval)
 			}
+		case ev := <-m.statusLineEvents:
+			m.handleHookEvent(runCtx, watcher, ingestor, ev)
 		case <-backfillTicker.C:
 			m.maintenanceDue.Store(true)
 			requestBackfill(backfillRequests)


### PR DESCRIPTION
Claude monitored histories do not contain monetary result records, but the opt-in status-line payload exposes Claude Code's cumulative `total_cost_usd` client estimate.

Add `--capture-cost` to compose with the existing status line using a short best-effort delivery deadline. Persist the estimate monotonically at session scope and display it distinctly from Captain list-price reconstruction.

Provider-attributed call costs remain higher priority, and the CLI estimate is never written to per-call `provider_cost_usd`.

resolves: https://github.com/flanksource/captain/issues/78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Claude Code session cost capture during monitor hook installation.
  - Cost estimates are stored and included in session overviews and cost reports.
  - Cost reports now identify whether totals are provider-reported, Claude-estimated, mixed, or allocated.
  - Existing Claude status lines are preserved and extended when compatible.

- **Bug Fixes**
  - Hook installation now updates existing Captain hooks instead of creating duplicates.
  - Improved handling of conflicting status-line settings and stale installations.

- **Documentation**
  - Updated quick-start guidance for installation, cost capture, and estimate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->