### PR TITLE
fix(ui): use Clicky 0.3.25 tool mode prop

### DIFF
--- a/pkg/cli/webapp/src/ChatLayer.tsx
+++ b/pkg/cli/webapp/src/ChatLayer.tsx
@@ -27,7 +27,7 @@ export function ChatLayer() {
         sessionsApi="/api/chat/sessions"
         runtimesApi="/api/chat/runtimes"
         tools={tools}
-        defaultToolPolicy="auto"
+        defaultToolMode="auto"
         chat={{
           api: "/api/chat",
           modelsApi: "/api/chat/models",


### PR DESCRIPTION
Captain’s permission vocabulary refactor renamed ChatWindowLayer’s defaultToolMode prop to defaultToolPolicy, but the pinned Clicky UI 0.3.25 release does not expose the new prop. This causes the frontend TypeScript build to fail.

Continue using defaultToolMode until Captain upgrades to a Clicky release containing the renamed API. This restores frozen-lockfile UI builds without changing dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the chat window’s default tool configuration to use automatic mode correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->