### PR TITLE
fix: build web UI before releasing binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26.x"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+      - uses: pnpm/action-setup@v4
+      - run: pnpm --dir pkg/cli/webapp install --frozen-lockfile
+      - run: pnpm --dir pkg/cli/webapp build
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean

--- a/README.md
+++ b/README.md
@@ -565,10 +565,12 @@ This repo uses `task` as the main task runner.
 
 ### Build
 
+Build the web UI before the Go binary so the generated JavaScript and CSS assets
+are included in the embedded filesystem:
+
 ```bash
+task www:build
 task build
-# or
-make build
 ```
 
 Binary output:

--- a/pkg/cli/webapp/pnpm-workspace.yaml
+++ b/pkg/cli/webapp/pnpm-workspace.yaml
@@ -2,7 +2,20 @@ packages:
   - .
 
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@flanksource/clicky-ui'
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  # semver 6.3.1 has no provenance attestation, but earlier-published 7.5.4 does, so pnpm flags a trust downgrade.
+  #
+  # npm lets maintainers update older major lines after newer majors have been
+  # released, and each published version records provenance independently.
+  # semver 6.2.0 (July 2019) had no provenance; 7.5.4 (July 7, 2023) had SLSA
+  # provenance; then the v6 backport 6.3.1 (July 10, 2023) was published without
+  # it. pnpm compares that publication timeline rather than version order, so it
+  # reports 6.3.1 as a downgrade. Babel requires ^6.3.1, so exempt only this
+  # immutable release; integrity and trust checks remain enabled elsewhere.
+  - semver@6.3.1
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
`captain serve` embeds `pkg/cli/webapp/dist`, but release jobs built Go binaries from clean checkouts without generating the ignored JavaScript and CSS bundles. The embedded index therefore referenced missing assets and rendered a blank UI.

Install the pinned Node and pnpm toolchain and build the webapp before GoReleaser so the generated assets are available to `go:embed`. Add narrowly scoped pnpm policy exceptions required by the current dependency graph.

Closes #90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Release**
  - Release builds now automatically install web application dependencies, compile web assets, and embed them in the Go binary.
  - The release process uses Node.js 24 for web asset builds.

- **Documentation**
  - Updated build instructions to require `task www:build` before `task build`.
  - Removed the outdated `make build` alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->