### PR TITLE
fix: restore dark mode foreground colors

### DIFF
--- a/pkg/cli/webapp/src/index.css
+++ b/pkg/cli/webapp/src/index.css
@@ -10,8 +10,8 @@ body,
 
 body {
   margin: 0;
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
+  background: var(--background);
+  color: var(--foreground);
 }
 
 button,


### PR DESCRIPTION
Captain wrapped Clicky UI’s complete theme colors in `hsl(...)`, producing invalid computed foreground and background values. In dark mode, inherited text rendered black and the transparent canvas exposed a white strip.

Use the theme variables directly so provider configuration and the deploy-agent modal inherit the correct colors in both themes.

Fixes #86

## Screenshots

### AI provider configuration

![Captain Whoami page in dark mode](https://ampcode.com/user-content/artifacts/74f32c9a4a4bedf9ce418d1fbb514c8fa710a8d4d3eeca9dcf798b61e7422b4b-file.png)

### Deploy agent form

![Captain deploy-agent form in dark mode](https://ampcode.com/user-content/artifacts/dd26f8bc0489c55b53d6d36eb51d08c8ea22f3acb481c507a4b3ce8e5a0d0ccc-file.png)