### PR TITLE
perf(monitor): make Codex transcript ingestion incremental

### DIFF
--- a/pkg/ai/history/codex_events.go
+++ b/pkg/ai/history/codex_events.go
@@ -178,42 +178,67 @@ type codexChatSlot struct {
 	families map[string]struct{}
 }
 
-// dedupeCodexToolUses folds each message's twin records into a single row.
-// Codex logs the same logical message twice, once as an event_msg and once as
-// a response_item, milliseconds to hours apart -- so the twins cannot be
-// matched on timestamp, only on content plus adjacency.
-//
-// records holds one entry per source record in emission order. Only the
-// immediately preceding record is a merge candidate, so any intervening chat
-// content keeps two identical messages apart.
-func dedupeCodexToolUses(records [][]ToolUse) []ToolUse {
-	var output []ToolUse
-	var previous map[string]*codexChatSlot
-	for _, record := range records {
-		current := make(map[string]*codexChatSlot, len(record))
-		for _, use := range record {
-			key, ok := codexChatDedupeKey(use)
-			if !ok {
-				output = append(output, use)
-				continue
-			}
-			if slot := mergeCodexTwin(output, previous[key], use); slot != nil {
-				current[key] = slot
-				continue
-			}
-			output = append(output, use)
-			current[key] = &codexChatSlot{
-				index:    len(output) - 1,
-				priority: codexRecordPriority(use.RecordType),
-				families: map[string]struct{}{codexRecordFamily(use.RecordType): {}},
-			}
-		}
-		previous = current
+// codexDeduper folds each message's twin records into a single row while
+// retaining only the unresolved output suffix. A live parser keeps this value
+// across appends; rows before the earliest slot are final and can be released.
+type codexDeduper struct {
+	pending  []ToolUse
+	previous map[string]*codexChatSlot
+}
+
+// push consumes one emitting source record and returns the prefix that can no
+// longer be changed by a twin in a later record.
+func (d *codexDeduper) push(record []ToolUse) []ToolUse {
+	if len(record) == 0 {
+		return nil
 	}
-	// The final chat record can still be followed by its twin when a live
-	// transcript grows. Keep it below the ingest high-water mark until another
-	// emitting record proves that boundary final.
-	for _, slot := range previous {
+	current := make(map[string]*codexChatSlot, len(record))
+	for _, use := range record {
+		key, ok := codexChatDedupeKey(use)
+		if !ok {
+			d.pending = append(d.pending, use)
+			continue
+		}
+		if slot := mergeCodexTwin(d.pending, d.previous[key], use); slot != nil {
+			current[key] = slot
+			continue
+		}
+		d.pending = append(d.pending, use)
+		current[key] = &codexChatSlot{
+			index:    len(d.pending) - 1,
+			priority: codexRecordPriority(use.RecordType),
+			families: map[string]struct{}{codexRecordFamily(use.RecordType): {}},
+		}
+	}
+	d.previous = current
+
+	frontier := len(d.pending)
+	for _, slot := range d.previous {
+		if slot.index < frontier {
+			frontier = slot.index
+		}
+	}
+	if frontier == 0 {
+		return nil
+	}
+	settled := d.pending[:frontier:frontier]
+	if frontier == len(d.pending) {
+		d.pending = nil
+		return settled
+	}
+	d.pending = d.pending[frontier:]
+	for _, slot := range d.previous {
+		slot.index -= frontier
+	}
+	return settled
+}
+
+// snapshot returns the unresolved suffix as it should look at the current EOF.
+// Only slots from the final emitting record are provisional; unrelated rows can
+// be retained behind one for ordering without pretending their content may grow.
+func (d *codexDeduper) snapshot() []ToolUse {
+	output := append([]ToolUse(nil), d.pending...)
+	for _, slot := range d.previous {
 		output[slot.index].Provisional = true
 	}
 	return output

--- a/pkg/ai/history/codex_events.go
+++ b/pkg/ai/history/codex_events.go
@@ -210,6 +210,12 @@ func dedupeCodexToolUses(records [][]ToolUse) []ToolUse {
 		}
 		previous = current
 	}
+	// The final chat record can still be followed by its twin when a live
+	// transcript grows. Keep it below the ingest high-water mark until another
+	// emitting record proves that boundary final.
+	for _, slot := range previous {
+		output[slot.index].Provisional = true
+	}
 	return output
 }
 
@@ -226,7 +232,9 @@ func mergeCodexTwin(output []ToolUse, slot *codexChatSlot, use ToolUse) *codexCh
 		return nil
 	}
 	if priority := codexRecordPriority(use.RecordType); priority > slot.priority {
+		firstLine := output[slot.index].SourceLine
 		output[slot.index] = use
+		output[slot.index].SourceLine = firstLine
 		slot.priority = priority
 	}
 	slot.families[family] = struct{}{}

--- a/pkg/ai/history/codex_parser.go
+++ b/pkg/ai/history/codex_parser.go
@@ -260,20 +260,22 @@ func ExtractCodexToolUsesFromReader(reader io.Reader) ([]ToolUse, error) {
 			add(extractLiveError(event, sessionCWD, sessionID))
 		}
 	}
-	// Everything flushed past this point is provisional: the transcript is still
-	// being appended to, so the span can grow and the unpaired call will get its
-	// output on a later pass. Ingest must keep re-offering these rows -- sealing
-	// them here is what left 21% of Codex tool parts with no result forever.
+	// EOF snapshots are provisional but are not source records. Feeding them
+	// through dedupe would make a synthetic pending row close the real final chat
+	// boundary, even though no appended transcript record did so.
+	var provisional []ToolUse
 	if reasoning.pending() {
-		add(asProvisional(reasoning.flush()))
+		snapshot := reasoning
+		provisional = append(provisional, stamp(asProvisional(snapshot.flush()))...)
 	}
 	for _, call := range sortedCodexPendingCalls(pendingCall) {
-		add(asProvisional(withSourceLine(buildPendingCallUses(call.event, sessionCWD, sessionID), call.line)))
+		provisional = append(provisional,
+			stamp(asProvisional(withSourceLine(buildPendingCallUses(call.event, sessionCWD, sessionID), call.line)))...)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	return dedupeCodexToolUses(records), nil
+	return append(dedupeCodexToolUses(records), provisional...), nil
 }
 
 // buildPendingCallUses builds the provisional row for a call whose output never

