### PR TITLE
perf(database): reduce transcript ingest write amplification

### DIFF
--- a/migrations/52_session_activity_triggers.sql
+++ b/migrations/52_session_activity_triggers.sql
@@ -22,6 +22,12 @@ DROP TRIGGER IF EXISTS captain_session_sources_emit_after ON public.captain_sess
 DROP FUNCTION IF EXISTS public.captain_emit_session_change();
 DROP FUNCTION IF EXISTS public.captain_notify_outbox();
 
+-- Measured with track_functions = 'pl' on embedded PostgreSQL 16: ingesting
+-- 10,000 messages with 8 KiB parts spent 285 ms in this function when it used
+-- to_jsonb(NEW), versus 115 ms with direct field access. captain_sessions had
+-- one tuple update in both runs because ingest projects the transcript maximum
+-- before writing child rows; the measured amplification was trigger CPU, not
+-- physical session-row updates.
 CREATE OR REPLACE FUNCTION public.captain_touch_session_activity()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -29,7 +35,6 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public
 AS $$
 DECLARE
-  row_data jsonb := to_jsonb(NEW);
   session_id_value uuid;
   agent_activity_at timestamptz;
 BEGIN
@@ -43,30 +48,41 @@ BEGIN
     RETURN NEW;
   END IF;
 
+  -- Only timestamps that represent agent work can advance last_activity_at.
+  -- Write-time fallbacks would make replayed historical sessions look active
+  -- and the monotonic projection could never correct them.
   CASE TG_TABLE_NAME
     WHEN 'captain_prompt_run_iterations' THEN
       SELECT r.session_id
         INTO session_id_value
         FROM public.captain_prompt_runs r
-       WHERE r.id = NULLIF(row_data ->> 'prompt_run_id', '')::uuid;
+       WHERE r.id = NEW.prompt_run_id;
+      agent_activity_at := NEW.started_at;
     WHEN 'captain_model_calls' THEN
       SELECT t.session_id
         INTO session_id_value
         FROM public.captain_turns t
-       WHERE t.id = NULLIF(row_data ->> 'turn_id', '')::uuid;
-    ELSE
-      session_id_value := NULLIF(row_data ->> 'session_id', '')::uuid;
+       WHERE t.id = NEW.turn_id;
+      agent_activity_at := NEW.started_at;
+    WHEN 'captain_messages' THEN
+      session_id_value := NEW.session_id;
+      agent_activity_at := NEW.occurred_at;
+    WHEN 'captain_turns' THEN
+      session_id_value := NEW.session_id;
+      agent_activity_at := NEW.started_at;
+    WHEN 'captain_turn_requests' THEN
+      session_id_value := NEW.session_id;
+      agent_activity_at := NEW.resolved_at;
+    WHEN 'captain_events' THEN
+      session_id_value := NEW.session_id;
+      agent_activity_at := NEW.occurred_at;
+    WHEN 'captain_prompt_runs' THEN
+      session_id_value := NEW.session_id;
+      agent_activity_at := NEW.started_at;
+    WHEN 'captain_artifacts' THEN
+      session_id_value := NEW.session_id;
+      agent_activity_at := NEW.occurred_at;
   END CASE;
-
-  -- Only timestamps that represent agent work can advance last_activity_at.
-  -- Write-time fallbacks would make replayed historical sessions look active
-  -- and the monotonic projection could never correct them.
-  agent_activity_at := COALESCE(
-    NULLIF(row_data ->> 'occurred_at', '')::timestamptz,
-    NULLIF(row_data ->> 'state_observed_at', '')::timestamptz,
-    NULLIF(row_data ->> 'started_at', '')::timestamptz,
-    NULLIF(row_data ->> 'resolved_at', '')::timestamptz
-  );
 
   -- Keep this as an allowlist: host telemetry, ingest bookkeeping, and any new
   -- table without an explicit activity contract must not affect idle checks.

--- a/migrations/72_ingest_storage_params.sql
+++ b/migrations/72_ingest_storage_params.sql
@@ -4,11 +4,12 @@
 -- autovacuum defaults never deliver, and two of the three are update-churned
 -- rather than append-only.
 --
