### PR TITLE
fix(db): preserve session metadata

### DIFF
--- a/migrations/02_merge_duplicate_sessions.sql
+++ b/migrations/02_merge_duplicate_sessions.sql
@@ -17,9 +17,9 @@
 -- duplicate groups no group had more than one member with messages, so this
 -- picks a winner rather than merging two transcripts; ties fall back to the
 -- oldest row and then to the id, so the choice is deterministic on re-run.
--- Prompt runs and child sessions pointing at a ghost are re-pointed, the ghosts
--- are deleted, and the winner then absorbs a ghost's provider label -- that label
--- exists nowhere else once the ghost is gone.
+-- Prompt runs, child sessions, and processes pointing at a ghost are re-pointed,
+-- the ghosts are deleted, and the winner then absorbs a ghost's provider label --
+-- that label exists nowhere else once the ghost is gone.
 --
 -- Every reference re-pointed below is one the ghost's ON DELETE CASCADE would
 -- otherwise destroy. The ghost's own transcript rows -- messages, turns, events,
@@ -103,6 +103,13 @@ BEGIN
   UPDATE captain_sessions w SET root_session_id = NULL
   FROM captain_duplicate_session_map m
   WHERE w.id = m.winner AND w.root_session_id = m.loser;
+
+  -- A running process is the durable identity of the execution that created the
+  -- ghost. Its session foreign key also cascades, so preserve it on the row that
+  -- actually owns the transcript before removing the duplicate.
+  UPDATE captain_session_processes p SET session_id = m.winner
+  FROM captain_duplicate_session_map m
+  WHERE p.session_id = m.loser;
 
   DELETE FROM captain_sessions s
   USING captain_duplicate_session_map m

--- a/pkg/database/session_prompt_store.go
+++ b/pkg/database/session_prompt_store.go
@@ -270,6 +270,13 @@ func (db *DB) CreateOrGetSession(ctx context.Context, input CreateSessionInput) 
 			return nil, fmt.Errorf("adopt Captain session provider label: %w", err)
 		}
 	}
+	if len(record.Metadata) > 0 {
+		if err := db.gorm.WithContext(ctx).Model(&sessionRecord{}).
+			Where("id = ?", existing.ID).
+			Update("metadata", gorm.Expr("COALESCE(metadata, '{}'::jsonb) || ?::jsonb", jsonbValue(record.Metadata))).Error; err != nil {
+			return nil, fmt.Errorf("merge Captain session metadata: %w", err)
+		}
+	}
 	if callerSuppliedID && existing.ID != input.ID {
 		return nil, fmt.Errorf("%w: provider identity already belongs to session %s, not caller-supplied ID %s", ErrSessionConflict, existing.ID, input.ID)
 	}


### PR DESCRIPTION
Preserve session references and metadata during database operations.

- Updates migration schema to handle session references correctly
- Refines session prompt store implementation to maintain data integrity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate session cleanup so active process references remain linked to the surviving session.
  * Fixed session creation and retrieval to correctly merge metadata when existing session records have no metadata.
  * Preserved session metadata more reliably when resolving ID conflicts or consolidating duplicate sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->