--- a/pkg/ai/history/codex_parser.go
+++ b/pkg/ai/history/codex_parser.go
@@ -15,8 +15,15 @@ import (
 
 func ParseCodexLine(line string) (CodexEvent, error) {
 	var event CodexEvent
-	err := json.Unmarshal([]byte(line), &event)
+	err := parseCodexLineInto(&event, line)
 	return event, err
+}
+
+// parseCodexLineInto resets caller-owned storage before decoding so fields
+// omitted by the next record cannot leak across lines.
+func parseCodexLineInto(event *CodexEvent, line string) error {
+	*event = CodexEvent{}
+	return json.Unmarshal([]byte(line), event)
 }
 
 func ExtractCodexToolUses(sessionFile string) ([]ToolUse, error) {
@@ -200,14 +207,14 @@ func ExtractCodexToolUsesFromReader(reader io.Reader) ([]ToolUse, error) {
 		records = append(records, stamp(uses))
 	}
 
+	var event CodexEvent
 	for scanner.Scan() {
 		lineNumber++
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
-		event, err := ParseCodexLine(line)
-		if err != nil {
+		if err := parseCodexLineInto(&event, line); err != nil {
 			log.Debugf("Error parsing codex line: %v", err)
 			continue
 		}

--- a/pkg/ai/history/codex_parser.go
+++ b/pkg/ai/history/codex_parser.go
@@ -167,115 +167,178 @@ func IsCodexAutoReviewModel(model string) bool {
 	return strings.EqualFold(strings.TrimSpace(model), api.CodexAutoReviewModel)
 }
 
-func ExtractCodexToolUsesFromReader(reader io.Reader) ([]ToolUse, error) {
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+// CodexParser retains the minimum rollout state needed to parse records added
+// after a known file offset. Call Snapshot after each append to project rows
+// that are valid at the current EOF but may still change on the next append.
+type CodexParser struct {
+	sessionCWD    string
+	sessionID     string
+	currentTurn   string
+	currentModel  string
+	currentEffort string
+	pendingCall   map[string]codexPendingCall
+	reasoning     codexReasoningCollapser
+	deduper       codexDeduper
+	info          *CodexSessionInfo
+	event         CodexEvent
+	lineNumber    int64
+	ignored       bool
+}
 
-	// records holds the uses of one source record per entry, in emission order.
-	// Dedupe needs those boundaries to merge a message's twin records: the
-	// boundary cannot be recovered afterwards, because distinct adjacent records
-	// routinely share a RecordType and a millisecond.
-	var records [][]ToolUse
-	var sessionCWD, sessionID, currentTurn, currentModel, currentEffort string
-	pendingCall := make(map[string]codexPendingCall)
-	var reasoning codexReasoningCollapser
-	var lineNumber int64
-	stamp := func(uses []ToolUse) []ToolUse {
-		for index := range uses {
-			if uses[index].TurnID == "" {
-				uses[index].TurnID = currentTurn
-			}
-			if uses[index].Model == "" {
-				uses[index].Model = currentModel
-			}
-			if uses[index].ReasoningEffort == "" {
-				uses[index].ReasoningEffort = currentEffort
-			}
-			if uses[index].SourceLine == 0 {
-				uses[index].SourceLine = lineNumber
-			}
-		}
-		return uses
+func NewCodexParser() *CodexParser {
+	return &CodexParser{pendingCall: make(map[string]codexPendingCall)}
+}
+
+// ConsumeLine advances the parser by one physical JSONL line and returns only
+// rows whose content can no longer change as this rollout grows. Malformed
+// records retain the historical best-effort behavior: they advance line
+// identity but do not poison the rest of the transcript.
+func (p *CodexParser) ConsumeLine(line string) []ToolUse {
+	p.lineNumber++
+	line = strings.TrimSpace(line)
+	if line == "" || p.ignored {
+		return nil
 	}
-	// A record that emits nothing -- an accumulating reasoning record, an
-	// unpaired function_call half, filtered internal user text -- must not count
-	// as intervening content, or it would break a twin pair apart.
+	if err := parseCodexLineInto(&p.event, line); err != nil {
+		log.Debugf("Error parsing codex line: %v", err)
+		return nil
+	}
+
+	var settled []ToolUse
 	add := func(uses []ToolUse) {
 		if len(uses) == 0 {
 			return
 		}
-		records = append(records, stamp(uses))
+		settled = append(settled, p.deduper.push(p.stamp(uses))...)
 	}
 
-	var event CodexEvent
+	// Every non-reasoning record closes the pending span before its own state is
+	// applied, so the span retains the model and turn that produced it.
+	if !isCodexReasoningRecord(p.event) {
+		add(p.reasoning.flush())
+	}
+	switch p.event.Type {
+	case "session_meta":
+		p.sessionCWD = p.event.Payload.CWD
+		p.sessionID = p.event.Payload.ID
+		if p.info == nil {
+			info := codexSessionInfo(p.event)
+			p.info = &info
+		}
+	case "turn_context":
+		p.currentTurn = firstNonEmpty(p.event.Payload.TurnID, p.currentTurn)
+		p.currentModel = firstNonEmpty(p.event.Payload.Model, p.currentModel)
+		p.currentEffort = firstNonEmpty(p.event.Payload.Effort, p.currentEffort)
+		p.observeTurnInfo()
+		if IsCodexAutoReviewModel(p.currentModel) {
+			p.ignored = true
+			return nil
+		}
+	case "response_item":
+		if p.event.Payload.Type == "reasoning" {
+			add(p.reasoning.observe(p.event, p.currentTurn, p.sessionCWD, p.sessionID, p.lineNumber))
+			return settled
+		}
+		add(extractResponseItem(p.event, p.pendingCall, p.sessionCWD, p.sessionID, p.lineNumber))
+	case "event_msg":
+		p.currentTurn = firstNonEmpty(p.event.Payload.TurnID, p.currentTurn)
+		add(extractEventMsg(p.event, p.sessionCWD, p.sessionID))
+	case "world_state":
+		add([]ToolUse{buildCodexTopLevelEventUse(p.event, "world_state", p.sessionCWD, p.sessionID)})
+	case "thread.started":
+		p.sessionID = firstNonEmpty(p.event.ThreadID, p.sessionID)
+		p.observeThreadInfo()
+	case "item.completed":
+		add(extractLiveItemCompleted(p.event, p.sessionCWD, p.sessionID))
+	case "turn.failed", "error":
+		add(extractLiveError(p.event, p.sessionCWD, p.sessionID))
+	}
+	return settled
+}
+
+func (p *CodexParser) stamp(uses []ToolUse) []ToolUse {
+	for index := range uses {
+		if uses[index].TurnID == "" {
+			uses[index].TurnID = p.currentTurn
+		}
+		if uses[index].Model == "" {
+			uses[index].Model = p.currentModel
+		}
+		if uses[index].ReasoningEffort == "" {
+			uses[index].ReasoningEffort = p.currentEffort
+		}
+		if uses[index].SourceLine == 0 {
+			uses[index].SourceLine = p.lineNumber
+		}
+	}
+	return uses
+}
+
+func (p *CodexParser) observeThreadInfo() {
+	if p.info == nil {
+		p.info = &CodexSessionInfo{StartedAt: p.event.Time()}
+	}
+	if p.info.ID == "" {
+		p.info.ID = p.event.ThreadID
+	}
+}
+
+func (p *CodexParser) observeTurnInfo() {
+	if p.info == nil {
+		p.info = &CodexSessionInfo{StartedAt: p.event.Time()}
+	}
+	if p.info.Model == "" {
+		p.info.Model = p.event.Payload.Model
+	}
+	if p.info.ReasoningEffort == "" {
+		p.info.ReasoningEffort = p.event.Payload.Effort
+	}
+}
+
+// Snapshot returns the unresolved tail without advancing parser state. Dedupe
+// candidates, open reasoning spans, and unpaired calls are re-created on every
+// append until a real source record settles them.
+func (p *CodexParser) Snapshot() []ToolUse {
+	uses := p.deduper.snapshot()
+	if p.reasoning.pending() {
+		reasoning := p.reasoning
+		uses = append(uses, p.stamp(asProvisional(reasoning.flush()))...)
+	}
+	for _, call := range sortedCodexPendingCalls(p.pendingCall) {
+		uses = append(uses,
+			p.stamp(asProvisional(withSourceLine(buildPendingCallUses(call.event, p.sessionCWD, p.sessionID), call.line)))...)
+	}
+	return uses
+}
+
+// SessionInfo returns the metadata observed by this parser so incremental
+// callers do not need a second scan of the transcript header.
+func (p *CodexParser) SessionInfo() *CodexSessionInfo {
+	if p.info == nil {
+		return nil
+	}
+	info := *p.info
+	return &info
+}
+
+func (p *CodexParser) LineNumber() int64 { return p.lineNumber }
+func (p *CodexParser) Ignored() bool     { return p.ignored }
+
+func ExtractCodexToolUsesFromReader(reader io.Reader) ([]ToolUse, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	parser := NewCodexParser()
+	var uses []ToolUse
 	for scanner.Scan() {
-		lineNumber++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		if err := parseCodexLineInto(&event, line); err != nil {
-			log.Debugf("Error parsing codex line: %v", err)
-			continue
-		}
-		// Every record that is not a reasoning record closes the pending span.
-		// Flushing only at turn_context/EOF is what made the span grow on each
-		// tailing pass -- a different count, a different dedupe key, a different
-		// row -- and shifted every downstream ordinal with it.
-		if !isCodexReasoningRecord(event) {
-			add(reasoning.flush())
-		}
-		switch event.Type {
-		case "session_meta":
-			sessionCWD = event.Payload.CWD
-			sessionID = event.Payload.ID
-		case "turn_context":
-			// The span was already flushed above, before the turn's model and
-			// effort roll over, so the closing span is stamped with the turn it
-			// belongs to. turn_context is the only reliable turn boundary: older
-			// rollouts carry no turn_id at all, so keying the span on turn_id
-			// alone would fold a whole multi-turn session into one bogus span.
-			currentTurn = firstNonEmpty(event.Payload.TurnID, currentTurn)
-			currentModel = firstNonEmpty(event.Payload.Model, currentModel)
-			if IsCodexAutoReviewModel(currentModel) {
-				return nil, nil
-			}
-			currentEffort = firstNonEmpty(event.Payload.Effort, currentEffort)
-		case "response_item":
-			if event.Payload.Type == "reasoning" {
-				add(reasoning.observe(event, currentTurn, sessionCWD, sessionID, lineNumber))
-				continue
-			}
-			add(extractResponseItem(event, pendingCall, sessionCWD, sessionID, lineNumber))
-		case "event_msg":
-			currentTurn = firstNonEmpty(event.Payload.TurnID, currentTurn)
-			add(extractEventMsg(event, sessionCWD, sessionID))
-		case "world_state":
-			add([]ToolUse{buildCodexTopLevelEventUse(event, "world_state", sessionCWD, sessionID)})
-		case "thread.started":
-			sessionID = firstNonEmpty(event.ThreadID, sessionID)
-		case "item.completed":
-			add(extractLiveItemCompleted(event, sessionCWD, sessionID))
-		case "turn.failed", "error":
-			add(extractLiveError(event, sessionCWD, sessionID))
-		}
-	}
-	// EOF snapshots are provisional but are not source records. Feeding them
-	// through dedupe would make a synthetic pending row close the real final chat
-	// boundary, even though no appended transcript record did so.
-	var provisional []ToolUse
-	if reasoning.pending() {
-		snapshot := reasoning
-		provisional = append(provisional, stamp(asProvisional(snapshot.flush()))...)
-	}
-	for _, call := range sortedCodexPendingCalls(pendingCall) {
-		provisional = append(provisional,
-			stamp(asProvisional(withSourceLine(buildPendingCallUses(call.event, sessionCWD, sessionID), call.line)))...)
+		uses = append(uses, parser.ConsumeLine(scanner.Text())...)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	return append(dedupeCodexToolUses(records), provisional...), nil
+	if parser.Ignored() {
+		return nil, nil
+	}
+	return append(uses, parser.Snapshot()...), nil
 }
 
 // buildPendingCallUses builds the provisional row for a call whose output never

--- a/pkg/database/session_ingest_store.go
+++ b/pkg/database/session_ingest_store.go
@@ -29,6 +29,7 @@ type SessionSourceState struct {
 	SessionID       uuid.UUID  `json:"sessionId"`
 	SourceKind      string     `json:"sourceKind"`
 	Path            string     `json:"path"`
+	SourceIdentity  string     `json:"sourceIdentity,omitempty"`
 	ParserVersion   int        `json:"parserVersion"`
 	ByteOffset      int64      `json:"byteOffset"`
 	ObservedSize    int64      `json:"observedSize"`
@@ -221,7 +222,8 @@ func (db *DB) ListSessionSources(ctx context.Context) (map[string]SessionSourceS
 	for _, r := range records {
 		out[r.Path] = SessionSourceState{
 			SessionID: r.SessionID, SourceKind: r.SourceKind, Path: r.Path,
-			ParserVersion: r.ParserVersion, ByteOffset: r.ByteOffset, ObservedSize: r.ObservedSize,
+			SourceIdentity: optionalString(r.SourceIdentity),
+			ParserVersion:  r.ParserVersion, ByteOffset: r.ByteOffset, ObservedSize: r.ObservedSize,
 			ObservedModTime: r.ObservedModTime, LastEventKey: optionalString(r.LastEventKey),
 		}
 	}

--- a/pkg/monitor/ingest.go
+++ b/pkg/monitor/ingest.go
@@ -1,9 +1,11 @@
 package monitor
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,7 +20,22 @@ import (
 
 // parserVersion invalidates every ingested transcript when the parsing or
 // mapping logic changes shape.
-const parserVersion = 4
+const parserVersion = 5
+
+type codexCheckpoint struct {
+	parser      *history.CodexParser
+	accumulator *session.CodexAccumulator
+	offset      int64
+	observed    os.FileInfo
+	identity    string
+	hasUses     bool
+}
+
+type codexPreparation struct {
+	checkpoint *codexCheckpoint
+	offset     int64
+	resetMark  bool
+}
 
 // ingestor turns changed transcript files into native database rows, skipping
 // files whose recorded mtime/size/parser version still match the disk state.
@@ -28,14 +45,21 @@ type ingestor struct {
 	// watchSubagents arms the watcher on a root transcript's subagents
 	// directory; nil outside watched (one-shot) runs.
 	watchSubagents func(rootTranscriptPath string)
+	// requeue schedules another pass when a descriptor-bounded parse observes
+	// that the path changed again before its database write completed.
+	requeue func(ctx context.Context, source, path string)
 
 	mu          sync.Mutex
 	sources     map[string]database.SessionSourceState
+	codex       map[string]*codexCheckpoint
 	ingestLocks sync.Map // transcript path -> *sync.Mutex
 }
 
 func newIngestor(m *Monitor) *ingestor {
-	return &ingestor{monitor: m, db: m.db, sources: map[string]database.SessionSourceState{}}
+	return &ingestor{
+		monitor: m, db: m.db,
+		sources: map[string]database.SessionSourceState{}, codex: map[string]*codexCheckpoint{},
+	}
 }
 
 func (ing *ingestor) refreshSourceStates(ctx context.Context) error {
@@ -62,6 +86,49 @@ func (ing *ingestor) recordSourceState(state database.SessionSourceState) {
 	ing.mu.Unlock()
 }
 
+func (ing *ingestor) prepareCodexCheckpoint(path string, info os.FileInfo) (*codexCheckpoint, bool) {
+	ing.mu.Lock()
+	defer ing.mu.Unlock()
+	checkpoint := ing.codex[path]
+	if checkpoint == nil {
+		return &codexCheckpoint{
+			parser: history.NewCodexParser(), accumulator: session.NewCodexAccumulator(path),
+		}, false
+	}
+	state, ok := ing.sources[path]
+	valid := checkpoint.parser != nil && checkpoint.accumulator != nil && checkpoint.observed != nil &&
+		ok && state.ParserVersion == parserVersion &&
+		state.ByteOffset == checkpoint.offset && state.ObservedSize == checkpoint.observed.Size() &&
+		state.SourceIdentity == checkpoint.identity && checkpoint.offset >= 0 && checkpoint.offset <= info.Size() &&
+		os.SameFile(checkpoint.observed, info) && info.Size() >= checkpoint.observed.Size()
+	if valid && info.Size() == checkpoint.observed.Size() {
+		valid = observedModTime(info).Equal(observedModTime(checkpoint.observed))
+	}
+	if valid {
+		return checkpoint, false
+	}
+	delete(ing.codex, path)
+	return &codexCheckpoint{
+		parser: history.NewCodexParser(), accumulator: session.NewCodexAccumulator(path),
+	}, true
+}
+
+func (ing *ingestor) commitCodexCheckpoint(path string, preparation *codexPreparation, info os.FileInfo, identity string) {
+	checkpoint := preparation.checkpoint
+	checkpoint.offset = preparation.offset
+	checkpoint.observed = info
+	checkpoint.identity = identity
+	ing.mu.Lock()
+	ing.codex[path] = checkpoint
+	ing.mu.Unlock()
+}
+
+func (ing *ingestor) dropCodexCheckpoint(path string) {
+	ing.mu.Lock()
+	delete(ing.codex, path)
+	ing.mu.Unlock()
+}
+
 // resumeAfter returns the highest message sequence a previous pass already
 // persisted for a transcript. Transcripts are append-only, so one appended line
 // would otherwise re-submit every message in the file — millions of insert
@@ -74,6 +141,10 @@ func (ing *ingestor) recordSourceState(state database.SessionSourceState) {
 func (ing *ingestor) resumeAfter(path string, info os.FileInfo) int64 {
 	state, ok := ing.sourceState(path)
 	if !ok || state.ParserVersion != parserVersion || info.Size() < state.ObservedSize {
+		return 0
+	}
+	if info.Size() == state.ObservedSize && state.ObservedModTime != nil &&
+		!state.ObservedModTime.Equal(observedModTime(info)) {
 		return 0
 	}
 	mark, err := strconv.ParseInt(state.LastEventKey, 10, 64)
@@ -169,9 +240,20 @@ func (ing *ingestor) ingestFile(ctx context.Context, source, path string) error 
 	pathLock.Lock()
 	defer pathLock.Unlock()
 
-	info, err := rootFS.Stat(relativePath)
+	var codexFile *os.File
+	var info os.FileInfo
+	if source == "codex" {
+		codexFile, err = rootFS.Open(relativePath)
+		if err == nil {
+			defer codexFile.Close()
+			info, err = codexFile.Stat()
+		}
+	} else {
+		info, err = rootFS.Stat(relativePath)
+	}
 	if err != nil {
 		if os.IsNotExist(err) {
+			ing.dropCodexCheckpoint(path)
 			ing.monitor.untrackTranscript(path)
 			return nil
 		}
@@ -180,25 +262,25 @@ func (ing *ingestor) ingestFile(ctx context.Context, source, path string) error 
 	if !ing.needsIngest(path, info) {
 		return nil
 	}
-	if source == "codex" {
-		ignored, ignoreErr := history.IsCodexAutoReviewSession(path)
-		if ignoreErr != nil {
-			return ignoreErr
-		}
-		if ignored {
-			return nil
-		}
-	}
 	var input database.IngestTranscriptInput
+	var codex *codexPreparation
 	switch source {
 	case "claude":
 		input, err = ing.claudeIngestInput(ctx, path)
 	case "codex":
-		input, err = codexIngestInput(path)
+		var ignored bool
+		input, codex, ignored, err = ing.incrementalCodexIngestInput(codexFile, path, info)
+		if ignored {
+			ing.dropCodexCheckpoint(path)
+			return nil
+		}
 	default:
 		return fmt.Errorf("unknown transcript source %q for %s", source, path)
 	}
 	if err != nil {
+		if source == "codex" {
+			ing.dropCodexCheckpoint(path)
+		}
 		return err
 	}
 	input.Session.HostID = ing.monitor.cfg.HostID
@@ -207,13 +289,22 @@ func (ing *ingestor) ingestFile(ctx context.Context, source, path string) error 
 	input.Source.ParserVersion = parserVersion
 	input.Source.ObservedSize = info.Size()
 	input.Source.ByteOffset = info.Size()
+	if codex != nil {
+		input.Source.ByteOffset = codex.offset
+	}
 	input.Source.ObservedModTime = observedModTime(info)
 
-	// Parsed against offered is the standing regression test for the high-water
-	// mark: the parse is always whole-file, the write should not be.
 	metrics := &ing.monitor.ingest
 	metrics.messagesParsed.Add(int64(len(input.Messages)))
-	input.Source.LastEventKey = strconv.FormatInt(highWaterMark(&input, ing.resumeAfter(path, info)), 10)
+	previous := ing.resumeAfter(path, info)
+	if codex != nil && codex.resetMark {
+		previous = 0
+	}
+	if state, ok := ing.sourceState(path); ok && state.SourceIdentity != "" &&
+		state.SourceIdentity != input.Source.SourceIdentity {
+		previous = 0
+	}
+	input.Source.LastEventKey = strconv.FormatInt(highWaterMark(&input, previous), 10)
 	metrics.messagesOffered.Add(int64(len(input.Messages)))
 	metrics.filesIngested.Add(1)
 
@@ -221,6 +312,9 @@ func (ing *ingestor) ingestFile(ctx context.Context, source, path string) error 
 	persisted, err := ing.db.IngestTranscript(ctx, input)
 	metrics.writeNanos.Add(int64(time.Since(writeStart)))
 	if err != nil {
+		if codex != nil {
+			ing.dropCodexCheckpoint(path)
+		}
 		return err
 	}
 	if source == "claude" && input.Session.ParentSessionID == nil && ing.watchSubagents != nil {
@@ -228,10 +322,21 @@ func (ing *ingestor) ingestFile(ctx context.Context, source, path string) error 
 	}
 	modTime := input.Source.ObservedModTime
 	ing.recordSourceState(database.SessionSourceState{
-		SessionID: persisted.ID, SourceKind: source, Path: path, ParserVersion: parserVersion,
-		ByteOffset: input.Source.ByteOffset, ObservedSize: input.Source.ObservedSize, ObservedModTime: &modTime,
+		SessionID: persisted.ID, SourceKind: source, Path: path, SourceIdentity: input.Source.SourceIdentity,
+		ParserVersion: parserVersion,
+		ByteOffset:    input.Source.ByteOffset, ObservedSize: input.Source.ObservedSize, ObservedModTime: &modTime,
 		LastEventKey: input.Source.LastEventKey,
 	})
+	if codex != nil {
+		ing.commitCodexCheckpoint(path, codex, info, input.Source.SourceIdentity)
+		if ing.requeue != nil {
+			latest, statErr := rootFS.Stat(relativePath)
+			if statErr == nil && (!os.SameFile(info, latest) || latest.Size() != info.Size() ||
+				!observedModTime(latest).Equal(observedModTime(info))) {
+				ing.requeue(ctx, source, path)
+			}
+		}
+	}
 	return nil
 }
 
@@ -258,6 +363,62 @@ func (ing *ingestor) claudeIngestInput(ctx context.Context, path string) (databa
 		input.Session.ProviderSessionID = info.RootSessionID
 	}
 	return input, nil
+}
+
+func (ing *ingestor) incrementalCodexIngestInput(file *os.File, path string, info os.FileInfo) (
+	database.IngestTranscriptInput, *codexPreparation, bool, error,
+) {
+	checkpoint, resetMark := ing.prepareCodexCheckpoint(path, info)
+	settled, offset, err := consumeCodexSuffix(file, checkpoint.offset, info.Size(), checkpoint.parser)
+	if err != nil {
+		return database.IngestTranscriptInput{}, nil, false, err
+	}
+	preparation := &codexPreparation{checkpoint: checkpoint, offset: offset, resetMark: resetMark}
+	if checkpoint.parser.Ignored() {
+		return database.IngestTranscriptInput{}, preparation, true, nil
+	}
+	provisional := checkpoint.parser.Snapshot()
+	if len(settled) > 0 || len(provisional) > 0 {
+		checkpoint.hasUses = true
+	}
+	if !checkpoint.hasUses {
+		return database.IngestTranscriptInput{}, preparation, false,
+			fmt.Errorf("codex transcript %s is not parseable", path)
+	}
+	checkpoint.accumulator.Add(checkpoint.parser.SessionInfo(), settled)
+	s := checkpoint.accumulator.Project(provisional)
+	if strings.TrimSpace(s.ID) == "" {
+		return database.IngestTranscriptInput{}, preparation, false,
+			fmt.Errorf("codex transcript %s has no session identity", path)
+	}
+	input := unifiedIngestInput(s, "codex", transcriptSequence)
+	input.Session.ProviderSessionID = s.ID
+	input.Source.SourceIdentity = s.ID
+	return input, preparation, false, nil
+}
+
+// consumeCodexSuffix parses only complete newline-terminated records inside the
+// descriptor snapshot [offset, size]. A partial final record leaves the cursor
+// before it so the next append re-reads the complete JSON value.
+func consumeCodexSuffix(file *os.File, offset, size int64, parser *history.CodexParser) ([]history.ToolUse, int64, error) {
+	if file == nil || parser == nil || offset < 0 || offset > size {
+		return nil, offset, fmt.Errorf("invalid Codex parser checkpoint %d for file size %d", offset, size)
+	}
+	reader := bufio.NewReader(io.NewSectionReader(file, offset, size-offset))
+	position := offset
+	var uses []history.ToolUse
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, position, err
+		}
+		position += int64(len(line))
+		uses = append(uses, parser.ConsumeLine(line)...)
+	}
+	return uses, position, nil
 }
 
 func codexIngestInput(path string) (database.IngestTranscriptInput, error) {

--- a/pkg/monitor/ingest_benchmark_test.go
+++ b/pkg/monitor/ingest_benchmark_test.go
@@ -1,0 +1,337 @@
+package monitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/flanksource/captain/pkg/ai/history"
+	"github.com/flanksource/captain/pkg/session"
+)
+
+const (
+	codexBenchmarkLineCount     = 10_000
+	codexBenchmarkTurns         = 1_111
+	codexBenchmarkMessages      = codexBenchmarkTurns * 4
+	codexEventHeavyTurns        = 99
+	codexEventHeavyBlocks       = 12
+	codexEventHeavyMessages     = codexEventHeavyTurns * (2 + codexEventHeavyBlocks*4)
+	codexEventHeavyLinesPerTurn = 5 + codexEventHeavyBlocks*8
+)
+
+var (
+	codexBenchmarkMessageCount int
+	codexBenchmarkSessionID    string
+	codexBenchmarkToolUseCount int
+)
+
+type codexBenchmarkFixture struct {
+	data     []byte
+	lines    int
+	turns    int
+	messages int
+}
+
+type codexBenchmarkWriter struct {
+	transcript bytes.Buffer
+	encoder    *json.Encoder
+	startedAt  time.Time
+	lines      int
+}
+
+// BenchmarkCodexIngestInput10000Lines is the stable decision benchmark for the
+// DB-free whole-file parser and normalization path used after a live append.
+func BenchmarkCodexIngestInput10000Lines(b *testing.B) {
+	fixture := syntheticCodexBenchmarkTranscript()
+	path := prepareCodexBenchmarkFixture(b, "many-turns-10000", fixture)
+	benchmarkCodexIngestInput(b, path, fixture)
+}
+
+// BenchmarkCodexIngestInputSizeSeries measures how whole-file ingestion scales
+// while preserving the same production-valid record mix at each size.
+func BenchmarkCodexIngestInputSizeSeries(b *testing.B) {
+	for _, turns := range []int{111, 555, codexBenchmarkTurns, 2_778} {
+		fixture := syntheticCodexManyTurnTranscript(turns)
+		name := fmt.Sprintf("%d_lines_%d_bytes", fixture.lines, len(fixture.data))
+		path := prepareCodexBenchmarkFixture(b, name, fixture)
+		b.Run(name, func(b *testing.B) {
+			benchmarkCodexIngestInput(b, path, fixture)
+		})
+	}
+}
+
+// BenchmarkCodexIngestInputWorkloadShapes10000Lines contrasts turn-heavy and
+// event-heavy transcripts without changing the exact line count.
+func BenchmarkCodexIngestInputWorkloadShapes10000Lines(b *testing.B) {
+	fixtures := []struct {
+		name    string
+		fixture codexBenchmarkFixture
+	}{
+		{name: "many_turns_1111_turns_4444_messages", fixture: syntheticCodexBenchmarkTranscript()},
+		{name: "event_heavy_99_turns_4950_messages", fixture: syntheticCodexEventHeavyTranscript()},
+	}
+	for _, benchmark := range fixtures {
+		path := prepareCodexBenchmarkFixture(b, benchmark.name, benchmark.fixture)
+		b.Run(benchmark.name, func(b *testing.B) {
+			benchmarkCodexIngestInput(b, path, benchmark.fixture)
+		})
+	}
+}
+
+// BenchmarkCodexIngestPhases10000Lines isolates the exported parser/build seams
+// and the monitor-owned final mapping without database or discovery work.
+func BenchmarkCodexIngestPhases10000Lines(b *testing.B) {
+	fixture := syntheticCodexBenchmarkTranscript()
+	path := prepareCodexBenchmarkFixture(b, "phases-10000", fixture)
+	sessions := session.BuildCodex([]string{path})
+	if len(sessions) != 1 {
+		b.Fatalf("build codex fixture: got %d sessions", len(sessions))
+	}
+	unified := sessions[0]
+
+	b.Run("read_session_info", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			info, err := history.ReadCodexSessionInfo(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			codexBenchmarkSessionID = info.ID
+		}
+	})
+	b.Run("extract_tool_uses", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(fixture.data)))
+		for b.Loop() {
+			uses, err := history.ExtractCodexToolUses(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			codexBenchmarkToolUseCount = len(uses)
+		}
+	})
+	b.Run("build_codex_session", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(fixture.data)))
+		for b.Loop() {
+			sessions := session.BuildCodex([]string{path})
+			if len(sessions) != 1 {
+				b.Fatalf("got %d sessions", len(sessions))
+			}
+			codexBenchmarkMessageCount = len(sessions[0].Messages)
+		}
+	})
+	b.Run("unified_ingest_input", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			input := unifiedIngestInput(unified, "codex", transcriptSequence)
+			codexBenchmarkMessageCount = len(input.Messages)
+		}
+	})
+}
+
+func benchmarkCodexIngestInput(b *testing.B, path string, fixture codexBenchmarkFixture) {
+	b.Helper()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(fixture.data)))
+	for b.Loop() {
+		input, err := codexIngestInput(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		codexBenchmarkMessageCount = len(input.Messages)
+	}
+	b.ReportMetric(float64(len(fixture.data)), "fixture_B")
+	b.ReportMetric(float64(fixture.lines), "lines")
+	b.ReportMetric(float64(fixture.turns), "turns")
+	b.ReportMetric(float64(fixture.messages), "messages")
+}
+
+func prepareCodexBenchmarkFixture(b *testing.B, name string, fixture codexBenchmarkFixture) string {
+	b.Helper()
+	if fixture.lines != bytes.Count(fixture.data, []byte{'\n'}) {
+		b.Fatalf("fixture records %d lines but contains %d", fixture.lines, bytes.Count(fixture.data, []byte{'\n'}))
+	}
+	path := filepath.Join(b.TempDir(), fmt.Sprintf("rollout-%s-019f0000-0000-7000-8000-000000000001.jsonl", name))
+	if err := os.WriteFile(path, fixture.data, 0o600); err != nil {
+		b.Fatalf("write codex fixture: %v", err)
+	}
+	input, err := codexIngestInput(path)
+	if err != nil {
+		b.Fatalf("parse codex fixture: %v", err)
+	}
+	if len(input.Messages) != fixture.messages || len(input.Turns) != fixture.turns {
+		b.Fatalf("fixture normalized to %d messages and %d turns, want %d messages and %d turns",
+			len(input.Messages), len(input.Turns), fixture.messages, fixture.turns)
+	}
+	return path
+}
+
+func newCodexBenchmarkWriter() *codexBenchmarkWriter {
+	w := &codexBenchmarkWriter{startedAt: time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)}
+	w.encoder = json.NewEncoder(&w.transcript)
+	return w
+}
+
+func (w *codexBenchmarkWriter) write(eventType string, payload map[string]any) {
+	event := map[string]any{
+		"timestamp": w.startedAt.Add(time.Duration(w.lines) * time.Millisecond).Format(time.RFC3339Nano),
+		"type":      eventType,
+		"payload":   payload,
+	}
+	if err := w.encoder.Encode(event); err != nil {
+		panic(err)
+	}
+	w.lines++
+}
+
+func (w *codexBenchmarkWriter) writeSessionMeta() {
+	w.write("session_meta", map[string]any{
+		"id": "019f0000-0000-7000-8000-000000000001", "cwd": "/repo",
+		"cli_version": "0.143.0", "model_provider": "openai",
+		"git": map[string]any{"branch": "main", "commit_hash": "3304de9598e486fabe4fb5d5ed64fc3a2c5f59ee"},
+	})
+}
+
+func (w *codexBenchmarkWriter) fixture(turns, messages int) codexBenchmarkFixture {
+	return codexBenchmarkFixture{
+		data: w.transcript.Bytes(), lines: w.lines, turns: turns, messages: messages,
+	}
+}
+
+func syntheticCodexBenchmarkTranscript() codexBenchmarkFixture {
+	fixture := syntheticCodexManyTurnTranscript(codexBenchmarkTurns)
+	if fixture.lines != codexBenchmarkLineCount || fixture.messages != codexBenchmarkMessages {
+		panic(fmt.Sprintf("generated %d lines and %d messages", fixture.lines, fixture.messages))
+	}
+	return fixture
+}
+
+func syntheticCodexManyTurnTranscript(turnCount int) codexBenchmarkFixture {
+	w := newCodexBenchmarkWriter()
+	w.writeSessionMeta()
+	for turn := range turnCount {
+		turnID := fmt.Sprintf("turn-%04d", turn)
+		callID := fmt.Sprintf("call-%04d", turn)
+		w.write("turn_context", map[string]any{
+			"turn_id": turnID, "model": "gpt-5.6-sol", "effort": "high",
+		})
+		w.write("event_msg", map[string]any{
+			"type": "task_started", "turn_id": turnID,
+		})
+		w.write("response_item", map[string]any{
+			"type": "message", "role": "user",
+			"content": []map[string]any{{"type": "input_text", "text": fmt.Sprintf("Inspect parser behavior for turn %d and report the result.", turn)}},
+		})
+		w.write("response_item", map[string]any{
+			"type":    "reasoning",
+			"summary": []map[string]any{{"type": "summary_text", "text": fmt.Sprintf("Tracing the monitor ingestion path for turn %d.", turn)}},
+		})
+		w.write("response_item", map[string]any{
+			"type": "function_call", "name": "exec_command", "call_id": callID,
+			"arguments": fmt.Sprintf(`{"cmd":"sed -n '1,20p' /repo/pkg/file_%04d.go"}`, turn),
+			"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
+		})
+		w.write("response_item", map[string]any{
+			"type": "function_call_output", "call_id": callID,
+			"output": fmt.Sprintf("Chunk ID: %04d\nProcess exited with code 0\nFinal output:\npackage monitor", turn),
+			"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
+		})
+		w.write("response_item", map[string]any{
+			"type": "message", "role": "assistant",
+			"content": []map[string]any{{"type": "output_text", "text": fmt.Sprintf("The parser and normalizer completed turn %d.", turn)}},
+		})
+		w.write("event_msg", map[string]any{
+			"type": "token_count", "turn_id": turnID, "info": codexBenchmarkTokenInfo(turn + 1),
+		})
+		w.write("event_msg", map[string]any{
+			"type": "task_complete", "turn_id": turnID, "duration_ms": 850,
+		})
+	}
+	return w.fixture(turnCount, turnCount*4)
+}
+
+func syntheticCodexEventHeavyTranscript() codexBenchmarkFixture {
+	w := newCodexBenchmarkWriter()
+	w.writeSessionMeta()
+	for turn := range codexEventHeavyTurns {
+		turnID := fmt.Sprintf("dense-turn-%03d", turn)
+		w.write("turn_context", map[string]any{
+			"turn_id": turnID, "model": "gpt-5.6-sol", "effort": "high",
+		})
+		w.write("event_msg", map[string]any{"type": "task_started", "turn_id": turnID})
+		w.write("response_item", map[string]any{
+			"type": "message", "role": "user",
+			"content": []map[string]any{{"type": "input_text", "text": fmt.Sprintf("Investigate the parser deeply for turn %d.", turn)}},
+		})
+		for block := range codexEventHeavyBlocks {
+			callID := fmt.Sprintf("dense-call-%03d-%02d", turn, block)
+			w.write("response_item", map[string]any{
+				"type":    "reasoning",
+				"summary": []map[string]any{{"type": "summary_text", "text": fmt.Sprintf("Reasoning through turn %d block %d.", turn, block)}},
+			})
+			w.write("response_item", map[string]any{
+				"type": "function_call", "name": "exec_command", "call_id": callID,
+				"arguments": fmt.Sprintf(`{"cmd":"rg -n 'parser' /repo/pkg/file_%03d_%02d.go"}`, turn, block),
+				"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
+			})
+			w.write("response_item", map[string]any{
+				"type": "function_call_output", "call_id": callID,
+				"output": fmt.Sprintf("Chunk ID: %03d%02d\nProcess exited with code 0\nFinal output:\n42: parser", turn, block),
+				"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
+			})
+			w.write("response_item", map[string]any{
+				"type": "message", "role": "assistant",
+				"content": []map[string]any{{"type": "output_text", "text": fmt.Sprintf("Observed turn %d block %d.", turn, block)}},
+			})
+			sequence := turn*codexEventHeavyBlocks + block + 1
+			w.write("event_msg", map[string]any{
+				"type": "token_count", "turn_id": turnID, "info": codexBenchmarkTokenInfo(sequence),
+			})
+			w.write("event_msg", map[string]any{
+				"type": "agent_reasoning", "turn_id": turnID,
+				"text": fmt.Sprintf("Checking another angle for turn %d block %d.", turn, block),
+			})
+			w.write("world_state", map[string]any{
+				"turn_id": turnID, "full": false,
+				"state": map[string]any{"skills": map[string]any{"includeInstructions": block%2 == 0}},
+			})
+			w.write("event_msg", map[string]any{
+				"type": "turn_diff", "turn_id": turnID,
+				"unified_diff": fmt.Sprintf("@@ turn %d block %d @@", turn, block),
+			})
+		}
+		w.write("response_item", map[string]any{
+			"type": "message", "role": "assistant",
+			"content": []map[string]any{{"type": "output_text", "text": fmt.Sprintf("Completed dense turn %d.", turn)}},
+		})
+		w.write("event_msg", map[string]any{
+			"type": "task_complete", "turn_id": turnID, "duration_ms": 12_500,
+		})
+	}
+	fixture := w.fixture(codexEventHeavyTurns, codexEventHeavyMessages)
+	wantLines := 1 + codexEventHeavyTurns*codexEventHeavyLinesPerTurn
+	if fixture.lines != codexBenchmarkLineCount || fixture.lines != wantLines {
+		panic(fmt.Sprintf("generated %d event-heavy lines, want %d", fixture.lines, wantLines))
+	}
+	return fixture
+}
+
+func codexBenchmarkTokenInfo(sequence int) map[string]any {
+	return map[string]any{
+		"last_token_usage": map[string]any{
+			"input_tokens": 180, "cached_input_tokens": 60, "output_tokens": 45,
+			"reasoning_output_tokens": 15, "total_tokens": 225,
+		},
+		"total_token_usage": map[string]any{
+			"input_tokens": sequence * 180, "cached_input_tokens": sequence * 60,
+			"output_tokens": sequence * 45, "reasoning_output_tokens": sequence * 15,
+			"total_tokens": sequence * 225,
+		},
+		"model_context_window": 200_000,
+	}
+}