--- captain_messages is written once per row and never updated: insertMessages
--- upserts with ON CONFLICT DO NOTHING. Its default fillfactor of 100 is
--- therefore correct -- there are no updates to keep HOT, and dense pages are
--- what an append-only table wants. What it does need is a far tighter
--- insert-driven vacuum. autovacuum_vacuum_insert_scale_factor defaults to 0.2,
+-- insertMessages first uses ON CONFLICT DO NOTHING, then convergeMessages
+-- updates only rows whose transcript-derived fields actually changed. Those
+-- exceptional updates do not justify reserving space on every heap page, so
+-- captain_messages keeps the dense default fillfactor of 100. It does need a
+-- far tighter insert-driven vacuum. autovacuum_vacuum_insert_scale_factor
+-- defaults to 0.2,
 -- so on a measured 714,045-row table roughly 143,000 new rows must accumulate
 -- before an insert vacuum fires -- about two weeks at the observed ~10,000
 -- messages/day. Across that window the visibility map rots, and because
@@ -21,10 +22,10 @@
 -- restored the map the same plan reported Heap Fetches: 2 and shared hit=2,029
 -- -- 5.7x fewer buffers for an identical result.
 --
--- captain_turns and captain_model_calls are a different shape. upsertTurns and
--- the model-call upsert both use ON CONFLICT DO UPDATE, and a live session is
--- re-ingested each time its transcript grows, so every turn already persisted
--- is rewritten on every pass. That is update churn, not appends, and it showed:
+-- captain_turns and captain_model_calls are a different shape. Their running
+-- aggregates genuinely change while a transcript grows, and before guarded
+-- upserts were introduced every persisted row was also rewritten on replay.
+-- That update churn showed:
 -- captain_turns sat at 26.9% and captain_model_calls at 38.6% all-visible page
 -- coverage. These two get fillfactor to keep the repeated rewrites HOT, the
 -- same reasoning as 71_session_storage_params.sql, plus the tightened insert

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -137,11 +137,10 @@ func TestSchemaBundleContainsGavelIntegrationContract(t *testing.T) {
 		"autovacuum_vacuum_scale_factor = 0.02",
 	)
 	assertContainsNone(t, "10_sessions.pg.hcl", "fillfactor", "autovacuum_")
-	// captain_messages is append-only (ON CONFLICT DO NOTHING), so it keeps the
-	// dense default fillfactor and only tightens the insert-driven vacuum that
-	// keeps its visibility map -- and therefore its index-only scans -- intact.
-	// captain_turns and captain_model_calls are re-upserted on every re-ingest
-	// pass, so they need in-page room for HOT updates as well.
+	// captain_messages keeps the dense default fillfactor because convergence
+	// updates are exceptional and guarded. Its insert-driven vacuum keeps the
+	// visibility map -- and therefore index-only scans -- intact. Turns and
+	// model calls still need in-page room for genuinely changing aggregates.
 	assertContainsAll(t, "72_ingest_storage_params.sql",
 		"-- phase: post",
 		"ALTER TABLE public.captain_messages SET (",
@@ -150,7 +149,7 @@ func TestSchemaBundleContainsGavelIntegrationContract(t *testing.T) {
 		"autovacuum_vacuum_insert_scale_factor = 0.02",
 	)
 	assertContainsNone(t, "72_ingest_storage_params.sql",
-		// An append-only table gains nothing from reserved in-page space.
+		// Exceptional convergence updates do not justify reserved in-page space.
 		"ALTER TABLE public.captain_messages SET (\n  fillfactor",
 	)
 	assertContainsNone(t, "30_execution.pg.hcl", "fillfactor", "autovacuum_")

--- a/pkg/database/session_ingest_store.go
+++ b/pkg/database/session_ingest_store.go
@@ -406,22 +406,42 @@ func (db *DB) upsertTurns(ctx context.Context, sessionID uuid.UUID, turns []Inge
 	if err != nil || len(records) == 0 {
 		return ids, err
 	}
-	// RETURNING carries turn_index back beside the ID, so the map is keyed from
-	// each row's own index rather than from the order PostgreSQL returns them.
-	err = db.gorm.WithContext(ctx).Clauses(
-		clause.OnConflict{
-			Columns: []clause.Column{{Name: "session_id"}, {Name: "turn_index"}},
-			DoUpdates: clause.AssignmentColumns([]string{
-				"provider_turn_id", "description", "status", "stop_reason", "started_at", "ended_at",
-			}),
-		},
-		clause.Returning{Columns: []clause.Column{{Name: "id"}, {Name: "turn_index"}}},
-	).CreateInBatches(&records, ingestBatchSize).Error
+	err = db.gorm.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "session_id"}, {Name: "turn_index"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"provider_turn_id", "description", "status", "stop_reason", "started_at", "ended_at",
+		}),
+		Where: clause.Where{Exprs: []clause.Expression{clause.Expr{SQL: `
+			(captain_turns.provider_turn_id, captain_turns.description, captain_turns.status,
+			 captain_turns.stop_reason, captain_turns.started_at, captain_turns.ended_at)
+			IS DISTINCT FROM
+			(excluded.provider_turn_id, excluded.description, excluded.status,
+			 excluded.stop_reason, excluded.started_at, excluded.ended_at)`}}},
+	}).CreateInBatches(&records, ingestBatchSize).Error
 	if err != nil {
 		return nil, fmt.Errorf("upsert %d Captain turns: %w", len(records), err)
 	}
