### PR TITLE
chore: use pure Go sqlite driver

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -33,11 +33,10 @@ tasks:
       OUTPUT: '{{.OUTPUT | default (printf "%s/%s" .BIN_DIR .BINARY)}}'
     cmds:
       - mkdir -p {{dir .OUTPUT}}
-      # GOOS set (image:lab) means cross-compiling: there is no linux cgo
-      # toolchain on a macOS host, so that binary drops the sqlite-backed AI
-      # response cache — opt-in via CacheTTL/CacheDBPath, and it fails loudly
-      # rather than silently when enabled.
-      - '{{if .GOOS}}GOOS={{.GOOS}} GOARCH={{.GOARCH}} CGO_ENABLED=0 {{end}}go build -ldflags "{{.LDFLAGS}}" -o {{.OUTPUT}} ./cmd/captain'
+      # CGO_ENABLED=0 unconditionally: every dependency is pure Go (sqlite comes
+      # from modernc.org/sqlite), so a cross-compile for image:lab produces the
+      # same binary the host build does, with no linux cgo toolchain needed.
+      - 'CGO_ENABLED=0 {{if .GOOS}}GOOS={{.GOOS}} GOARCH={{.GOARCH}} {{end}}go build -ldflags "{{.LDFLAGS}}" -o {{.OUTPUT}} ./cmd/captain'
 
   www:build:
     desc: Build the embedded Captain web UI

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/dotprompt/go v0.0.0-20260502013637-5cd4a8405ca3
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.13.0
-	github.com/mattn/go-sqlite3 v1.14.38
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/samber/lo v1.53.0
@@ -43,6 +42,7 @@ require (
 	github.com/flanksource/commons-db v0.1.31
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/pelletier/go-toml/v2 v2.4.3
+	modernc.org/sqlite v1.55.0
 )
 
 require (
@@ -62,7 +62,6 @@ require (
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.55.0 // indirect
 )
 
 require (

--- a/pkg/ai/cache/cache.go
+++ b/pkg/ai/cache/cache.go
@@ -10,8 +10,13 @@ import (
 	"time"
 
 	"github.com/flanksource/commons/logger"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/samber/lo"
+
+	// Pure Go, so the cache works on the CGO_ENABLED=0 binaries goreleaser and
+	// the sandbox image ship. commons-db/connection blank-imports the same
+	// driver, and the name "sqlite" may only be registered once — see the
+	// github.com/glebarez/sqlite replace in go.mod before adding another.
+	_ "modernc.org/sqlite"
 )
 
 // log is the package-scoped logger for AI providers. Its level follows
@@ -91,7 +96,7 @@ func New(config Config) (*Cache, error) {
 		return nil, fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite3", config.DBPath)
+	db, err := sql.Open("sqlite", config.DBPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -240,6 +245,9 @@ func (c *Cache) GetStats() ([]StatsEntry, error) {
 		var s StatsEntry
 		var provider sql.NullString
 		var inputTok, outputTok, reasonTok, cacheReadTok, cacheWriteTok sql.NullInt64
+		// MIN/MAX erase the column's declared TIMESTAMP type, so the driver hands
+		// back the raw stored text instead of a time.Time.
+		var firstRequest, lastRequest sql.NullString
 
 		if err := rows.Scan(
 			&s.Model, &provider,
@@ -247,9 +255,16 @@ func (c *Cache) GetStats() ([]StatsEntry, error) {
 			&inputTok, &outputTok, &reasonTok,
 			&cacheReadTok, &cacheWriteTok,
 			&s.TotalCost, &s.AvgDurationMS,
-			&s.FirstRequest, &s.LastRequest,
+			&firstRequest, &lastRequest,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan stats: %w", err)
+		}
+
+		if s.FirstRequest, err = parseTimestamp(firstRequest); err != nil {
+			return nil, fmt.Errorf("failed to parse first request time for %s: %w", s.Model, err)
+		}
+		if s.LastRequest, err = parseTimestamp(lastRequest); err != nil {
+			return nil, fmt.Errorf("failed to parse last request time for %s: %w", s.Model, err)
 		}
 
 		if provider.Valid {
@@ -274,6 +289,28 @@ func (c *Cache) GetStats() ([]StatsEntry, error) {
 		stats = append(stats, s)
 	}
 	return stats, nil
+}
+
+// timestampLayouts covers what lands in a TIMESTAMP column: CURRENT_TIMESTAMP
+// writes UTC seconds with a space separator, while a driver-bound time.Time
+// keeps its offset and sub-second precision.
+var timestampLayouts = []string{
+	"2006-01-02 15:04:05.999999999-07:00",
+	"2006-01-02T15:04:05.999999999-07:00",
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02T15:04:05.999999999",
+}
+
+func parseTimestamp(value sql.NullString) (time.Time, error) {
+	if !value.Valid || value.String == "" {
+		return time.Time{}, nil
+	}
+	for _, layout := range timestampLayouts {
+		if parsed, err := time.Parse(layout, value.String); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognised timestamp %q", value.String)
 }
 
 func (c *Cache) cleanupExpired() {

--- a/pkg/ai/cache/cache_ginkgo_test.go
+++ b/pkg/ai/cache/cache_ginkgo_test.go
@@ -1,0 +1,185 @@
+package cache_test
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/flanksource/captain/pkg/ai/cache"
+)
+
+// cgoOnlySQLiteDrivers register their driver only under `//go:build cgo`, so a
+// binary built with CGO_ENABLED=0 — which is every goreleaser artifact and the
+// linux binary baked into the sandbox image — links a stub that fails on the
+// first query. modernc.org/sqlite is pure Go and is already linked through
+// commons-db/connection, so it is the only sqlite engine this repo may import.
+var cgoOnlySQLiteDrivers = []string{"github.com/mattn/go-sqlite3"}
+
+func newCache(ttl time.Duration) *cache.Cache {
+	GinkgoHelper()
+	c, err := cache.New(cache.Config{DBPath: filepath.Join(GinkgoT().TempDir(), "cache.db"), TTL: ttl})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(c.Close)
+	return c
+}
+
+func entry(prompt, response string) *cache.Entry {
+	return &cache.Entry{
+		Model:        "claude-opus-5",
+		Provider:     "anthropic",
+		Prompt:       prompt,
+		Response:     response,
+		TokensInput:  120,
+		TokensOutput: 40,
+		TokensTotal:  160,
+		CostUSD:      0.25,
+		DurationMS:   1500,
+	}
+}
+
+var _ = Describe("AI response cache", func() {
+	It("round-trips an entry through the pure-Go sqlite driver", func() {
+		c := newCache(time.Hour)
+		Expect(c.Set(entry("what is 2+2?", "4"))).To(Succeed())
+
+		got, err := c.Get("what is 2+2?", "claude-opus-5")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*got).To(MatchFields(IgnoreExtras, Fields{
+			"Model":        Equal("claude-opus-5"),
+			"Provider":     Equal("anthropic"),
+			"Prompt":       Equal("what is 2+2?"),
+			"Response":     Equal("4"),
+			"TokensInput":  Equal(120),
+			"TokensOutput": Equal(40),
+			"TokensTotal":  Equal(160),
+			"CostUSD":      Equal(0.25),
+			"DurationMS":   Equal(int64(1500)),
+		}))
+	})
+
+	It("reads the TIMESTAMP columns back as times rather than raw strings", func() {
+		c := newCache(time.Hour)
+		Expect(c.Set(entry("when?", "now"))).To(Succeed())
+
+		got, err := c.Get("when?", "claude-opus-5")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.CreatedAt).To(BeTemporally("~", time.Now(), time.Minute))
+		Expect(got.AccessedAt).To(BeTemporally("~", time.Now(), time.Minute))
+		Expect(got.ExpiresAt).NotTo(BeNil())
+		Expect(*got.ExpiresAt).To(BeTemporally("~", time.Now().Add(time.Hour), time.Minute))
+	})
+
+	It("misses on a prompt that was never cached", func() {
+		c := newCache(time.Hour)
+		Expect(c.Set(entry("cached", "yes"))).To(Succeed())
+
+		_, err := c.Get("never cached", "claude-opus-5")
+		Expect(err).To(MatchError(cache.ErrNotFound))
+	})
+
+	It("does not serve an entry past its TTL", func() {
+		c := newCache(time.Millisecond)
+		Expect(c.Set(entry("stale", "old answer"))).To(Succeed())
+
+		Eventually(func() error {
+			_, err := c.Get("stale", "claude-opus-5")
+			return err
+		}, time.Second, 10*time.Millisecond).Should(MatchError(cache.ErrNotFound))
+	})
+
+	It("refuses to read or write when caching is disabled", func() {
+		c, err := cache.New(cache.Config{
+			DBPath:  filepath.Join(GinkgoT().TempDir(), "cache.db"),
+			TTL:     time.Hour,
+			NoCache: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(c.Close)
+
+		Expect(c.Set(entry("ignored", "ignored"))).To(Succeed())
+		_, err = c.Get("ignored", "claude-opus-5")
+		Expect(err).To(MatchError(cache.ErrCacheDisabled))
+	})
+
+	It("aggregates stats across entries, including the MIN/MAX request times", func() {
+		c := newCache(time.Hour)
+		Expect(c.Set(entry("first", "1"))).To(Succeed())
+		Expect(c.Set(entry("second", "2"))).To(Succeed())
+
+		stats, err := c.GetStats()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stats).To(HaveLen(1))
+		Expect(stats[0]).To(MatchFields(IgnoreExtras, Fields{
+			"Model":             Equal("claude-opus-5"),
+			"Provider":          Equal("anthropic"),
+			"TotalRequests":     Equal(int64(2)),
+			"TotalInputTokens":  Equal(int64(240)),
+			"TotalOutputTokens": Equal(int64(80)),
+			"TotalCost":         BeNumerically("~", 0.5, 0.0001),
+		}))
+		Expect(stats[0].FirstRequest).To(BeTemporally("~", time.Now(), time.Minute))
+		Expect(stats[0].LastRequest).To(BeTemporally("~", time.Now(), time.Minute))
+	})
+
+	It("clears every cached entry", func() {
+		c := newCache(time.Hour)
+		Expect(c.Set(entry("drop me", "gone"))).To(Succeed())
+		Expect(c.Clear()).To(Succeed())
+
+		_, err := c.Get("drop me", "claude-opus-5")
+		Expect(err).To(MatchError(cache.ErrNotFound))
+	})
+})
+
+var _ = Describe("sqlite driver choice", func() {
+	It("keeps every captain package free of cgo-only sqlite drivers", func() {
+		root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+		Expect(err).NotTo(HaveOccurred())
+
+		offenders := map[string][]string{}
+		err = filepath.WalkDir(root, func(path string, dirEntry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if dirEntry.IsDir() {
+				// Dot-directories hold scratch worktrees (.tmp, .shell) that carry
+				// their own copy of this file, and hack/ is untracked scratch.
+				name := dirEntry.Name()
+				if path != root && (strings.HasPrefix(name, ".") || name == "node_modules" || name == "hack") {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+			if parseErr != nil {
+				return parseErr
+			}
+			for _, spec := range file.Imports {
+				imported, unquoteErr := strconv.Unquote(spec.Path.Value)
+				if unquoteErr != nil {
+					return unquoteErr
+				}
+				for _, driver := range cgoOnlySQLiteDrivers {
+					if imported == driver {
+						rel, _ := filepath.Rel(root, path)
+						offenders[rel] = append(offenders[rel], imported)
+					}
+				}
+			}
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(offenders).To(BeEmpty())
+	})
+})

--- a/pkg/ai/cache/cache_suite_test.go
+++ b/pkg/ai/cache/cache_suite_test.go
@@ -1,0 +1,13 @@
+package cache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AI Response Cache Suite")
+}


### PR DESCRIPTION
## What

- Replace the cgo-dependent `sqlite3` driver with pure Go `modernc.org/sqlite`
- Update the AI cache (`pkg/ai/cache`) and its ginkgo suite to the new driver
- Adjust `go.mod` and `Taskfile.yaml` accordingly

## Why

- Removes the cgo requirement from the build, simplifying cross-compilation and CI toolchain needs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Builds now consistently produce portable binaries without requiring a platform-specific C toolchain.
  - The AI response cache now uses a pure-Go database driver, improving compatibility across build environments.
  - Cache statistics more reliably handle timestamp values in supported formats.

- **Bug Fixes**
  - Improved cache handling for misses, expiration, disabled caching, clearing entries, and statistics retrieval.

- **Tests**
  - Added comprehensive coverage for cache behavior, timestamp handling, and build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->