### PR TITLE
fix(serve): authenticate all off-box API routes

### DIFF
--- a/pkg/cli/serve_auth.go
+++ b/pkg/cli/serve_auth.go
@@ -19,15 +19,10 @@ import (
 	"github.com/flanksource/captain/pkg/gitagent"
 )
 
-const (
-	// gitPathPrefix is the subtree the git smart-HTTP transport is served
-	// under. Taken from the transport rather than restated, so the routing, the
-	// auth scope and the database-context exemption cannot drift apart.
-	gitPathPrefix = gitagent.GitHTTPPrefix
-	// apiPathPrefix is the REST executor's subtree. A request here runs a
-	// captain command, which is why it needs the stronger of the two scopes.
-	apiPathPrefix = "/api/v1"
-)
+// gitPathPrefix is the subtree the git smart-HTTP transport is served
+// under. Taken from the transport rather than restated, so the routing, the
+// auth scope and the database-context exemption cannot drift apart.
+const gitPathPrefix = gitagent.GitHTTPPrefix
 
 // tokenContextKey carries the verified credential to the handler.
 type tokenContextKey struct{}
@@ -102,7 +97,7 @@ func requiredScope(path string) (captaintoken.Scope, bool) {
 	switch {
 	case strings.HasPrefix(path, gitPathPrefix):
 		return captaintoken.ScopeGit, true
-	case path == apiPathPrefix || strings.HasPrefix(path, apiPathPrefix+"/"):
+	case path == "/api" || strings.HasPrefix(path, "/api/"):
 		return captaintoken.ScopeAPI, true
 	default:
 		return "", false

--- a/pkg/cli/serve_auth_test.go
+++ b/pkg/cli/serve_auth_test.go
@@ -228,22 +228,25 @@ func TestAStoreOutageIsNotAnAuthenticationFailure(t *testing.T) {
 }
 
 // The SPA has nowhere to put a bearer token, so the pages a browser loads stay
-// open; only the two subtrees that act on the host are protected.
-func TestOnlyTheCommandAndGitSubtreesAreProtected(t *testing.T) {
+// open; the API and git subtrees that act on the host are protected.
+func TestTheAPIAndGitSubtreesAreProtected(t *testing.T) {
 	fixture := newAuthFixture(t, captaintoken.ScopeAPI)
 
-	for _, path := range []string{"/", "/health", "/assets/index.js", "/api/captain/prompt/runs", "/api/chat"} {
+	for _, path := range []string{"/", "/health", "/assets/index.js"} {
 		recorder := fixture.call(http.MethodGet, path, remoteAddr, nil)
 		assert.Equalf(t, http.StatusOK, recorder.Code, "%s should not require a token", path)
 	}
 
-	for _, path := range []string{"/api/v1", "/api/v1/sessions", "/git/mailboxes/aaa.git/info/refs"} {
+	for _, path := range []string{
+		"/api/openapi.json", "/api/v1/sessions", "/api/captain/prompt/runs", "/api/chat",
+		"/api/attachments/aaa", "/git/mailboxes/aaa.git/info/refs",
+	} {
 		recorder := fixture.call(http.MethodGet, path, remoteAddr, nil)
 		assert.Equalf(t, http.StatusUnauthorized, recorder.Code, "%s must require a token", path)
 	}
 
 	// A path that merely starts with the same letters is not the API subtree.
-	recorder := fixture.call(http.MethodGet, "/api/v1beta/sessions", remoteAddr, nil)
+	recorder := fixture.call(http.MethodGet, "/apiary", remoteAddr, nil)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 


### PR DESCRIPTION
Captain token authentication intentionally classified only the `/api/v1` command executor and `/git` transport as protected.

Bespoke host-backed endpoints under `/api/captain`, `/api/chat`, and `/api/attachments` share the same non-loopback listener, allowing any network caller to bypass token verification and access supervisor capabilities.

Classify the complete `/api` namespace as API-scoped for non-loopback requests. Loopback access, SPA assets, `/health`, and the separate Git scope remain unchanged.

Fixes #93.

## Security impact

When `captain serve` binds off-loopback for remote agents, these endpoints were reachable by any network caller without presenting a Captain token. Representative high-impact examples include:

- **Kubernetes reconnaissance and partial secret disclosure:** `GET /api/captain/secrets/resources` and `GET /api/captain/secrets/preview` use the supervisor's kubeconfig to expose Secret and ConfigMap names, keys, and masked value previews. The sandbox picker routes also expose Kubernetes namespaces, Secret names, and ClusterIssuers.
- **AI execution using supervisor credentials:** `POST /api/chat` starts model executions through the supervisor's configured providers, allowing an unauthenticated caller to consume model capacity and create persisted runs.
- **Conversation and session disclosure:** `GET /api/chat/sessions`, `GET /api/chat/sessions/{id}`, and `GET /api/captain/sessions/live` expose persisted conversations, initial prompts, working directories, branches, provider sessions, and live-process metadata.
- **Unauthorized tool approval:** `POST /api/chat/sessions/{id}/approvals/{approvalID}` can resolve a pending host-backed tool request without authenticating the approving caller.
- **Task and process interference:** the `/api/captain/tasks` routes allow callers to enumerate live runs, stop or restart runs and child tasks, and write to task stdin when those controls are advertised.
- **Prompt-run control:** the `/api/captain/prompt/runs/{runId}` routes expose live output and allow unauthenticated callers to send messages, interrupt, or stop active runs.
- **Untrusted file persistence:** `POST /api/attachments` stores caller-controlled files on the supervisor, permitting repeated unauthenticated uploads up to the configured per-request limit.

These are representative examples rather than an endpoint allowlist. Protecting the `/api` namespace ensures newly added host-backed routes cannot silently bypass authentication again.