### PR TITLE
refactor: rename Annotations to Metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 
 require (
 	github.com/alpkeskin/gotoon v0.1.1 // indirect
-	github.com/glebarez/go-sqlite v1.23.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
 	github.com/go-openapi/swag/conv v0.25.4 // indirect
 	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
@@ -398,3 +397,12 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+// github.com/glebarez/sqlite is a gorm dialector that, unreplaced, links its own
+// copy of the modernc engine (github.com/glebarez/go-sqlite) and calls
+// sql.Register("sqlite"). commons-db also registers modernc.org/sqlite (see
+// connection/sql.go), so the unreplaced dialector panics at init with
+// "sql: Register called twice for driver sqlite". The clarkmcc fork imports
+// modernc.org/sqlite/lib instead of vendoring, so there is exactly one
+// registration. gavel and oipa-cli carry the identical replace.
+replace github.com/glebarez/sqlite => github.com/clarkmcc/gorm-sqlite v0.0.0-20240426202654-00ed082c0311

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/firebase/genkit/go v1.11.0
-	github.com/flanksource/clicky v1.21.61-0.20260909025458-3d41408b1c07
-	github.com/flanksource/clicky/aichat v1.21.58-0.20260823135047-e9ff84a33d81
+	github.com/flanksource/clicky v1.21.61
+	github.com/flanksource/clicky/aichat v1.21.61
 	github.com/flanksource/commons v1.59.0
 	github.com/flanksource/sandbox-runtime v1.0.2
 	github.com/fsnotify/fsnotify v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/xpty v0.1.3 h1:eGSitii4suhzrISYH50ZfufV3v085BXQwIytcOdFSsw=
 github.com/charmbracelet/x/xpty v0.1.3/go.mod h1:poPYpWuLDBFCKmKLDnhBp51ATa0ooD8FhypRwEFtH3Y=
+github.com/clarkmcc/gorm-sqlite v0.0.0-20240426202654-00ed082c0311 h1://GDWpsQ8pSg8u8SCavanukwPu5yE0Rz3uu7CuFVfFc=
+github.com/clarkmcc/gorm-sqlite v0.0.0-20240426202654-00ed082c0311/go.mod h1:HrR53jwmQF7sTyNxEJ3rqfx9sRVnaTUqIo1nXn0KRho=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
@@ -307,10 +309,6 @@ github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZ
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
 github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01KS3zGE=
 github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
-github.com/glebarez/go-sqlite v1.23.0 h1:FyhIq4jqmgphQAUlY79zPldYGwISEZikaDfhiGWkkaI=
-github.com/glebarez/go-sqlite v1.23.0/go.mod h1:IIYrOH3L0rHY3jb4IXOHoWdklNajSGUN2eJcvK8WrnI=
-github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=
-github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=

--- a/go.sum
+++ b/go.sum
@@ -274,10 +274,10 @@ github.com/fergusstrange/embedded-postgres v1.34.0 h1:c6RKhPKFsLVU+Tdxsx8q0UxCHs
 github.com/fergusstrange/embedded-postgres v1.34.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/firebase/genkit/go v1.11.0 h1:dmf219fDGP6IcKwPkJoTnXpcTEya7o5Bi+z5iP+FuTk=
 github.com/firebase/genkit/go v1.11.0/go.mod h1:x9h3TsbMLiuK1hgbwnkUmKQ9bmTNPORHaqG9XQhI0K8=
-github.com/flanksource/clicky v1.21.61-0.20260909025458-3d41408b1c07 h1:noKhkizguWVrIIBMzy8UPoPXZNrOXOR/Ak/KP0ve3yQ=
-github.com/flanksource/clicky v1.21.61-0.20260909025458-3d41408b1c07/go.mod h1:L+RlBYG6Ngay9pWs6iuRanfIArxEOttcQPXRL73qXrA=
-github.com/flanksource/clicky/aichat v1.21.58-0.20260823135047-e9ff84a33d81 h1:q4FicSW0YNn7yCc/MJHEdZkMwOXsczkWANor8OMeGIs=
-github.com/flanksource/clicky/aichat v1.21.58-0.20260823135047-e9ff84a33d81/go.mod h1:c/uelViGeVFm0KkJCZI4p4P8snJJ+qlT0D9ehkHyEf4=
+github.com/flanksource/clicky v1.21.61 h1:4OO6RpxGpDJr2VDvDLHEnodcXSNbk+ELU/WnERtLO8E=
+github.com/flanksource/clicky v1.21.61/go.mod h1:L+RlBYG6Ngay9pWs6iuRanfIArxEOttcQPXRL73qXrA=
+github.com/flanksource/clicky/aichat v1.21.61 h1:hTy7CHeUQ7zNd/bil4k0Zk0ajM5I3fZfGA4eWRmf4L8=
+github.com/flanksource/clicky/aichat v1.21.61/go.mod h1:CD/LUlP4ZX5mTTECKEQsLFeYEu2hfdF3f2zPqEe4VbY=
 github.com/flanksource/commons v1.59.0 h1:RP3K/HtcqyCN4qfXGD51X1hneLpWC5SE6aQ0WtuMV0g=
 github.com/flanksource/commons v1.59.0/go.mod h1:DYc4OVPg4K1SXzKGEkinh28iSbcnmSC3QzJJK2UJZpw=
 github.com/flanksource/commons-db v0.1.31 h1:KnerFTgwqMrCWoRvRoTLQ5dMDTI/9uE6KIrlMiHfJM0=

--- a/pkg/ai/provider/claudeagent/task_identity.go
+++ b/pkg/ai/provider/claudeagent/task_identity.go
@@ -23,8 +23,8 @@ const (
 // operator cannot tell which run is which.
 //
 // The split is deliberate: Labels are fixed when the run starts and are what
-// the task list filters on, while Annotations are re-read on every snapshot and
-// carry what only becomes true (or changes) while the process runs.
+// the task list filters on, while Metadata is re-read on every snapshot and
+// carries what only becomes true (or changes) while the process runs.
 func (p *Provider) taskIdentity(req ai.Request) exec.SupervisedTaskOptions {
 	labels := req.HostLabels()
 	runtime := p.GetRuntime()
@@ -39,12 +39,12 @@ func (p *Provider) taskIdentity(req ai.Request) exec.SupervisedTaskOptions {
 	}
 
 	return exec.SupervisedTaskOptions{
-		Name:        agentTaskName(req, p.model),
-		Kind:        "agent",
-		Labels:      labels,
-		Href:        req.HostLabel(labelHref),
-		Background:  true,
-		Annotations: p.taskAnnotations,
+		Name:       agentTaskName(req, p.model),
+		Kind:       "agent",
+		Labels:     labels,
+		Href:       req.HostLabel(labelHref),
+		Background: true,
+		Metadata:   p.taskMetadata,
 	}
 }
 
@@ -57,25 +57,24 @@ func agentTaskName(req ai.Request, model string) string {
 	return fmt.Sprintf("claude-agent (%s)", model)
 }
 
-// taskAnnotations reports what has changed since the process started: the
-// provider session only exists once the handshake lands, and whether a turn is
-// in flight is the difference between an agent that is working and one that is
-// waiting on its caller.
-func (p *Provider) taskAnnotations() map[string]string {
-	annotations := map[string]string{"state": "idle"}
+// taskMetadata reports what has changed since the process started: the provider
+// session only exists once the handshake lands, and whether a turn is in flight
+// is the difference between an agent that is working and one that is waiting on
+// its caller. The turn reports its own shape, so a viewer can tell a plan-only
+// turn, or one already winding down under an interrupt, from an ordinary one.
+func (p *Provider) taskMetadata() any {
+	metadata := ai.AgentMetadata{State: ai.AgentIdle}
 
 	p.activeMu.Lock()
-	active := p.active != nil
+	active := p.active
 	p.activeMu.Unlock()
-	if active {
-		annotations["state"] = "running"
+	if active != nil {
+		metadata.State = ai.AgentRunning
+		metadata.Turn = active.summary()
 	}
 
 	p.sessMu.Lock()
-	sessionID := p.sessionID
+	metadata.Session = p.sessionID
 	p.sessMu.Unlock()
-	if sessionID != "" {
-		annotations["session"] = sessionID
-	}
-	return annotations
+	return metadata
 }

--- a/pkg/ai/provider/claudeagent/task_identity_test.go
+++ b/pkg/ai/provider/claudeagent/task_identity_test.go
@@ -64,17 +64,21 @@ var _ = Describe("Supervised agent task identity", func() {
 	It("reports the turn state and fills the session in once the handshake lands", func() {
 		provider := newProvider()
 
-		Expect(provider.taskAnnotations()).To(Equal(map[string]string{"state": "idle"}))
+		Expect(provider.taskMetadata()).To(Equal(ai.AgentMetadata{State: ai.AgentIdle}))
 
-		provider.setActive(&turnState{})
+		provider.setActive(&turnState{planMode: true, pending: 2})
 		provider.rememberSession("df7aa36e")
 
-		Expect(provider.taskAnnotations()).To(Equal(map[string]string{
-			"state":   "running",
-			"session": "df7aa36e",
+		Expect(provider.taskMetadata()).To(Equal(ai.AgentMetadata{
+			State:   ai.AgentRunning,
+			Session: "df7aa36e",
+			Turn:    &ai.AgentTurn{PlanMode: true, Pending: 2},
 		}))
 
 		provider.clearActive()
-		Expect(provider.taskAnnotations()).To(HaveKeyWithValue("state", "idle"))
+		Expect(provider.taskMetadata()).To(Equal(ai.AgentMetadata{
+			State:   ai.AgentIdle,
+			Session: "df7aa36e",
+		}))
 	})
 })

--- a/pkg/ai/provider/claudeagent/turn.go
+++ b/pkg/ai/provider/claudeagent/turn.go
@@ -402,6 +402,20 @@ func (p *Provider) rememberSession(id string) {
 	p.sessMu.Unlock()
 }
 
+// summary projects the turn for a task snapshot. It reads pending under the
+// same lock that maintains it, because the snapshot path runs concurrently with
+// the turn it is describing.
+func (ts *turnState) summary() *ai.AgentTurn {
+	ts.promptMu.Lock()
+	pending := ts.pending
+	ts.promptMu.Unlock()
+	return &ai.AgentTurn{
+		PlanMode:     ts.planMode,
+		Pending:      pending,
+		Interrupting: ts.interrupting.Load(),
+	}
+}
+
 func (ts *turnState) addPrompt() bool {
 	ts.promptMu.Lock()
 	defer ts.promptMu.Unlock()

--- a/pkg/ai/provider/codex_appserver_task.go
+++ b/pkg/ai/provider/codex_appserver_task.go
@@ -16,8 +16,8 @@ import (
 //
 // Unlike the claude-agent provider the app-server is spawned once and reused
 // across turns, so the fixed Labels can only describe the run that started it.
-// Anything that moves from turn to turn belongs in Annotations, which are
-// re-read on every snapshot.
+// Anything that moves from turn to turn belongs in Metadata, which is re-read on
+// every snapshot.
 func (c *CodexAppServer) taskIdentity() exec.SupervisedTaskOptions {
 	c.mu.Lock()
 	runLabels := c.runLabels
@@ -46,28 +46,29 @@ func (c *CodexAppServer) taskIdentity() exec.SupervisedTaskOptions {
 		// The app-server outlives any wait its caller makes, so it must not be
 		// counted by a global task drain — see the claude-agent provider for the
 		// deadlock this avoids.
-		Background:  true,
-		Annotations: c.taskAnnotations,
+		Background: true,
+		Metadata:   c.taskMetadata,
 	}
 }
 
-// taskAnnotations reports what changes while the server runs: whether a turn is
-// in flight, and the thread the current run is working in.
-func (c *CodexAppServer) taskAnnotations() map[string]string {
+// taskMetadata reports what changes while the server runs: whether a turn is in
+// flight, the thread the current run is working in, and the run itself — the
+// app-server outlives any one of them, so none can be a fixed Label.
+func (c *CodexAppServer) taskMetadata() any {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	annotations := map[string]string{"state": "idle"}
+	metadata := ai.AgentMetadata{
+		State:  ai.AgentIdle,
+		Thread: c.threadID,
+		Run:    c.runLabels["title"],
+	}
 	if c.active != nil {
-		annotations["state"] = "running"
+		metadata.State = ai.AgentRunning
 	}
-	if c.threadID != "" {
-		annotations["thread"] = c.threadID
-	}
-	if title := c.runLabels["title"]; title != "" {
-		annotations["run"] = title
-	}
-	return annotations
+	// Turn is left nil: the app-server's turn state carries no plan mode, prompt
+	// count or interrupt flag to report, and State already says one is in flight.
+	return metadata
 }
 
 // rememberRunLabels records the host's identification of the current run so the

--- a/pkg/ai/task_metadata.go
+++ b/pkg/ai/task_metadata.go
@@ -1,0 +1,47 @@
+package ai
+
+// AgentMetadata is the structured account a supervised agent process reports on
+// every task snapshot — what clicky carries in ProcessDetails.Metadata and a
+// task view renders in the row header.
+//
+// The split from task Labels is deliberate and unchanged: Labels are fixed when
+// the run starts and are what a task list filters on (model, provider, mode,
+// the host's own run labels), while this carries only what becomes true, or
+// changes, while the process runs. Being a struct rather than a string map is
+// what lets the in-flight turn be reported as a nested object instead of a
+// handful of flattened, separately-parsed keys.
+type AgentMetadata struct {
+	State AgentState `json:"state"`
+	// Session is the provider's own session id, which only exists once the
+	// handshake has landed.
+	Session string `json:"session,omitempty"`
+	// Thread is the conversation the current run is working in, where the
+	// provider models one (the codex app-server does; the claude-agent SDK
+	// session does not).
+	Thread string `json:"thread,omitempty"`
+	// Run names the work the host asked for, when it gave the run a title.
+	Run string `json:"run,omitempty"`
+	// Turn describes the turn in flight, and is nil when the agent is idle.
+	Turn *AgentTurn `json:"turn,omitempty"`
+}
+
+// AgentState is the difference between an agent that is working and one that is
+// waiting on its caller — the single most useful thing to see in a task row.
+type AgentState string
+
+const (
+	AgentIdle    AgentState = "idle"
+	AgentRunning AgentState = "running"
+)
+
+// AgentTurn is the in-flight turn's shape.
+type AgentTurn struct {
+	// PlanMode marks a plan-only turn, which ends on ExitPlanMode rather than on
+	// the usual terminal signal.
+	PlanMode bool `json:"planMode,omitempty"`
+	// Pending is how many prompts the turn is still waiting on answers for.
+	Pending int `json:"pending,omitempty"`
+	// Interrupting is set once an interrupt has been requested but the turn has
+	// not yet wound down.
+	Interrupting bool `json:"interrupting,omitempty"`
+}

--- a/pkg/cli/webapp/package.json
+++ b/pkg/cli/webapp/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.201",
-    "@flanksource/clicky-ui": "0.3.34",
+    "@flanksource/clicky-ui": "0.3.36",
     "@shikijs/langs": "^1.24.0",
     "@shikijs/themes": "^1.24.0",
     "@shikijs/transformers": "^1.24.0",

--- a/pkg/cli/webapp/pnpm-lock.yaml
+++ b/pkg/cli/webapp/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^3.0.201
         version: 3.0.216(react@18.3.1)(zod@4.4.3)
       '@flanksource/clicky-ui':
-        specifier: 0.3.34
-        version: 0.3.34(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)
+        specifier: 0.3.36
+        version: 0.3.36(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)
       '@shikijs/langs':
         specifier: ^1.24.0
         version: 1.29.2
@@ -426,8 +426,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@flanksource/clicky-ui@0.3.34':
-    resolution: {integrity: sha512-5o1e8K2ZWbS9bWjsE0sd/rm0UkxZMbQ4/d0PRNQMHwGh3a55XG3oAkBhlBYxv2uUfhBj1zR1F6f195rDnKLvRg==}
+  '@flanksource/clicky-ui@0.3.36':
+    resolution: {integrity: sha512-ix5u2lIcstYUIgx9t/ng33T/k11E4eXeL2/K4CN0tRjeyvQlGceOKjQYWykAJyqV8WVNxmhQW7VrKO8UWUipzg==}
     peerDependencies:
       '@ai-sdk/react': ^3.0.0
       '@mdxeditor/editor': ^4.0.4
@@ -847,6 +847,15 @@ packages:
     resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2771,7 +2780,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@flanksource/clicky-ui@0.3.34(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)':
+  '@flanksource/clicky-ui@0.3.36(@ai-sdk/react@3.0.216(react@18.3.1)(zod@4.4.3))(@babel/core@7.29.7)(@babel/template@7.29.7)(@shikijs/langs@1.29.2)(@shikijs/themes@1.29.2)(@shikijs/transformers@1.29.2)(@types/react@19.2.17)(ai@6.0.214(zod@4.4.3))(marked@15.0.12)(monaco-editor@0.48.0)(react-dom@18.3.1(react@18.3.1))(react-rnd@10.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(recharts@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1))(shiki@1.29.2)(streamdown@2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tailwindcss@4.3.1)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0
@@ -2785,6 +2794,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@18.3.1)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@18.3.1)
       '@tanstack/react-query': 5.101.2(react@18.3.1)
+      '@tanstack/react-virtual': 3.14.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       country-flag-icons: 1.6.20
@@ -3124,6 +3134,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.101.2
       react: 18.3.1
+
+  '@tanstack/react-virtual@3.14.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## What

- Rename `Annotations` to `Metadata` for task snapshots across the Claude agent and Codex app-server providers.
- Touches `pkg/ai/task_metadata.go`, `pkg/ai/provider/claudeagent/{task_identity,turn}.go`, and `pkg/ai/provider/codex_appserver_task.go`, plus the accompanying test.

## Notes

- Naming-only refactor; no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured metadata for supervised agent tasks, including idle or running status and associated session or thread information.
  - Added live in-progress turn details, including plan mode, pending prompts, and interruption status.
  - Improved task snapshots for supported AI providers with clearer run and activity information.

- **Bug Fixes**
  - Task activity information now consistently reflects the agent’s current state while preserving session context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->