### PR TITLE
fix: trust generated HTTPS certificates for Git agents

### DIFF
--- a/pkg/cli/gitagent_directory.go
+++ b/pkg/cli/gitagent_directory.go
@@ -126,17 +126,24 @@ func enrollmentRefusal(err error) error {
 	}
 }
 
-// RecordAgent stores everything a dispatch to this agent needs: its client
-// key, its endpoint, and the host key to pin when pushing there. Recording
-// only the key would leave an enrollment that looks complete but cannot be
-// dispatched to.
+// RecordAgent stores everything a dispatch to this agent needs: its identity,
+// endpoint, authentication credential, and optional HTTPS trust anchor.
+// Recording only the key would leave an enrollment that looks complete but
+// cannot be dispatched to.
 func (d gitAgentDirectory) RecordAgent(e gitagent.AgentEnrollment) error {
+	if err := captaintoken.ValidateName(e.Name); err != nil {
+		return fmt.Errorf("invalid agent name: %w", err)
+	}
 	if e.URL == "" {
 		return fmt.Errorf(
 			"agent %q advertised no endpoint; rerun its serve with --advertise ssh://host:port or "+
 				"--advertise https://host/git/%s", e.Name, SidecarRepoName)
 	}
 	credential, err := recordDispatchCredential(e)
+	if err != nil {
+		return err
+	}
+	trust, err := recordDispatchTrust(e)
 	if err != nil {
 		return err
 	}
@@ -158,6 +165,7 @@ func (d gitAgentDirectory) RecordAgent(e gitagent.AgentEnrollment) error {
 		// agent across transports cannot leave the other one's key beside it and
 		// make the entry look like it authenticates two ways.
 		maps.Copy(entry, credential)
+		maps.Copy(entry, trust)
 		agents[e.Name] = entry
 		backend.Options["agents"] = agents
 		cfg.Sandbox.Backends[d.backend] = backend
@@ -199,6 +207,25 @@ func recordDispatchCredential(e gitagent.AgentEnrollment) (map[string]any, error
 	}
 }
 
+// recordDispatchTrust persists a supervisor-local copy of a generated sidecar
+// certificate. An empty certificate deliberately leaves public HTTPS endpoints
+// on the system trust store without a renewal-sensitive pin.
+func recordDispatchTrust(e gitagent.AgentEnrollment) (map[string]any, error) {
+	certificate := strings.TrimSpace(e.CACertificate)
+	if gitagent.EndpointScheme(e.URL) != "https" || certificate == "" {
+		return nil, nil
+	}
+	path, err := writeDispatchCertificateFile(e.Name, certificate)
+	if err != nil {
+		return nil, err
+	}
+	trust := map[string]any{"caPath": path}
+	if pin := strings.TrimSpace(e.PinnedPublicKey); pin != "" {
+		trust["pinnedPubkey"] = pin
+	}
+	return trust, nil
+}
+
 // dispatchTokensDir holds one file per agent this supervisor dispatches to over
 // https.
 //
@@ -216,6 +243,11 @@ func recordDispatchCredential(e gitagent.AgentEnrollment) (map[string]any, error
 // import this package.
 const dispatchTokensDir = "dispatch-tokens"
 
+// dispatchCertificatesDir holds supervisor-local trust anchors received during
+// authenticated enrollment. Re-enrollment atomically replaces the agent's file,
+// making generated-certificate rotation an explicit re-enrollment operation.
+const dispatchCertificatesDir = "dispatch-certificates"
+
 func writeDispatchTokenFile(agent, token string) (string, error) {
 	keysDir, err := gitAgentKeysDir()
 	if err != nil {
@@ -224,6 +256,25 @@ func writeDispatchTokenFile(agent, token string) (string, error) {
 	path := filepath.Join(keysDir, dispatchTokensDir, agent+".token")
 	if err := gitagent.WriteTokenFile(path, text.NewSensitiveString(token)); err != nil {
 		return "", fmt.Errorf("store the dispatch token for agent %q: %w", agent, err)
+	}
+	return path, nil
+}
+
+func writeDispatchCertificateFile(agent, certificate string) (string, error) {
+	keysDir, err := gitAgentKeysDir()
+	if err != nil {
+		return "", err
+	}
+	filename := agent + ".crt"
+	if !filepath.IsLocal(filename) {
+		return "", fmt.Errorf("agent name %q does not produce a local certificate path", agent)
+	}
+	path := filepath.Join(keysDir, dispatchCertificatesDir, filename)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create dispatch certificate directory: %w", err)
+	}
+	if err := writeCredentialFile(path, []byte(certificate)); err != nil {
+		return "", fmt.Errorf("store dispatch certificate for agent %q: %w", agent, err)
 	}
 	return path, nil
 }

--- a/pkg/cli/gitagent_serve.go
+++ b/pkg/cli/gitagent_serve.go
@@ -267,12 +267,31 @@ func joinSupervisor(
 	if err != nil {
 		return err
 	}
+	var caCertificate, pinnedPublicKey string
+	if transport == transportHTTPS &&
+		strings.TrimSpace(opts.TLSCert) == "" && strings.TrimSpace(opts.TLSKey) == "" {
+		host, err := advertiseHostname(advertise)
+		if err != nil {
+			return err
+		}
+		credential, err := gitagent.EnsureTLSCredential(keysDir, []string{host})
+		if err != nil {
+			return fmt.Errorf("prepare generated sidecar certificate for enrollment: %w", err)
+		}
+		pem, err := credential.PEM()
+		if err != nil {
+			return fmt.Errorf("read generated sidecar certificate for enrollment: %w", err)
+		}
+		caCertificate, pinnedPublicKey = string(pem), credential.PublicKeyPin
+	}
 	resp, err := gitagent.Enroll(ctx, opts.Supervisor, token.Value(), opts.HostFingerprint, signer, gitagent.EnrollRequest{
 		Agent:           enrolledAgentName(opts.Backend),
 		AdvertiseURL:    advertise,
 		ListenPort:      port,
 		HostFingerprint: hostFP,
 		DispatchToken:   dispatchToken.Value(),
+		CACertificate:   caCertificate,
+		PinnedPublicKey: pinnedPublicKey,
 	})
 	if err != nil {
 		return err
@@ -309,6 +328,9 @@ func joinSupervisor(
 			"tokenPath":       tokenPath,
 			"caPath":          caPath,
 			"pinnedPubkey":    resp.PinnedPublicKey,
+			// Present even when empty, distinguishing system-trusted TLS from a
+			// legacy enrollment that never exchanged sidecar trust.
+			"sidecarPinnedPubkey": pinnedPublicKey,
 		}
 		// Authorize the supervisor's dispatch key so its push is accepted
 		// here — the direction a one-way enrollment leaves broken.

--- a/pkg/cli/gitagent_serve_options.go
+++ b/pkg/cli/gitagent_serve_options.go
@@ -73,6 +73,27 @@ func reusableEnrollment(
 		if _, err := gitagent.LoadDispatchCredential(filepath.Join(keysDir, gitagent.DispatchCredentialName)); err != nil {
 			return "", nil
 		}
+		if enrolledPin, trustRecorded := supervisor["sidecarPinnedPubkey"].(string); trustRecorded {
+			currentPin := ""
+			if strings.TrimSpace(opts.TLSCert) == "" && strings.TrimSpace(opts.TLSKey) == "" {
+				advertise, err := advertiseURL(opts.Advertise)
+				if err != nil {
+					return "", err
+				}
+				host, err := advertiseHostname(advertise)
+				if err != nil {
+					return "", err
+				}
+				credential, err := gitagent.EnsureTLSCredential(keysDir, []string{host})
+				if err != nil {
+					return "", fmt.Errorf("load generated sidecar certificate: %w", err)
+				}
+				currentPin = credential.PublicKeyPin
+			}
+			if strings.TrimSpace(enrolledPin) != currentPin {
+				return "", nil
+			}
+		}
 	} else {
 		agents, _ := backend.Options["agents"].(map[string]any)
 		dispatch, _ := agents[supervisorAgentID].(map[string]any)

--- a/pkg/cli/serve_git.go
+++ b/pkg/cli/serve_git.go
@@ -185,6 +185,8 @@ func gitAgentEnroll(offer gitagent.EnrollmentOffer, backend string) func(*http.R
 			URL:             url,
 			HostFingerprint: strings.TrimSpace(req.HostFingerprint),
 			DispatchToken:   strings.TrimSpace(req.DispatchToken),
+			CACertificate:   strings.TrimSpace(req.CACertificate),
+			PinnedPublicKey: strings.TrimSpace(req.PinnedPublicKey),
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/gitagent/enroll.go
+++ b/pkg/gitagent/enroll.go
@@ -58,6 +58,13 @@ type EnrollRequest struct {
 	// rejects. Redaction belongs where the value is held — see
 	// DispatchRequest.Token — not where it is transmitted.
 	DispatchToken string `json:"dispatchToken,omitempty"`
+	// CACertificate is the agent's Captain-generated TLS certificate,
+	// PEM-encoded. The supervisor persists its own copy as the trust anchor for
+	// direct HTTPS dispatches. Empty for endpoints using operator-supplied TLS,
+	// which continue to use the system trust store.
+	CACertificate string `json:"caCertificate,omitempty"`
+	// PinnedPublicKey optionally pins the key in CACertificate.
+	PinnedPublicKey string `json:"pinnedPubkey,omitempty"`
 }
 
 // EnrollResponse is what the supervisor hands back so the agent can complete
@@ -94,8 +101,8 @@ func (o EnrollmentOffer) ResponseFor(agent string) EnrollResponse {
 	}
 }
 
-// AgentEnrollment is one recorded agent: its key, its endpoint, and the host
-// key to pin when dispatching there.
+// AgentEnrollment is one recorded agent: its identity, endpoint, dispatch
+// authentication, and HTTPS trust material.
 type AgentEnrollment struct {
 	Name        string
 	Fingerprint string
@@ -106,6 +113,10 @@ type AgentEnrollment struct {
 	// bearer token the agent minted. Exactly one is ever set.
 	HostFingerprint string
 	DispatchToken   string
+	// CACertificate and PinnedPublicKey carry trust for a Captain-generated
+	// HTTPS certificate. They remain empty for publicly trusted endpoints.
+	CACertificate   string
+	PinnedPublicKey string
 }
 
 // Enroll reaches the supervisor endpoint, presents the captain token along

--- a/pkg/gitagent/httpserver.go
+++ b/pkg/gitagent/httpserver.go
@@ -149,8 +149,8 @@ func (cfg HTTPServerConfig) enroll(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// maxEnrollRequestBytes bounds an enrollment body. It carries a URL, a port and
-// a fingerprint; anything larger is not a captain agent.
+// maxEnrollRequestBytes bounds an enrollment body. It carries endpoint and
+// authentication details plus, at most, one PEM certificate.
 const maxEnrollRequestBytes = 64 << 10
 
 func enrollRefusalDetail(err error) string {

--- a/pkg/gitagent/server.go
+++ b/pkg/gitagent/server.go
@@ -139,6 +139,8 @@ func handleEnroll(s ssh.Session, cfg ServerConfig, fingerprint string, cmd []str
 		URL:             agentDispatchURL(req, s.RemoteAddr(), cfg.AgentRepoPath),
 		HostFingerprint: strings.TrimSpace(req.HostFingerprint),
 		DispatchToken:   strings.TrimSpace(req.DispatchToken),
+		CACertificate:   strings.TrimSpace(req.CACertificate),
+		PinnedPublicKey: strings.TrimSpace(req.PinnedPublicKey),
 	}
 	if err := cfg.Directory.RecordAgent(enrollment); err != nil {
 		fmt.Fprintf(s.Stderr(), "captain: enrollment failed: %v\n", err)

--- a/pkg/sandbox/adapter/gitagent.go
+++ b/pkg/sandbox/adapter/gitagent.go
@@ -93,17 +93,20 @@ func (g *gitAgentSandbox) Execute(ctx context.Context, spec api.Spec) (*api.Resp
 	if timeout == "" {
 		timeout = target.waitTimeout.String()
 	}
+	transport := target.transport()
 	dispatch, err := gitagent.Dispatch(ctx, gitagent.DispatchRequest{
-		RepoDir:       repoDir,
-		MailboxPath:   mailbox.Path,
-		MailboxRoute:  mailbox.Route,
-		Agent:         target.agent,
-		SidecarURL:    target.url,
-		SidecarHostFP: target.hostFingerprint,
-		Token:         target.token,
-		KeyPath:       target.keyPath,
-		Relay:         target.relay,
-		Policy:        target.policy,
+		RepoDir:         repoDir,
+		MailboxPath:     mailbox.Path,
+		MailboxRoute:    mailbox.Route,
+		Agent:           target.agent,
+		SidecarURL:      transport.URL,
+		SidecarHostFP:   transport.HostFingerprint,
+		Token:           transport.Token,
+		CAPath:          transport.CAPath,
+		PinnedPublicKey: transport.PinnedPublicKey,
+		KeyPath:         transport.KeyPath,
+		Relay:           target.relay,
+		Policy:          target.policy,
 		// The resolved backend travels with the model: the agent must run the
 		// runtime the supervisor selected, not re-resolve the name against its
 		// own defaults and quietly pick a different one.
@@ -167,12 +170,23 @@ type gitAgentTarget struct {
 	hostFingerprint string
 	// token authenticates this supervisor to an https agent, and is empty for an
 	// ssh one, which authenticates by key instead.
-	token       text.SensitiveString
-	keyPath     string
-	mailboxRoot string
-	relay       gitagent.RelayMode
-	policy      gitagent.Policy
-	waitTimeout time.Duration
+	token           text.SensitiveString
+	caPath          string
+	pinnedPublicKey string
+	keyPath         string
+	mailboxRoot     string
+	relay           gitagent.RelayMode
+	policy          gitagent.Policy
+	waitTimeout     time.Duration
+}
+
+// transport is the shared trust and authentication boundary for Git dispatch
+// and HTTPS sidecar control requests.
+func (target gitAgentTarget) transport() gitagent.TransportTarget {
+	return gitagent.TransportTarget{
+		URL: target.url, KeyPath: target.keyPath, HostFingerprint: target.hostFingerprint,
+		Token: target.token, CAPath: target.caPath, PinnedPublicKey: target.pinnedPublicKey,
+	}
 }
 
 // resolveTarget picks the enrolled agent — pinned by the spec's sandbox.agent,
@@ -214,6 +228,8 @@ func (g *gitAgentSandbox) resolveTarget() (*gitAgentTarget, error) {
 		url:             url,
 		hostFingerprint: hostFP,
 		token:           token,
+		caPath:          stringOption(entry, "caPath", ""),
+		pinnedPublicKey: stringOption(entry, "pinnedPubkey", ""),
 		keyPath:         stringOption(opts, "key", filepath.Join(keysDir, dispatchKeyFile)),
 		// The long-running endpoint serves this root; each dispatch derives a
 		// repository-specific mailbox beneath it from the request working tree.
@@ -229,11 +245,6 @@ func (g *gitAgentSandbox) resolveTarget() (*gitAgentTarget, error) {
 
 // dispatchCredentials resolves how this supervisor authenticates to an agent,
 // which the agent's own URL scheme decides.
-//
-// CAPath and PinnedPublicKey are deliberately left empty for https. The agent is
-// fronted by an ingress holding a publicly trusted certificate for its own
-// hostname, so the git client verifies it by name through the system trust
-// store; pinning here would break on every certificate renewal.
 func dispatchCredentials(name, endpoint string, entry map[string]any) (string, text.SensitiveString, error) {
 	switch scheme := gitagent.EndpointScheme(endpoint); scheme {
 	case "ssh":


### PR DESCRIPTION
Captain cannot send HTTPS requests to a Git-agent sidecar when the sidecar uses its automatically generated certificate. Enrollment succeeds and the supervisor records the sidecar’s address and access token, but it never receives the certificate needed to verify that address. The secure connection is rejected before the request reaches the sidecar. This blocks PR #102, which needs to send setup and cleanup requests to the sidecar over HTTPS.

Remote task dispatch works today because it normally uses SSH, not this HTTPS path.

This change sends the generated certificate during enrollment so the supervisor can verify later HTTPS requests. Publicly trusted certificates are unchanged.

Fixes #104 and unblocks #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HTTPS agent enrollment now supports certificate-based trust and optional public-key pinning.
  - Generated HTTPS credentials are securely stored and reused.
  - Enrollment records retain certificate and pinning details for future connections.
  - Agent dispatch applies configured certificate authorities and public-key pins.

- **Bug Fixes**
  - Detects changed generated TLS credentials and avoids reusing stale enrollments.
  - Validates agent names during enrollment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->