--- a/pkg/monitor/ingest_benchmark_test.go
+++ b/pkg/monitor/ingest_benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flanksource/captain/pkg/ai/history"
+	"github.com/flanksource/captain/pkg/database"
 	"github.com/flanksource/captain/pkg/session"
 )
 
@@ -60,6 +61,19 @@ func BenchmarkCodexIngestInputSizeSeries(b *testing.B) {
 		path := prepareCodexBenchmarkFixture(b, name, fixture)
 		b.Run(name, func(b *testing.B) {
 			benchmarkCodexIngestInput(b, path, fixture)
+		})
+	}
+}
+
+// BenchmarkCodexIncrementalAppendSizeSeries measures the warm monitor path for
+// the same nine-line turn appended after progressively larger settled prefixes.
+func BenchmarkCodexIncrementalAppendSizeSeries(b *testing.B) {
+	for _, turns := range []int{111, codexBenchmarkTurns, 2_778} {
+		fixture := syntheticCodexManyTurnTranscript(turns)
+		name := fmt.Sprintf("after_%d_lines_%d_bytes", fixture.lines, len(fixture.data))
+		path := prepareCodexBenchmarkFixture(b, "warm-"+name, fixture)
+		b.Run(name, func(b *testing.B) {
+			benchmarkCodexIncrementalAppend(b, path, fixture)
 		})
 	}
 }
