### PR TITLE
fix: report git-agent worker failures to supervisors

### DIFF
--- a/pkg/cli/gitagent_hook.go
+++ b/pkg/cli/gitagent_hook.go
@@ -76,7 +76,11 @@ func RunGitAgentHook(ctx context.Context, opts GitAgentHookOptions) (any, error)
 		// alternative — launching nothing — leaves the supervisor waiting out
 		// its whole budget on work that never started.
 		DefaultAgentCommand: func(repo, task string) string {
-			return DefaultAgentCommand(exe, repo, task, configPath)
+			command := DefaultAgentCommand(exe, repo, task, configPath)
+			if backend := strings.TrimSpace(opts.Backend); backend != "" {
+				command += fmt.Sprintf(" --backend %q", backend)
+			}
+			return command
 		},
 	}
 	switch opts.Hook {

--- a/pkg/cli/gitagent_runtask.go
+++ b/pkg/cli/gitagent_runtask.go
@@ -26,13 +26,28 @@ type GitAgentRunTaskOptions struct {
 
 // RunGitAgentRunTask performs one task end to end on the agent host: read the
 // dispatched prompt, run it in the worktree, then commit and push. Its output
-// is the agent log, so every failure is reported there rather than to a
-// terminal nobody is watching.
+// is the agent log; failures are also relayed as terminal supervisor outcomes.
 func RunGitAgentRunTask(ctx context.Context, opts GitAgentRunTaskOptions) (_ any, runErr error) {
 	started := time.Now()
+	reportFailure := true
 	defer func() {
 		if runErr != nil {
 			log.Errorf("git-agent task %s failed after %s: %v", opts.Task, time.Since(started).Round(time.Millisecond), runErr)
+			if !reportFailure {
+				return
+			}
+			runtime, err := hookRuntimeFromConfig(opts.Backend)
+			if err != nil {
+				log.Errorf("git-agent task %s could not load relay configuration: %v", opts.Task, err)
+				return
+			}
+			reportCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			if err := gitagent.ReportTaskFailure(reportCtx, opts.Repo, runtime.Relay, opts.Task, runErr); err != nil {
+				log.Errorf("git-agent task %s could not report its failure to the supervisor: %v", opts.Task, err)
+				return
+			}
+			log.Infof("git-agent task %s reported its terminal failure to the supervisor", opts.Task)
 		}
 	}()
 	if strings.TrimSpace(opts.Config) != "" {
@@ -52,7 +67,9 @@ func RunGitAgentRunTask(ctx context.Context, opts GitAgentRunTaskOptions) (_ any
 		return nil, fmt.Errorf("running the dispatched prompt: %w", err)
 	}
 	log.Infof("git-agent task %s agent finished after %s; preparing submission", opts.Task, time.Since(started).Round(time.Millisecond))
-	if err := submitWork(ctx, worktree, opts.Task); err != nil {
+	pushAttempted, err := submitWork(ctx, worktree, opts.Task)
+	reportFailure = !pushAttempted
+	if err != nil {
 		return nil, err
 	}
 	log.Infof("git-agent task %s accepted after %s", opts.Task, time.Since(started).Round(time.Millisecond))
@@ -89,27 +106,29 @@ func runTaskPrompt(ctx context.Context, worktree string, payload gitagent.TaskPa
 
 // submitWork performs the agent's half of the protocol: stage everything the
 // run produced, commit, and push. A run that changed nothing is reported as
-// such rather than pushed as an empty success.
-func submitWork(ctx context.Context, worktree, task string) error {
+// such rather than pushed as an empty success. The boolean becomes true once
+// push starts, because a failed push may already have produced an authoritative
+// hook verdict that the runner must not replace with a terminal worker error.
+func submitWork(ctx context.Context, worktree, task string) (bool, error) {
 	log.Infof("git-agent task %s staging workspace changes", task)
 	if err := git(ctx, worktree, "add", "-A"); err != nil {
-		return err
+		return false, err
 	}
 	staged, err := hasStagedChanges(ctx, worktree)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !staged {
-		return fmt.Errorf("the agent produced no changes for task %s; nothing to submit", task)
+		return false, fmt.Errorf("the agent produced no changes for task %s; nothing to submit", task)
 	}
 	log.Infof("git-agent task %s committing workspace changes", task)
 	if err := git(ctx, worktree, "commit", "-m", "captain: "+task); err != nil {
-		return err
+		return false, err
 	}
 	// The push carries the work through both hook tiers and blocks until the
 	// verdict, so its output is the agent's most important log line.
 	log.Infof("git-agent task %s pushing for sidecar and supervisor verification", task)
-	return git(ctx, worktree, "push")
+	return true, git(ctx, worktree, "push")
 }
 
 func git(ctx context.Context, dir string, args ...string) error {

--- a/pkg/gitagent/admit.go
+++ b/pkg/gitagent/admit.go
@@ -112,7 +112,7 @@ func admitProtocolRef(req AdmitRequest, u RefUpdate) (RefInfo, error) {
 	}
 	allowed := map[ReceiverRole][]RefKind{
 		RoleSidecar: {RefDispatch, RefControl},
-		RoleMailbox: {RefResult, RefControl},
+		RoleMailbox: {RefResult, RefControl, RefVerdict},
 	}[req.Role]
 	if !containsKind(allowed, info.Kind) {
 		return RefInfo{}, fmt.Errorf("ref %s: a %s does not accept %s refs over the wire", u.Ref, req.Role, info.Kind)
@@ -201,6 +201,12 @@ func requireAtomicPairs(ctx context.Context, req AdmitRequest, protocol map[stri
 		kinds[k][info.Kind] = true
 	}
 	for k, present := range kinds {
+		if present[RefVerdict] {
+			if len(present) != 1 {
+				return fmt.Errorf("task %s attempt %d: a terminal verdict must be pushed alone", k.task, k.attempt)
+			}
+			continue
+		}
 		code := present[RefDispatch] || present[RefResult]
 		if code && !present[RefControl] && !controlRefExists(ctx, req, k.task, k.attempt) {
 			return fmt.Errorf("task %s attempt %d: a code ref without its control ref is unprocessable (R3.4)", k.task, k.attempt)
@@ -224,7 +230,7 @@ func controlRefExists(ctx context.Context, req AdmitRequest, task string, attemp
 // admitCodeContent runs the content checks that need object access: result
 // parentage, blob caps and name gates. Control refs carry no worktree code.
 func admitCodeContent(ctx context.Context, req AdmitRequest, u RefUpdate, info RefInfo) error {
-	if info.Kind != RefResult {
+	if info.Kind != RefResult && info.Kind != RefVerdict {
 		return nil
 	}
 	st, ok, err := LoadTaskState(req.Repo, info.Task)
@@ -240,6 +246,10 @@ func admitCodeContent(ctx context.Context, req AdmitRequest, u RefUpdate, info R
 			got = req.Envelope.Base
 		}
 		return fmt.Errorf("task %s: envelope base %s does not match dispatched base %s", info.Task, got, st.Base)
+	}
+	if info.Kind == RefVerdict {
+		_, err := readRelayedVerdict(ctx, req.Repo, req.Env, u.New, info)
+		return err
 	}
 	parents, err := runGit(ctx, req.Repo, req.Env, "rev-list", "--parents", "-n", "1", u.New)
 	if err != nil {

--- a/pkg/gitagent/control.go
+++ b/pkg/gitagent/control.go
@@ -15,9 +15,10 @@ import (
 
 // Control payload file names (§4).
 const (
-	ControlTaskFile   = "task.json"
-	ControlHooksFile  = "hooks.json"
-	ControlPolicyFile = "policy.json"
+	ControlTaskFile    = "task.json"
+	ControlHooksFile   = "hooks.json"
+	ControlPolicyFile  = "policy.json"
+	ControlVerdictFile = "verdict.json"
 )
 
 // HookSets is the hooks.json wire payload. The supervisor chooses both tiers;

--- a/pkg/gitagent/dispatch.go
+++ b/pkg/gitagent/dispatch.go
@@ -273,9 +273,9 @@ func SSHTransportCommand(executable string) string {
 }
 
 // AwaitOutcome polls the mailbox for the task's final verdict: the first
-// accepted one, or a rejection on the task's last permitted attempt, or a
-// timeout. Rejected non-final attempts keep waiting — rejection is not
-// termination (§6.3).
+// accepted one, a worker-reported terminal error, a rejection on the task's
+// last permitted attempt, or a timeout. Rejected non-final attempts keep
+// waiting — rejection is not termination (§6.3).
 func AwaitOutcome(ctx context.Context, mailbox, task string, timeout time.Duration) (*TierVerdict, error) {
 	if timeout <= 0 {
 		timeout = time.Hour
@@ -302,6 +302,9 @@ func AwaitOutcome(ctx context.Context, mailbox, task string, timeout time.Durati
 				break
 			}
 			if v.Status == StatusAccepted {
+				return v, nil
+			}
+			if v.Terminal {
 				return v, nil
 			}
 			if maxAttempts > 0 && attempt >= maxAttempts {

--- a/pkg/gitagent/dispatch.go
+++ b/pkg/gitagent/dispatch.go
@@ -290,8 +290,10 @@ func AwaitOutcome(ctx context.Context, mailbox, task string, timeout time.Durati
 			return nil, err
 		}
 		maxAttempts := 0
+		highestAttempt := 0
 		if ok {
 			maxAttempts = st.Policy.MaxAttempts
+			highestAttempt = st.Attempts
 		}
 		for attempt := 1; attempt <= MaxAttempt; attempt++ {
 			v, found, err := LoadVerdict(mailbox, task, attempt)
@@ -299,7 +301,10 @@ func AwaitOutcome(ctx context.Context, mailbox, task string, timeout time.Durati
 				return nil, err
 			}
 			if !found {
-				break
+				if attempt >= highestAttempt {
+					break
+				}
+				continue
 			}
 			if v.Status == StatusAccepted {
 				return v, nil

--- a/pkg/gitagent/hookmain.go
+++ b/pkg/gitagent/hookmain.go
@@ -448,7 +448,7 @@ func rejectWithVerdict(repo string, verdict TierVerdict, sideband io.Writer) err
 
 // RunPostReceive owns the work that is only legal once quarantine has ended
 // (R6.4): sidecar workspace setup and agent launch on dispatch, supervisor
-// integration and the verdict ref on an accepted result.
+// integration, and persistence of accepted or worker-reported verdicts.
 func RunPostReceive(ctx context.Context, repo string, role ReceiverRole, host HookHost, stdin io.Reader) error {
 	updates, err := ParseRefUpdates(stdin)
 	if err != nil {
@@ -550,6 +550,21 @@ func loadDispatchPayloads(ctx context.Context, repo string, updates []RefUpdate,
 }
 
 func mailboxPostReceive(ctx context.Context, repo string, host HookHost, updates []RefUpdate) error {
+	if verdictUpdate, info, ok := singleVerdictUpdate(updates); ok {
+		verdict, err := readRelayedVerdict(ctx, repo, os.Environ(), verdictUpdate.New, info)
+		if err != nil {
+			return err
+		}
+		if _, err := UpdateTaskState(repo, info.Task, func(current *TaskState) (bool, error) {
+			if info.Attempt > current.Attempts {
+				current.Attempts = info.Attempt
+			}
+			return true, nil
+		}); err != nil {
+			return err
+		}
+		return SaveVerdict(repo, verdict)
+	}
 	resultUpdate, info, ok := singleResultUpdate(updates)
 	if !ok {
 		return nil
@@ -607,7 +622,7 @@ func writeVerdictRef(ctx context.Context, repo string, verdict TierVerdict) erro
 	if err != nil {
 		return err
 	}
-	commit, err := BuildControlCommit(ctx, repo, nil, map[string][]byte{"verdict.json": payload})
+	commit, err := BuildControlCommit(ctx, repo, nil, map[string][]byte{ControlVerdictFile: payload})
 	if err != nil {
 		return err
 	}
@@ -627,6 +642,15 @@ func singleAgentBranchUpdate(updates []RefUpdate) (RefUpdate, string, bool) {
 func singleResultUpdate(updates []RefUpdate) (RefUpdate, RefInfo, bool) {
 	for _, u := range updates {
 		if info, err := ParseTaskRef(u.Ref); err == nil && info.Kind == RefResult {
+			return u, info, true
+		}
+	}
+	return RefUpdate{}, RefInfo{}, false
+}
+
+func singleVerdictUpdate(updates []RefUpdate) (RefUpdate, RefInfo, bool) {
+	for _, u := range updates {
+		if info, err := ParseTaskRef(u.Ref); err == nil && info.Kind == RefVerdict {
 			return u, info, true
 		}
 	}

--- a/pkg/gitagent/relay.go
+++ b/pkg/gitagent/relay.go
@@ -236,20 +236,16 @@ func ReportTaskFailure(ctx context.Context, repo string, target RelayTarget, tas
 	if failure == nil {
 		return fmt.Errorf("task failure is required")
 	}
-	var attempt int
-	st, err := UpdateTaskState(repo, task, func(current *TaskState) (bool, error) {
-		attempt = current.Attempts + 1
-		if current.Policy.MaxAttempts > 0 && attempt > current.Policy.MaxAttempts {
-			return false, fmt.Errorf("attempt %d exceeds the task's maxAttempts %d", attempt, current.Policy.MaxAttempts)
-		}
-		current.Attempts = attempt
-		return true, nil
-	})
+	st, ok, err := LoadTaskState(repo, task)
 	if err != nil {
 		return err
 	}
-	if st == nil {
+	if !ok {
 		return fmt.Errorf("task %s state is missing", task)
+	}
+	attempt := st.Attempts + 1
+	if st.Policy.MaxAttempts > 0 && attempt > st.Policy.MaxAttempts {
+		return fmt.Errorf("attempt %d exceeds the task's maxAttempts %d", attempt, st.Policy.MaxAttempts)
 	}
 	message := failure.Error()
 	if len(message) > maxFindingFeedback {
@@ -302,6 +298,15 @@ func ReportTaskFailure(ctx context.Context, repo string, target RelayTarget, tas
 	}
 	if _, err := runGit(ctx, repo, env, args...); err != nil {
 		return fmt.Errorf("relay terminal failure verdict: %w", err)
+	}
+	if _, err := UpdateTaskState(repo, task, func(current *TaskState) (bool, error) {
+		if current.Attempts >= attempt {
+			return false, nil
+		}
+		current.Attempts = attempt
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("record relayed failure attempt: %w", err)
 	}
 	return nil
 }

--- a/pkg/gitagent/relay.go
+++ b/pkg/gitagent/relay.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
@@ -225,6 +226,82 @@ func Relay(ctx context.Context, repo string, hookEnv []string, target RelayTarge
 			return &upstreamRejectedError{verdict: *feedback.verdict}
 		}
 		return fmt.Errorf("supervisor rejected attempt %d (exit %d)%s", envelope.Attempt, code, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+// ReportTaskFailure sends a terminal error verdict when the detached worker
+// exits before it can make the ordinary branch push that starts result relay.
+func ReportTaskFailure(ctx context.Context, repo string, target RelayTarget, task string, failure error) error {
+	if failure == nil {
+		return fmt.Errorf("task failure is required")
+	}
+	var attempt int
+	st, err := UpdateTaskState(repo, task, func(current *TaskState) (bool, error) {
+		attempt = current.Attempts + 1
+		if current.Policy.MaxAttempts > 0 && attempt > current.Policy.MaxAttempts {
+			return false, fmt.Errorf("attempt %d exceeds the task's maxAttempts %d", attempt, current.Policy.MaxAttempts)
+		}
+		current.Attempts = attempt
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	if st == nil {
+		return fmt.Errorf("task %s state is missing", task)
+	}
+	message := failure.Error()
+	if len(message) > maxFindingFeedback {
+		message = message[:maxFindingFeedback] + "\n[failure message truncated]"
+	}
+	verdict := TierVerdict{
+		V: ProtocolVersion, Task: task, Attempt: attempt,
+		Tier: string(RoleSidecar), Status: StatusError, Terminal: true,
+		Findings: []Finding{{Hook: "agent", Kind: "exec", Message: message}},
+	}
+	if err := SaveVerdict(repo, verdict); err != nil {
+		return fmt.Errorf("save local failure verdict: %w", err)
+	}
+	payload, err := json.MarshalIndent(verdict, "", "  ")
+	if err != nil {
+		return err
+	}
+	commit, err := BuildControlCommit(ctx, repo, nil, map[string][]byte{ControlVerdictFile: payload})
+	if err != nil {
+		return err
+	}
+	mailboxURL, err := MailboxURL(target.URL, st.Mailbox)
+	if err != nil {
+		return err
+	}
+	verdictRef, err := VerdictRef(task, attempt)
+	if err != nil {
+		return err
+	}
+	envelope := Envelope{
+		Version: ProtocolVersion, Task: task, Attempt: attempt,
+		Base: st.Base, Depth: 0, Agent: st.Agent, Relay: st.Relay,
+	}
+	opts, err := envelope.Encode()
+	if err != nil {
+		return err
+	}
+	args := []string{"push", "--atomic"}
+	for _, option := range opts {
+		args = append(args, "--push-option="+option)
+	}
+	args = append(args, mailboxURL, commit+":"+verdictRef)
+	transport, err := target.Transport(mailboxURL)
+	if err != nil {
+		return err
+	}
+	env, err := TransportEnv(ScrubGitEnv(os.Environ()), transport)
+	if err != nil {
+		return err
+	}
+	if _, err := runGit(ctx, repo, env, args...); err != nil {
+		return fmt.Errorf("relay terminal failure verdict: %w", err)
 	}
 	return nil
 }

--- a/pkg/gitagent/scan.go
+++ b/pkg/gitagent/scan.go
@@ -34,10 +34,11 @@ type TaskSnapshot struct {
 // Concluded reports the terminal outcome of a task, if it has one.
 //
 // The filesystem never records "this task is over", so it is derived: an
-// accepted verdict at the supervisor tier ends the task, and so does a
-// non-accepted one once the attempt budget is spent. Anything else is still in
-// flight — a rejection with attempts remaining is explicitly not terminal
-// (SPEC-git-agent-protocol §6.3, "rejection is not termination").
+// accepted verdict at the supervisor tier ends the task, as does an explicitly
+// terminal worker error or a non-accepted verdict once the attempt budget is
+// spent. Anything else is still in flight — a rejection with attempts
+// remaining is explicitly not terminal (SPEC-git-agent-protocol §6.3,
+// "rejection is not termination").
 func (s TaskSnapshot) Concluded() (VerdictStatus, bool) {
 	final, ok := s.finalVerdict()
 	if !ok {
@@ -45,6 +46,9 @@ func (s TaskSnapshot) Concluded() (VerdictStatus, bool) {
 	}
 	if final.Status == StatusAccepted {
 		return StatusAccepted, true
+	}
+	if final.Terminal {
+		return final.Status, true
 	}
 	budget := 0
 	if s.State != nil {

--- a/pkg/gitagent/verdict.go
+++ b/pkg/gitagent/verdict.go
@@ -4,11 +4,15 @@
 package gitagent
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // VerdictStatus is accepted | rejected | error. error means the tier could
@@ -37,12 +41,65 @@ type TierVerdict struct {
 	Attempt  int           `json:"attempt"`
 	Status   VerdictStatus `json:"status"`
 	Tier     string        `json:"tier"` // "sidecar" | "supervisor"
+	Terminal bool          `json:"terminal,omitempty"`
 	Findings []Finding     `json:"findings,omitempty"`
 }
 
 // Rejects reports whether the push must be refused. Only an explicit accept
 // passes: error is indeterminate and indeterminate rejects (R7.5).
 func (v TierVerdict) Rejects() bool { return v.Status != StatusAccepted }
+
+// readRelayedVerdict decodes the only verdict a worker may send directly:
+// a terminal sidecar error for a run that ended before it could push code.
+func readRelayedVerdict(ctx context.Context, repo string, env []string, commit string, info RefInfo) (TierVerdict, error) {
+	var verdict TierVerdict
+	parents, err := runGit(ctx, repo, env, "rev-list", "--parents", "-n", "1", commit)
+	if err != nil {
+		return verdict, err
+	}
+	if fields := strings.Fields(parents); len(fields) != 1 || fields[0] != commit {
+		return verdict, fmt.Errorf("relayed verdict must be a parentless control commit")
+	}
+	tree, err := runGitRaw(ctx, repo, env, nil, "ls-tree", "-z", commit)
+	if err != nil {
+		return verdict, err
+	}
+	if !strings.HasPrefix(tree, "100644 blob ") || !strings.HasSuffix(tree, "\t"+ControlVerdictFile+"\x00") || strings.Count(tree, "\x00") != 1 {
+		return verdict, fmt.Errorf("relayed verdict control commit must contain only %s", ControlVerdictFile)
+	}
+	raw, err := ReadControlPayload(ctx, repo, env, commit, ControlVerdictFile)
+	if err != nil {
+		return verdict, fmt.Errorf("read relayed verdict: %w", err)
+	}
+	if len(raw) > MaxFeedbackBytes {
+		return verdict, fmt.Errorf("relayed verdict is %d bytes, over the %d-byte cap", len(raw), MaxFeedbackBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&verdict); err != nil {
+		return verdict, fmt.Errorf("decode relayed verdict: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values")
+		}
+		return verdict, fmt.Errorf("decode relayed verdict: %w", err)
+	}
+	if verdict.V != ProtocolVersion {
+		return verdict, fmt.Errorf("relayed verdict version %d does not match protocol version %d", verdict.V, ProtocolVersion)
+	}
+	if verdict.Task != info.Task || verdict.Attempt != info.Attempt {
+		return verdict, fmt.Errorf("relayed verdict %s attempt %d disagrees with ref %s attempt %d",
+			verdict.Task, verdict.Attempt, info.Task, info.Attempt)
+	}
+	if verdict.Tier != string(RoleSidecar) || verdict.Status != StatusError || !verdict.Terminal {
+		return verdict, fmt.Errorf("relayed verdict must be a terminal sidecar error")
+	}
+	if len(verdict.Findings) == 0 {
+		return verdict, fmt.Errorf("relayed verdict carries no failure finding")
+	}
+	return verdict, nil
+}
 
 func verdictPath(repo, task string, attempt int) string {
 	return filepath.Join(taskStateDir(repo, task), "verdicts", strconv.Itoa(attempt)+".json")

--- a/pkg/gitagent/verdict.go
+++ b/pkg/gitagent/verdict.go
@@ -67,6 +67,17 @@ func readRelayedVerdict(ctx context.Context, repo string, env []string, commit s
 	if !strings.HasPrefix(tree, "100644 blob ") || !strings.HasSuffix(tree, "\t"+ControlVerdictFile+"\x00") || strings.Count(tree, "\x00") != 1 {
 		return verdict, fmt.Errorf("relayed verdict control commit must contain only %s", ControlVerdictFile)
 	}
+	sizeText, err := runGit(ctx, repo, env, "cat-file", "-s", commit+":"+ControlVerdictFile)
+	if err != nil {
+		return verdict, fmt.Errorf("read relayed verdict size: %w", err)
+	}
+	size, err := strconv.ParseInt(sizeText, 10, 64)
+	if err != nil {
+		return verdict, fmt.Errorf("read relayed verdict size %q: %w", sizeText, err)
+	}
+	if size > MaxFeedbackBytes {
+		return verdict, fmt.Errorf("relayed verdict is %d bytes, over the %d-byte cap", size, MaxFeedbackBytes)
+	}
 	raw, err := ReadControlPayload(ctx, repo, env, commit, ControlVerdictFile)
 	if err != nil {
 		return verdict, fmt.Errorf("read relayed verdict: %w", err)

--- a/pkg/sandbox/adapter/gitagent.go
+++ b/pkg/sandbox/adapter/gitagent.go
@@ -1,12 +1,13 @@
 // The git-agent adapter: whole-run relocation over the git-agent protocol.
 // Execute snapshots the supervisor's dirty worktree, dispatches it to an
 // enrolled agent's sidecar, and blocks until the two-tier vet loop produces a
-// final verdict, which comes back as the run's response.
+// final outcome, returned as either the run response or a terminal worker error.
 package adapter
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,7 +120,11 @@ func (g *gitAgentSandbox) Execute(ctx context.Context, spec api.Spec) (*api.Resp
 	if err != nil {
 		return nil, fmt.Errorf("task %s dispatched but not concluded: %w", dispatch.Task, err)
 	}
-	return gitAgentResponse(dispatch.Task, verdict), nil
+	response := gitAgentResponse(dispatch.Task, verdict)
+	if verdict.Terminal && verdict.Status == gitagent.StatusError {
+		return nil, errors.New(response.Text)
+	}
+	return response, nil
 }
 
 // hookSetsJSON preserves the sidecar/supervisor split declared by the backend


### PR DESCRIPTION
Git-agent tasks can stop before sending back code, such as when a model rejects the worker's credentials. The worker wrote the failure to its own log, but nothing notified Captain that the work was over, so the chat stayed at “Waiting for response” until the full timeout.

The worker now packages the failure as `verdict.json` in a small Git commit and sends it to the supervisor over the same secure connection used for completed work. The supervisor checks and records the message, stops waiting, and displays the original failure.

```text
┌──────────────────┐
│ Worker gets 401  │
└────────┬─────────┘
         ▼
┌────────────────────────┐
│ Build verdict.json     │
│ status: error          │
│ terminal: true         │
└────────┬───────────────┘
         ▼ git push
┌────────────────────────┐
│ Supervisor mailbox     │
│ verdict/<attempt> ref  │
└────────┬───────────────┘
         ▼
┌────────────────────────┐
│ Validate and record    │
│ terminal verdict       │
└────────┬───────────────┘
         ▼
┌────────────────────────┐
│ Stop waiting and show  │
│ the original error     │
└────────────────────────┘
```

The sidecar sends a `verdict.json` file shaped like this:

```json
{
  "v": 1,
  "task": "t-a1b2c3",
  "attempt": 1,
  "status": "error",
  "tier": "sidecar",
  "terminal": true,
  "findings": [
    {
      "hook": "agent",
      "kind": "exec",
      "message": "running the dispatched prompt: 401 Unauthorized"
    }
  ]
}
```

Fixes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reporting terminal worker failures when tasks cannot complete normally.
  * Added backend selection to generated agent commands.
  * Added handling and persistence for terminal verdicts.

* **Bug Fixes**
  * Terminal worker errors now conclude task monitoring immediately.
  * Terminal failures are surfaced as execution errors instead of successful responses.
  * Improved validation and rejection of invalid verdict updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->