### PR TITLE
fix(ai): disable GPT-5.6 reasoning for Chat Completions tools

### DIFF
--- a/pkg/ai/provider/genkit/options.go
+++ b/pkg/ai/provider/genkit/options.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/flanksource/captain/pkg/ai"
 	captools "github.com/flanksource/captain/pkg/ai/tools"
@@ -113,7 +114,15 @@ func generateOptions(p *Provider, req ai.Request, stream gkai.ModelStreamCallbac
 	if modelToken == "" {
 		modelToken = req.ID
 	}
-	if cfg := ai.EffortConfig(p.backend, modelToken, req.Effort, req.Budget.MaxTokens, req.Temperature); cfg != nil {
+	cfg := ai.EffortConfig(p.backend, modelToken, req.Effort, req.Budget.MaxTokens, req.Temperature)
+	model := bareModel(modelToken)
+	if p.backend == ai.BackendOpenAI && len(toolOptions) > 0 && (model == "gpt-5.6" || strings.HasPrefix(model, "gpt-5.6-")) {
+		if cfg == nil {
+			cfg = map[string]any{}
+		}
+		cfg["reasoning_effort"] = "none"
+	}
+	if cfg != nil {
 		opts = append(opts, gkai.WithConfig(cfg))
 	}
 	if stream != nil {


### PR DESCRIPTION
Captain's direct OpenAI API backend uses Genkit's Chat Completions transport. GPT-5.6 rejects that endpoint's combination of function tools and non-none reasoning effort.

When effective caller tools are attached to any GPT-5.6 model, send `reasoning_effort: "none"`. Tool-free requests, older models, and Codex's Responses-based runtimes keep their configured effort.

Closes #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling for OpenAI GPT-5.6 models that use tools.
  * Ensured these models receive the appropriate reasoning-effort setting for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->