@@ -151,6 +165,102 @@ func benchmarkCodexIngestInput(b *testing.B, path string, fixture codexBenchmark
 	b.ReportMetric(float64(fixture.messages), "messages")
 }
 
+func benchmarkCodexIncrementalAppend(b *testing.B, path string, fixture codexBenchmarkFixture) {
+	b.Helper()
+	ing := seedCodexBenchmarkCheckpoint(b, path)
+	line := fixture.lines
+	turn := fixture.turns
+	firstAppend := syntheticCodexManyTurnAppend(turn, line)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(firstAppend)))
+	b.ResetTimer()
+	for b.Loop() {
+		b.StopTimer()
+		appendData := syntheticCodexManyTurnAppend(turn, line)
+		writer, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := writer.Write(appendData); err != nil {
+			_ = writer.Close()
+			b.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StartTimer()
+		file, err := os.Open(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		info, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			b.Fatal(err)
+		}
+		input, preparation, ignored, err := ing.incrementalCodexIngestInput(file, path, info)
+		if closeErr := file.Close(); err == nil {
+			err = closeErr
+		}
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if ignored || len(input.Messages) != 4 || len(input.Turns) != 1 {
+			b.Fatalf("warm append normalized to %d messages and %d turns (ignored=%v), want 4 and 1",
+				len(input.Messages), len(input.Turns), ignored)
+		}
+		recordCodexBenchmarkCheckpoint(ing, path, input, preparation, info)
+		codexBenchmarkMessageCount = len(input.Messages)
+		line += bytes.Count(appendData, []byte{'\n'})
+		turn++
+		b.StartTimer()
+	}
+	b.ReportMetric(9, "append_lines")
+	b.ReportMetric(float64(fixture.lines), "prefix_lines")
+	b.ReportMetric(float64(len(fixture.data)), "prefix_B")
+}
+
+func seedCodexBenchmarkCheckpoint(b *testing.B, path string) *ingestor {
+	b.Helper()
+	ing := &ingestor{
+		sources: map[string]database.SessionSourceState{},
+		codex:   map[string]*codexCheckpoint{},
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		b.Fatal(err)
+	}
+	input, preparation, ignored, err := ing.incrementalCodexIngestInput(file, path, info)
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		b.Fatal(err)
+	}
+	if ignored {
+		b.Fatal("benchmark rollout was ignored")
+	}
+	recordCodexBenchmarkCheckpoint(ing, path, input, preparation, info)
+	return ing
+}
+
+func recordCodexBenchmarkCheckpoint(ing *ingestor, path string, input database.IngestTranscriptInput, preparation *codexPreparation, info os.FileInfo) {
+	modTime := observedModTime(info)
+	ing.recordSourceState(database.SessionSourceState{
+		Path: path, SourceKind: "codex", SourceIdentity: input.Source.SourceIdentity,
+		ParserVersion: parserVersion, ByteOffset: preparation.offset,
+		ObservedSize: info.Size(), ObservedModTime: &modTime,
+	})
+	ing.commitCodexCheckpoint(path, preparation, info, input.Source.SourceIdentity)
+}
+
 func prepareCodexBenchmarkFixture(b *testing.B, name string, fixture codexBenchmarkFixture) string {
 	b.Helper()
 	if fixture.lines != bytes.Count(fixture.data, []byte{'\n'}) {
@@ -215,44 +325,55 @@ func syntheticCodexManyTurnTranscript(turnCount int) codexBenchmarkFixture {
 	w := newCodexBenchmarkWriter()
 	w.writeSessionMeta()
 	for turn := range turnCount {
-		turnID := fmt.Sprintf("turn-%04d", turn)
-		callID := fmt.Sprintf("call-%04d", turn)
-		w.write("turn_context", map[string]any{
-			"turn_id": turnID, "model": "gpt-5.6-sol", "effort": "high",
-		})
-		w.write("event_msg", map[string]any{
-			"type": "task_started", "turn_id": turnID,
-		})
-		w.write("response_item", map[string]any{
-			"type": "message", "role": "user",
-			"content": []map[string]any{{"type": "input_text", "text": fmt.Sprintf("Inspect parser behavior for turn %d and report the result.", turn)}},
-		})
-		w.write("response_item", map[string]any{
-			"type":    "reasoning",
-			"summary": []map[string]any{{"type": "summary_text", "text": fmt.Sprintf("Tracing the monitor ingestion path for turn %d.", turn)}},
-		})
-		w.write("response_item", map[string]any{
-			"type": "function_call", "name": "exec_command", "call_id": callID,
-			"arguments": fmt.Sprintf(`{"cmd":"sed -n '1,20p' /repo/pkg/file_%04d.go"}`, turn),
-			"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
-		})
-		w.write("response_item", map[string]any{
-			"type": "function_call_output", "call_id": callID,
-			"output": fmt.Sprintf("Chunk ID: %04d\nProcess exited with code 0\nFinal output:\npackage monitor", turn),
-			"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
-		})
-		w.write("response_item", map[string]any{
-			"type": "message", "role": "assistant",
-			"content": []map[string]any{{"type": "output_text", "text": fmt.Sprintf("The parser and normalizer completed turn %d.", turn)}},
-		})
-		w.write("event_msg", map[string]any{
-			"type": "token_count", "turn_id": turnID, "info": codexBenchmarkTokenInfo(turn + 1),
-		})
-		w.write("event_msg", map[string]any{
-			"type": "task_complete", "turn_id": turnID, "duration_ms": 850,
-		})
+		w.writeManyTurn(turn)
 	}
 	return w.fixture(turnCount, turnCount*4)
+}
+
+func syntheticCodexManyTurnAppend(turn, line int) []byte {
+	w := newCodexBenchmarkWriter()
+	w.lines = line
+	w.writeManyTurn(turn)
+	return w.transcript.Bytes()
+}
+
+func (w *codexBenchmarkWriter) writeManyTurn(turn int) {
+	turnID := fmt.Sprintf("turn-%04d", turn)
+	callID := fmt.Sprintf("call-%04d", turn)
+	w.write("turn_context", map[string]any{
+		"turn_id": turnID, "model": "gpt-5.6-sol", "effort": "high",
+	})
+	w.write("event_msg", map[string]any{
+		"type": "task_started", "turn_id": turnID,
+	})
+	w.write("response_item", map[string]any{
+		"type": "message", "role": "user",
+		"content": []map[string]any{{"type": "input_text", "text": fmt.Sprintf("Inspect parser behavior for turn %d and report the result.", turn)}},
+	})
+	w.write("response_item", map[string]any{
+		"type":    "reasoning",
+		"summary": []map[string]any{{"type": "summary_text", "text": fmt.Sprintf("Tracing the monitor ingestion path for turn %d.", turn)}},
+	})
+	w.write("response_item", map[string]any{
+		"type": "function_call", "name": "exec_command", "call_id": callID,
+		"arguments": fmt.Sprintf(`{"cmd":"sed -n '1,20p' /repo/pkg/file_%04d.go"}`, turn),
+		"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
+	})
+	w.write("response_item", map[string]any{
+		"type": "function_call_output", "call_id": callID,
+		"output": fmt.Sprintf("Chunk ID: %04d\nProcess exited with code 0\nFinal output:\npackage monitor", turn),
+		"internal_chat_message_metadata_passthrough": map[string]any{"turn_id": turnID},
+	})
+	w.write("response_item", map[string]any{
+		"type": "message", "role": "assistant",
+		"content": []map[string]any{{"type": "output_text", "text": fmt.Sprintf("The parser and normalizer completed turn %d.", turn)}},
+	})
+	w.write("event_msg", map[string]any{
+		"type": "token_count", "turn_id": turnID, "info": codexBenchmarkTokenInfo(turn + 1),
+	})
+	w.write("event_msg", map[string]any{
+		"type": "task_complete", "turn_id": turnID, "duration_ms": 850,
+	})
 }
 
 func syntheticCodexEventHeavyTranscript() codexBenchmarkFixture {

--- a/pkg/monitor/watch.go
+++ b/pkg/monitor/watch.go
@@ -44,6 +44,7 @@ func newTranscriptWatcher(m *Monitor, ingestor *ingestor) (*transcriptWatcher, e
 	ingestor.watchSubagents = func(rootTranscriptPath string) {
 		w.watchDir(subagentsDir(rootTranscriptPath), "claude")
 	}
+	ingestor.requeue = w.schedule
 	return w, nil
 }
 
@@ -106,6 +107,10 @@ func (w *transcriptWatcher) handle(ctx context.Context, event fsnotify.Event) {
 	if !ok {
 		return
 	}
+	w.schedule(ctx, source, path)
+}
+
+func (w *transcriptWatcher) schedule(ctx context.Context, source, path string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if timer, ok := w.timers[path]; ok {

--- a/pkg/session/build_codex.go
+++ b/pkg/session/build_codex.go
@@ -36,29 +36,9 @@ func BuildCodex(files []string) []*Session {
 		if len(uses) == 0 {
 			continue
 		}
-		sessionID := ""
-		if info != nil {
-			sessionID = strings.TrimSpace(info.ID)
-		}
-		if sessionID == "" {
-			sessionID = codexSessionIDFromHistoryFile(f)
-		}
-		if sessionID != "" {
-			if info == nil {
-				info = &history.CodexSessionInfo{}
-			}
-			info.ID = sessionID
-			for i := range uses {
-				if strings.TrimSpace(uses[i].SessionID) == "" {
-					uses[i].SessionID = sessionID
-				}
-			}
-		}
-		s := buildCodexSession(uses, info)
-		s.HistoryFile = f
-		if s.Root != nil {
-			s.Root.HistoryFile = f
-		}
+		accumulator := newCodexAccumulator(f, true)
+		accumulator.Add(info, uses)
+		s := accumulator.fullSession()
 		out = append(out, s)
 	}
 	return out
@@ -82,177 +62,349 @@ func codexSessionIDFromHistoryFile(path string) string {
 	return id.String()
 }
 
-// buildCodexSession assembles one Session from a Codex session's tool uses and
-// metadata sidecar.
-func buildCodexSession(uses []history.ToolUse, info *history.CodexSessionInfo) *Session {
-	s := &Session{Source: "codex"}
-	if info != nil {
-		s.CWD = info.CWD
+// CodexAccumulator keeps the aggregate state needed by the monitor without
+// retaining the transcript's historical messages and events. Add accepts only
+// settled rows; Project overlays the parser's current EOF snapshot without
+// committing provisional data to this checkpoint.
+type CodexAccumulator struct {
+	session       Session
+	collect       bool
+	read          map[string]struct{}
+	written       map[string]struct{}
+	costByModel   map[string]api.Cost
+	turns         *codexTurnBuilder
+	agents        map[string]*Agent
+	cumulative    codexCumulative
+	plan          codexPlanState
+	freshMessages []Message
+}
+
+// NewCodexAccumulator creates the compact accumulator used for live monitor
+// updates. A separate full collector powers BuildCodex through the same core.
+func NewCodexAccumulator(historyFile string) *CodexAccumulator {
+	return newCodexAccumulator(historyFile, false)
+}
+
+func newCodexAccumulator(historyFile string, collect bool) *CodexAccumulator {
+	s := Session{
+		ID:          codexSessionIDFromHistoryFile(historyFile),
+		Source:      "codex",
+		HistoryFile: historyFile,
 	}
-	root := &Agent{IsRoot: true}
+	return &CodexAccumulator{
+		session: s, collect: collect,
+		read: map[string]struct{}{}, written: map[string]struct{}{},
+		costByModel: map[string]api.Cost{},
+		turns:       newCodexTurnBuilder(collect),
+		agents:      map[string]*Agent{},
+	}
+}
 
-	var read, written []string
-	costs := api.Costs{}
-	turns := newCodexTurnBuilder()
-	agents := map[string]*Agent{}
-	var latestContext *Context
-	var cumulative codexCumulative
+// Add advances aggregate state with rows the parser has declared final.
+func (a *CodexAccumulator) Add(info *history.CodexSessionInfo, uses []history.ToolUse) {
+	a.applyInfo(info)
+	for _, use := range uses {
+		if use.SessionID == "" {
+			use.SessionID = a.session.ID
+		}
+		a.observe(use)
+	}
+}
 
-	for _, u := range uses {
-		if s.ID == "" && u.SessionID != "" {
-			s.ID = u.SessionID
-		}
-		if s.CWD == "" {
-			s.CWD = u.CWD
-		}
-		if s.Model == "" {
-			s.Model = u.Model
-		}
-		if u.Timestamp != nil {
-			extendRange(s, *u.Timestamp)
-		}
-		if tools.IsEventToolName(u.Tool) || u.Tool == "ApiError" {
-			ev := codexUseToEvent(u)
-			if u.Tool == "MemoryCitation" {
-				ev.Scope = "session"
-				s.Events = append(s.Events, ev)
-			} else if ev.Scope == "turn" {
-				turns.addEvent(u, ev)
-			} else {
+func (a *CodexAccumulator) applyInfo(info *history.CodexSessionInfo) {
+	if info == nil {
+		return
+	}
+	if id := strings.TrimSpace(info.ID); id != "" {
+		a.session.ID = id
+	}
+	if a.session.CWD == "" {
+		a.session.CWD = info.CWD
+	}
+	a.session.Provider = info.ModelProvider
+	a.session.Version = info.CLIVersion
+	a.session.Git.Branch = info.GitBranch
+	a.session.Git.Commit = info.GitCommit
+	if a.session.Model == "" {
+		a.session.Model = info.Model
+	}
+	if info.StartedAt != nil {
+		extendRange(&a.session, *info.StartedAt)
+	}
+}
+
+func (a *CodexAccumulator) observe(use history.ToolUse) {
+	s := &a.session
+	if s.ID == "" {
+		s.ID = use.SessionID
+	}
+	if s.CWD == "" {
+		s.CWD = use.CWD
+	}
+	if s.Model == "" {
+		s.Model = use.Model
+	}
+	if use.Timestamp != nil {
+		extendRange(s, *use.Timestamp)
+	}
+	a.plan.observe(use)
+	if items := todosFromCodexUse(use); len(items) > 0 {
+		s.Todos = items
+	}
+
+	if tools.IsEventToolName(use.Tool) || use.Tool == "ApiError" {
+		ev := codexUseToEvent(use)
+		if use.Tool == "MemoryCitation" {
+			ev.Scope = "session"
+			if a.collect {
 				s.Events = append(s.Events, ev)
 			}
-			mergeCodexCapabilities(&s.Capabilities, u)
-			if u.Tool == "TokenCount" {
-				// Prefer codex's own running total over the record's
-				// self-reported delta: the deltas do not add up to it.
-				cost := codexCostFromUse(u)
-				if delta, ok := cumulative.delta(u); ok {
-					cost = codexCostFromUsage(u.Model, delta)
-				}
-				if cost.TotalTokens != 0 {
-					costs = append(costs, cost)
-					turns.addUsage(u, cost)
-				}
-				if ctx := codexContextFromUse(u); ctx != nil {
-					latestContext = ctx
-				}
-			}
+		} else if ev.Scope == "turn" {
+			a.turns.addEvent(use, ev)
+		} else if a.collect {
+			s.Events = append(s.Events, ev)
+		}
+		if a.collect {
+			mergeCodexCapabilities(&s.Capabilities, use)
+		}
+		if use.Tool == "TokenCount" {
+			a.observeUsage(use)
+		}
+		return
+	}
+	if a.collect {
+		mergeCodexCapabilities(&s.Capabilities, use)
+		if use.Tool == "Agent" && use.AgentID != "" && a.agents[use.AgentID] == nil {
+			a.agents[use.AgentID] = &Agent{ID: use.AgentID, Type: use.AgentType, Desc: use.AgentDesc}
+		}
+	}
+	a.collectPaths(use)
+	message := codexUseToMessage(use)
+	a.turns.addMessage(use, message.ID)
+	if a.collect {
+		s.Messages = append(s.Messages, message)
+	} else {
+		a.freshMessages = append(a.freshMessages, message)
+	}
+	observeCodexIdentity(s, message)
+}
+
+func (a *CodexAccumulator) observeUsage(use history.ToolUse) {
+	cost := codexCostFromUse(use)
+	if delta, ok := a.cumulative.delta(use); ok {
+		cost = codexCostFromUsage(use.Model, delta)
+	}
+	if cost.TotalTokens != 0 {
+		a.session.Cost = a.session.Cost.Add(cost)
+		modelCost := a.costByModel[cost.Model]
+		modelCost.Model = cost.Model
+		a.costByModel[cost.Model] = modelCost.Add(cost)
+		a.turns.addUsage(use, cost)
+	}
+	if context := codexContextFromUse(use); context != nil {
+		a.session.Context = context
+	}
+}
+
+func (a *CodexAccumulator) collectPaths(use history.ToolUse) {
+	footprint := history.ToolFootprint(use)
+	for _, path := range footprint.Read {
+		a.read[claude.AbsolutePath(path, use.CWD, "")] = struct{}{}
+	}
+	for _, path := range footprint.Written {
+		a.written[claude.AbsolutePath(path, use.CWD, "")] = struct{}{}
+	}
+}
+
+// Project builds the next database projection from committed aggregates plus
+// the parser's non-destructive EOF snapshot. Only messages and turns touched by
+// this pass are returned; session metadata remains the full current projection.
+func (a *CodexAccumulator) Project(provisional []history.ToolUse) *Session {
+	s := a.baseSession()
+	s.Messages = append([]Message(nil), a.freshMessages...)
+	a.freshMessages = nil
+
+	plan := a.plan
+	plan.taggedEvents = append([]PlanEvent(nil), plan.taggedEvents...)
+	var extraRead, extraWritten []string
+	for _, use := range provisional {
+		if use.SessionID == "" {
+			use.SessionID = s.ID
+		}
+		if use.Timestamp != nil {
+			extendRange(&s, *use.Timestamp)
+		}
+		plan.observe(use)
+		if items := todosFromCodexUse(use); len(items) > 0 {
+			s.Todos = items
+		}
+		if tools.IsEventToolName(use.Tool) || use.Tool == "ApiError" {
 			continue
 		}
-		mergeCodexCapabilities(&s.Capabilities, u)
-		if u.Tool == "Agent" && u.AgentID != "" {
-			if agents[u.AgentID] == nil {
-				agents[u.AgentID] = &Agent{
-					ID:   u.AgentID,
-					Type: u.AgentType,
-					Desc: u.AgentDesc,
-				}
-			}
-		}
-		collectCodexPaths(u, &read, &written)
-		msg := codexUseToMessage(u)
-		turns.addMessage(u, msg.ID)
-		s.Messages = append(s.Messages, msg)
+		footprint := history.ToolFootprint(use)
+		appendAbsolute(&extraRead, footprint.Read, use.CWD)
+		appendAbsolute(&extraWritten, footprint.Written, use.CWD)
+		message := codexUseToMessage(use)
+		s.Messages = append(s.Messages, message)
+		observeCodexIdentity(&s, message)
 	}
+	s.Plan = plan.value()
+	s.Files = a.changedFiles(extraRead, extraWritten)
+	s.Turns = a.turns.takeDirty(provisional)
+	return &s
+}
 
-	if info != nil {
-		if s.ID == "" {
-			s.ID = info.ID
-		}
-		if s.CWD == "" {
-			s.CWD = info.CWD
-		}
-		s.Provider = info.ModelProvider
-		s.Version = info.CLIVersion
-		s.Git.Branch = info.GitBranch
-		s.Git.Commit = info.GitCommit
-		if s.Model == "" {
-			s.Model = info.Model
-		}
-		if info.StartedAt != nil {
-			extendRange(s, *info.StartedAt)
-		}
-	}
+func (a *CodexAccumulator) baseSession() Session {
+	s := a.session
 	if s.Project == "" && s.CWD != "" {
 		s.Project = filepath.Base(claude.FindProjectRoot(s.CWD))
 	}
-
-	root.ID = s.ID
-	root.Cost = costs.Sum()
-	root.Usage = usageFromCost(root.Cost)
-	s.Root = root
-	s.Agents = []*Agent{root}
-	for _, agent := range sortedCodexAgents(agents) {
-		agent.ParentID = root.ID
-		root.Children = append(root.Children, agent)
-		s.Agents = append(s.Agents, agent)
-	}
-	s.Files = ChangedFiles{
-		Read:    sortedUnique(relativizeAll(read, s.CWD)),
-		Written: sortedUnique(relativizeAll(written, s.CWD)),
-	}
-	s.Todos = latestTodos(uses, func(tu history.ToolUse) (string, map[string]any) {
-		return tu.Tool, tu.Input
-	})
-	s.Plan = CodexPlanFromToolUses(uses)
-	s.Cost = costs.Sum()
+	s.Files = a.changedFiles(nil, nil)
+	s.Plan = a.plan.value()
 	s.Usage = usageFromCost(s.Cost)
-	s.ToolCosts = collapseByModel(costs)
-	s.Context = latestContext
-	s.Turns = turns.finish()
+	s.ToolCosts = codexCostsByModel(a.costByModel)
+	return s
+}
+
+func (a *CodexAccumulator) changedFiles(extraRead, extraWritten []string) ChangedFiles {
+	read := make([]string, 0, len(a.read)+len(extraRead))
+	written := make([]string, 0, len(a.written)+len(extraWritten))
+	for path := range a.read {
+		read = append(read, path)
+	}
+	for path := range a.written {
+		written = append(written, path)
+	}
+	read = append(read, extraRead...)
+	written = append(written, extraWritten...)
+	return ChangedFiles{
+		Read:    sortedUnique(relativizeAll(read, a.session.CWD)),
+		Written: sortedUnique(relativizeAll(written, a.session.CWD)),
+	}
+}
+
+func (a *CodexAccumulator) fullSession() *Session {
+	s := a.baseSession()
+	s.Turns = a.turns.finish()
 	s.Capabilities.Tools = sortedStrings(s.Capabilities.Tools)
 	s.Capabilities.PendingMCPServers = sortedStrings(s.Capabilities.PendingMCPServers)
 	s.Capabilities.Agents = sortedStrings(s.Capabilities.Agents)
 	s.Capabilities.Skills = sortedStrings(s.Capabilities.Skills)
-	applySessionIdentity(s)
-	return s
+
+	root := &Agent{
+		ID: s.ID, IsRoot: true, HistoryFile: s.HistoryFile,
+		Cost: s.Cost, Usage: s.Usage,
+	}
+	s.Root = root
+	s.Agents = []*Agent{root}
+	for _, agent := range sortedCodexAgents(a.agents) {
+		agent.ParentID = root.ID
+		root.Children = append(root.Children, agent)
+		s.Agents = append(s.Agents, agent)
+	}
+	applySessionIdentity(&s)
+	return &s
+}
+
+func codexCostsByModel(byModel map[string]api.Cost) api.Costs {
+	models := make([]string, 0, len(byModel))
+	for model := range byModel {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	costs := make(api.Costs, 0, len(models))
+	for _, model := range models {
+		costs = append(costs, byModel[model])
+	}
+	return costs
+}
+
+func todosFromCodexUse(use history.ToolUse) []tools.TodoItem {
+	if _, ok := todoToolNames[use.Tool]; !ok {
+		return nil
+	}
+	return todosFromInput(use.Input)
+}
+
+func observeCodexIdentity(s *Session, message Message) {
+	if s.InitialPrompt != "" || message.Role != "user" {
+		return
+	}
+	for _, part := range message.Parts {
+		if part.Type != PartText || strings.TrimSpace(part.Text) == "" {
+			continue
+		}
+		s.InitialPrompt = strings.TrimSpace(part.Text)
+		s.Title = DeriveTitle(s.InitialPrompt)
+		return
+	}
+}
+
+// buildCodexSession assembles one Session from an already parsed rollout. It is
+// retained as the package seam used by focused normalizer tests.
+func buildCodexSession(uses []history.ToolUse, info *history.CodexSessionInfo) *Session {
+	accumulator := newCodexAccumulator("", true)
+	accumulator.Add(info, uses)
+	return accumulator.fullSession()
 }
 
 // CodexPlanFromToolUses renders the latest Codex update_plan/TodoWrite state as
 // a canonical inline Plan. Codex revises plans in-place rather than writing plan
 // files, so the final TodoWrite payload is the durable plan content.
 func CodexPlanFromToolUses(uses []history.ToolUse) *Plan {
-	var latest []any
-	var ts *time.Time
-	var taggedContent string
-	var taggedEvents []PlanEvent
+	var state codexPlanState
 	for _, use := range uses {
-		if use.Tool == "Plan" {
-			content, _ := use.Input["content"].(string)
-			if content = strings.TrimSpace(content); content != "" {
-				taggedContent = content
-				taggedEvents = append(taggedEvents, PlanEvent{Kind: PlanWrite, Timestamp: use.Timestamp})
-			}
-			continue
-		}
-		if use.Tool != "TodoWrite" {
-			continue
-		}
-		todos, ok := use.Input["todos"].([]any)
-		if !ok || len(todos) == 0 {
-			continue
-		}
-		latest = todos
-		ts = use.Timestamp
+		state.observe(use)
 	}
-	if taggedContent != "" {
+	return state.value()
+}
+
+type codexPlanState struct {
+	latest        []any
+	latestAt      *time.Time
+	taggedContent string
+	taggedEvents  []PlanEvent
+}
+
+func (s *codexPlanState) observe(use history.ToolUse) {
+	if use.Tool == "Plan" {
+		content, _ := use.Input["content"].(string)
+		if content = strings.TrimSpace(content); content != "" {
+			s.taggedContent = content
+			s.taggedEvents = append(s.taggedEvents, PlanEvent{Kind: PlanWrite, Timestamp: use.Timestamp})
+		}
+		return
+	}
+	if use.Tool != "TodoWrite" {
+		return
+	}
+	todos, ok := use.Input["todos"].([]any)
+	if !ok || len(todos) == 0 {
+		return
+	}
+	s.latest = todos
+	s.latestAt = use.Timestamp
+}
+
+func (s codexPlanState) value() *Plan {
+	if s.taggedContent != "" {
 		return &Plan{
-			Content:  taggedContent,
+			Content:  s.taggedContent,
 			Explicit: true,
-			Events:   taggedEvents,
+			Events:   append([]PlanEvent(nil), s.taggedEvents...),
 		}
 	}
-	if len(latest) == 0 {
+	if len(s.latest) == 0 {
 		return nil
 	}
-	content := renderCodexPlan(latest)
+	content := renderCodexPlan(s.latest)
 	if strings.TrimSpace(content) == "" {
 		return nil
 	}
 	return &Plan{
 		Content:  content,
 		Explicit: true,
-		Events:   []PlanEvent{{Kind: PlanWrite, Timestamp: ts}},
+		Events:   []PlanEvent{{Kind: PlanWrite, Timestamp: s.latestAt}},
 	}
 }
 
@@ -421,12 +573,20 @@ func appendAbsolute(dst *[]string, paths []string, cwd string) {
 }
 
 type codexTurnBuilder struct {
-	order []string
-	byID  map[string]*Turn
+	order         []string
+	byID          map[string]*Turn
+	dirty         map[string]struct{}
+	lastEventAt   map[string]*time.Time
+	explicitEnded map[string]bool
+	collect       bool
 }
 
-func newCodexTurnBuilder() *codexTurnBuilder {
-	return &codexTurnBuilder{byID: map[string]*Turn{}}
+func newCodexTurnBuilder(collect bool) *codexTurnBuilder {
+	return &codexTurnBuilder{
+		byID: map[string]*Turn{}, dirty: map[string]struct{}{},
+		lastEventAt: map[string]*time.Time{}, explicitEnded: map[string]bool{},
+		collect: collect,
+	}
 }
 
 func (b *codexTurnBuilder) ensure(id string, ts *time.Time) *Turn {
@@ -436,6 +596,7 @@ func (b *codexTurnBuilder) ensure(id string, ts *time.Time) *Turn {
 	if turn := b.byID[id]; turn != nil {
 		if turn.StartedAt == nil && ts != nil {
 			turn.StartedAt = cloneTime(ts)
+			b.dirty[id] = struct{}{}
 		}
 		return turn
 	}
@@ -448,6 +609,7 @@ func (b *codexTurnBuilder) ensure(id string, ts *time.Time) *Turn {
 	}
 	b.byID[id] = turn
 	b.order = append(b.order, id)
+	b.dirty[id] = struct{}{}
 	return turn
 }
 
@@ -456,8 +618,11 @@ func (b *codexTurnBuilder) addMessage(u history.ToolUse, messageID string) {
 	if turn == nil {
 		return
 	}
-	turn.MessageIDs = appendUnique(turn.MessageIDs, messageID)
+	if b.collect {
+		turn.MessageIDs = appendUnique(turn.MessageIDs, messageID)
+	}
 	observeCodexTurnRuntime(turn, u)
+	b.dirty[turn.ID] = struct{}{}
 }
 
 func (b *codexTurnBuilder) addEvent(u history.ToolUse, ev Event) {
@@ -470,9 +635,16 @@ func (b *codexTurnBuilder) addEvent(u history.ToolUse, ev Event) {
 	}
 	if u.Tool == "TaskComplete" && u.Timestamp != nil {
 		turn.EndedAt = cloneTime(u.Timestamp)
+		b.explicitEnded[turn.ID] = true
 	}
-	turn.Events = append(turn.Events, ev)
+	if u.Timestamp != nil {
+		b.lastEventAt[turn.ID] = cloneTime(u.Timestamp)
+	}
+	if b.collect {
+		turn.Events = append(turn.Events, ev)
+	}
 	observeCodexTurnRuntime(turn, u)
+	b.dirty[turn.ID] = struct{}{}
 }
 
 func (b *codexTurnBuilder) addUsage(u history.ToolUse, cost api.Cost) {
@@ -486,6 +658,7 @@ func (b *codexTurnBuilder) addUsage(u history.ToolUse, cost api.Cost) {
 		turn.Context = ctx
 	}
 	observeCodexTurnRuntime(turn, u)
+	b.dirty[turn.ID] = struct{}{}
 }
 
 func observeCodexTurnRuntime(turn *Turn, u history.ToolUse) {
@@ -500,19 +673,80 @@ func observeCodexTurnRuntime(turn *Turn, u history.ToolUse) {
 func (b *codexTurnBuilder) finish() []Turn {
 	turns := make([]Turn, 0, len(b.order))
 	for _, id := range b.order {
-		turn := b.byID[id]
-		if turn == nil {
+		turn, ok := b.view(id)
+		if !ok {
 			continue
 		}
-		if turn.EndedAt == nil {
-			for i := len(turn.Events) - 1; i >= 0; i-- {
-				if turn.Events[i].Timestamp != nil {
-					turn.EndedAt = cloneTime(turn.Events[i].Timestamp)
-					break
-				}
+		turns = append(turns, turn)
+	}
+	return turns
+}
+
+func (b *codexTurnBuilder) view(id string) (Turn, bool) {
+	stored := b.byID[id]
+	if stored == nil {
+		return Turn{}, false
+	}
+	turn := *stored
+	if !b.explicitEnded[id] && b.lastEventAt[id] != nil {
+		turn.EndedAt = cloneTime(b.lastEventAt[id])
+	}
+	return turn, true
+}
+
+// takeDirty returns committed turns changed by this batch plus transient copies
+// touched by the current EOF snapshot, then clears the committed dirty set.
+func (b *codexTurnBuilder) takeDirty(provisional []history.ToolUse) []Turn {
+	projected := map[string]Turn{}
+	for id := range b.dirty {
+		if turn, ok := b.view(id); ok {
+			projected[id] = turn
+		}
+	}
+	b.dirty = map[string]struct{}{}
+
+	nextIndex := len(b.order) + 1
+	for _, use := range provisional {
+		id := use.TurnID
+		if id == "" {
+			continue
+		}
+		turn, ok := projected[id]
+		if !ok {
+			if committed, exists := b.view(id); exists {
+				turn = committed
+			} else {
+				turn = Turn{ID: id, Index: nextIndex}
+				nextIndex++
 			}
 		}
-		turns = append(turns, *turn)
+		if turn.StartedAt == nil && use.Timestamp != nil {
+			turn.StartedAt = cloneTime(use.Timestamp)
+		}
+		observeCodexTurnRuntime(&turn, use)
+		if (tools.IsEventToolName(use.Tool) || use.Tool == "ApiError") && use.Timestamp != nil &&
+			use.Tool != "MemoryCitation" && !b.explicitEnded[id] {
+			turn.EndedAt = cloneTime(use.Timestamp)
+		}
+		projected[id] = turn
+	}
+
+	turns := make([]Turn, 0, len(projected))
+	for _, id := range b.order {
+		if turn, ok := projected[id]; ok {
+			turns = append(turns, turn)
+			delete(projected, id)
+		}
+	}
+	if len(projected) > 0 {
+		ids := make([]string, 0, len(projected))
+		for id := range projected {
+			ids = append(ids, id)
+		}
+		sort.Slice(ids, func(i, j int) bool { return projected[ids[i]].Index < projected[ids[j]].Index })
+		for _, id := range ids {
+			turns = append(turns, projected[id])
+		}
 	}
 	return turns
 }

--- a/pkg/session/build_codex.go
+++ b/pkg/session/build_codex.go
@@ -209,11 +209,37 @@ func (a *CodexAccumulator) observeUsage(use history.ToolUse) {
 func (a *CodexAccumulator) collectPaths(use history.ToolUse) {
 	footprint := history.ToolFootprint(use)
 	for _, path := range footprint.Read {
-		a.read[claude.AbsolutePath(path, use.CWD, "")] = struct{}{}
+		a.addPath(a.read, &a.session.Files.Read, path, use.CWD)
 	}
 	for _, path := range footprint.Written {
-		a.written[claude.AbsolutePath(path, use.CWD, "")] = struct{}{}
+		a.addPath(a.written, &a.session.Files.Written, path, use.CWD)
 	}
+}
+
+func (a *CodexAccumulator) addPath(seen map[string]struct{}, files *[]string, path, cwd string) {
+	absolute := claude.AbsolutePath(path, cwd, "")
+	if absolute == "" {
+		return
+	}
+	if _, ok := seen[absolute]; ok {
+		return
+	}
+	seen[absolute] = struct{}{}
+	*files = insertSortedString(*files, claude.RelativePath(absolute, a.session.CWD))
+}
+
+func insertSortedString(values []string, value string) []string {
+	if value == "" {
+		return values
+	}
+	index := sort.SearchStrings(values, value)
+	if index < len(values) && values[index] == value {
+		return values
+	}
+	values = append(values, "")
+	copy(values[index+1:], values[index:])
+	values[index] = value
+	return values
 }
 
 // Project builds the next database projection from committed aggregates plus
@@ -267,20 +293,20 @@ func (a *CodexAccumulator) baseSession() Session {
 }
 
 func (a *CodexAccumulator) changedFiles(extraRead, extraWritten []string) ChangedFiles {
-	read := make([]string, 0, len(a.read)+len(extraRead))
-	written := make([]string, 0, len(a.written)+len(extraWritten))
-	for path := range a.read {
-		read = append(read, path)
+	if len(extraRead) == 0 && len(extraWritten) == 0 {
+		return a.session.Files
 	}
-	for path := range a.written {
-		written = append(written, path)
+	files := ChangedFiles{
+		Read:    append([]string(nil), a.session.Files.Read...),
+		Written: append([]string(nil), a.session.Files.Written...),
 	}
-	read = append(read, extraRead...)
-	written = append(written, extraWritten...)
-	return ChangedFiles{
-		Read:    sortedUnique(relativizeAll(read, a.session.CWD)),
-		Written: sortedUnique(relativizeAll(written, a.session.CWD)),
+	for _, path := range extraRead {
+		files.Read = insertSortedString(files.Read, claude.RelativePath(path, a.session.CWD))
 	}
+	for _, path := range extraWritten {
+		files.Written = insertSortedString(files.Written, claude.RelativePath(path, a.session.CWD))
+	}
+	return files
 }
 
 func (a *CodexAccumulator) fullSession() *Session {
@@ -732,22 +758,10 @@ func (b *codexTurnBuilder) takeDirty(provisional []history.ToolUse) []Turn {
 	}
 
 	turns := make([]Turn, 0, len(projected))
-	for _, id := range b.order {
-		if turn, ok := projected[id]; ok {
-			turns = append(turns, turn)
-			delete(projected, id)
-		}
+	for _, turn := range projected {
+		turns = append(turns, turn)
 	}
-	if len(projected) > 0 {
-		ids := make([]string, 0, len(projected))
-		for id := range projected {
-			ids = append(ids, id)
-		}
-		sort.Slice(ids, func(i, j int) bool { return projected[ids[i]].Index < projected[ids[j]].Index })
-		for _, id := range ids {
-			turns = append(turns, projected[id])
-		}
-	}
+	sort.Slice(turns, func(i, j int) bool { return turns[i].Index < turns[j].Index })
 	return turns
 }
 


### PR DESCRIPTION
Captain reprocessed the complete Codex JSONL transcript after every append, so live-update latency and allocation grew with the full session history.

This keeps an in-memory parser and normalization checkpoint per transcript and resumes from the last complete newline. Partial records are reread on the next update, and checkpoints advance only after ingestion succeeds. Restart, parser-version changes, truncation, replacement, or source-bookkeeping drift safely fall back to a full replay.

## Benchmark

`benchstat` compares the PR's original benchmark commit (`841a46c`, whole-file refresh) with the incremental implementation (`829d4ca`, warm nine-line append). Each side used 10 samples and 10 iterations per sample. The benchmark labels were normalized to `CodexLiveUpdate` because the before and after measurements intentionally exercise different production entry points.

```text
goos: linux
goarch: amd64
pkg: github.com/flanksource/captain/pkg/monitor
cpu: Intel(R) Xeon(R) Processor @ 2.60GHz
                                            │   before.txt   │              after.txt               │
                                            │     sec/op     │    sec/op     vs base                │
CodexLiveUpdate/1000_lines_219048_bytes-8      11154.1µ ± 8%   160.8µ ± 96%  -98.56% (p=0.000 n=10)
CodexLiveUpdate/10000_lines_2198875_bytes-8   119841.1µ ± 3%   183.9µ ± 23%  -99.85% (p=0.000 n=10)
CodexLiveUpdate/25003_lines_5507854_bytes-8   286470.0µ ± 2%   192.2µ ± 12%  -99.93% (p=0.000 n=10)
geomean                                          72.62m        178.5µ        -99.75%

                                            │   before.txt    │              after.txt               │
                                            │      B/op       │     B/op      vs base                │
CodexLiveUpdate/1000_lines_219048_bytes-8      12476.6Ki ± 0%   118.3Ki ± 3%  -99.05% (p=0.000 n=10)
CodexLiveUpdate/10000_lines_2198875_bytes-8   130447.8Ki ± 0%   118.4Ki ± 1%  -99.91% (p=0.000 n=10)
CodexLiveUpdate/25003_lines_5507854_bytes-8   325956.5Ki ± 0%   118.4Ki ± 1%  -99.96% (p=0.000 n=10)
geomean                                          79.06Mi        118.3Ki       -99.85%

                                            │   before.txt   │             after.txt              │
                                            │   allocs/op    │ allocs/op   vs base                │
CodexLiveUpdate/1000_lines_219048_bytes-8       54284.0 ± 0%   578.0 ± 1%  -98.94% (p=0.000 n=10)
CodexLiveUpdate/10000_lines_2198875_bytes-8    540415.5 ± 0%   578.0 ± 1%  -99.89% (p=0.000 n=10)
CodexLiveUpdate/25003_lines_5507854_bytes-8   1350673.5 ± 0%   578.0 ± 1%  -99.96% (p=0.000 n=10)
geomean                                          340.9k        578.0       -99.83%
```

Warm update time and allocation are now effectively flat as the transcript grows. A cold replay remains available for restart and invalidation cases.

<img width="690" height="224" alt="image" src="https://github.com/user-attachments/assets/a6d3ee0a-dcde-4498-a6b3-bcb0f0ad8a8c" />


Closes #91