-	for _, record := range records {
-		ids[record.TurnIndex] = record.ID
+
+	// PostgreSQL does not return conflicts skipped by the no-op guard, so resolve
+	// both inserted and existing IDs after the upsert.
+	for start := 0; start < len(records); start += ingestBatchSize {
+		batch := records[start:min(start+ingestBatchSize, len(records))]
+		indices := make([]int, len(batch))
+		for i, record := range batch {
+			indices[i] = record.TurnIndex
+		}
+		var persisted []turnRecord
+		if err := db.gorm.WithContext(ctx).Select("id", "turn_index").
+			Where("session_id = ? AND turn_index IN ?", sessionID, indices).
+			Find(&persisted).Error; err != nil {
+			return nil, fmt.Errorf("resolve Captain turn IDs: %w", err)
+		}
+		for _, record := range persisted {
+			ids[record.TurnIndex] = record.ID
+		}
+	}
+	if len(ids) != len(records) {
+		return nil, fmt.Errorf("resolve Captain turn IDs: got %d of %d", len(ids), len(records))
 	}
 
 	calls := make([]modelCallRecord, 0, len(turns))

--- a/pkg/database/session_message_ingest.go
+++ b/pkg/database/session_message_ingest.go
@@ -24,6 +24,22 @@ func (db *DB) upsertTurnCalls(ctx context.Context, calls []modelCallRecord) erro
 			"input_cost", "output_cost", "reasoning_cost", "cache_read_cost", "cache_write_cost", "currency",
 			"started_at", "ended_at",
 		}),
+		Where: clause.Where{Exprs: []clause.Expression{clause.Expr{SQL: `
+			(captain_model_calls.model, captain_model_calls.backend, captain_model_calls.effort,
+			 captain_model_calls.stop_reason, captain_model_calls.input_tokens, captain_model_calls.output_tokens,
+			 captain_model_calls.reasoning_tokens, captain_model_calls.cache_read_tokens,
+			 captain_model_calls.cache_write_tokens, captain_model_calls.context_tokens,
+			 captain_model_calls.context_window_tokens, captain_model_calls.input_cost,
+			 captain_model_calls.output_cost, captain_model_calls.reasoning_cost,
+			 captain_model_calls.cache_read_cost, captain_model_calls.cache_write_cost,
+			 captain_model_calls.currency, captain_model_calls.started_at, captain_model_calls.ended_at)
+			IS DISTINCT FROM
+			(excluded.model, excluded.backend, excluded.effort, excluded.stop_reason,
+			 excluded.input_tokens, excluded.output_tokens, excluded.reasoning_tokens,
+			 excluded.cache_read_tokens, excluded.cache_write_tokens, excluded.context_tokens,
+			 excluded.context_window_tokens, excluded.input_cost, excluded.output_cost,
+			 excluded.reasoning_cost, excluded.cache_read_cost, excluded.cache_write_cost,
+			 excluded.currency, excluded.started_at, excluded.ended_at)`}}},
 	}).CreateInBatches(&calls, ingestBatchSize).Error
 	if err != nil {
 		return fmt.Errorf("upsert %d Captain model calls: %w", len(calls), err)


### PR DESCRIPTION
Large transcript ingests invoked the session activity trigger once per message and serialized each full row, including JSONB parts. Replays also rewrote unchanged turn and model-call aggregates.

Read activity fields directly, guard conflict updates with IS DISTINCT FROM, and resolve turn IDs after guarded upserts. Record the measured trigger cost and correct the message storage rationale.

closes: https://github.com/flanksource/captain/issues/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary database writes when session turns and model call details have not changed.
  * Improved replay and ingestion efficiency by preventing unchanged records from being rewritten.
* **Reliability**
  * Improved session activity tracking across prompts, iterations, model calls, messages, turns, requests, events, and artifacts.
  * Added safeguards to ensure ingested records remain correctly associated with their persisted IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->